### PR TITLE
No more macros

### DIFF
--- a/candid/src/de.rs
+++ b/candid/src/de.rs
@@ -784,9 +784,8 @@ pub trait DecodeArguments<'a>: Sized {
 
 // // Is this a sensible impl?
 impl <'a> DecodeArguments<'a> for () {
-    fn decode_arguments(mut de: IDLDeserialize<'a>) -> Result<(IDLDeserialize<'a>, ())> {
-        let a_new = de.get_value()?;
-        Ok((de, (a_new)))
+    fn decode_arguments(de: IDLDeserialize<'a>) -> Result<(IDLDeserialize<'a>, ())> {
+        Ok((de, ()))
     }
 }
 

--- a/candid/src/de.rs
+++ b/candid/src/de.rs
@@ -5,7 +5,7 @@ use super::types::internal::Opcode;
 use super::{idl_hash, Int, Nat};
 use byteorder::{LittleEndian, ReadBytesExt};
 use leb128::read::{signed as sleb128_decode, unsigned as leb128_decode};
-use serde::de::{self, Visitor, Deserialize};
+use serde::de::{self, Deserialize, Visitor};
 use std::collections::{BTreeMap, VecDeque};
 use std::convert::TryFrom;
 use std::io::Read;
@@ -783,7 +783,7 @@ pub trait DecodeArguments<'a>: Sized {
 }
 
 // // Is this a sensible impl?
-impl <'a> DecodeArguments<'a> for () {
+impl<'a> DecodeArguments<'a> for () {
     fn decode_arguments(de: IDLDeserialize<'a>) -> Result<(IDLDeserialize<'a>, ())> {
         Ok((de, ()))
     }

--- a/candid/src/de.rs
+++ b/candid/src/de.rs
@@ -831,3 +831,8 @@ pub fn decode_args<'a, Candid: DecodeArguments<'a>>(bytes: &'a [u8]) -> Result<C
     de.done()?;
     Ok(res)
 }
+
+pub fn decode_one<'a, Candid: Deserialize<'a>>(bytes: &'a [u8]) -> Result<Candid> {
+    let (res,) = decode_args(bytes)?;
+    Ok(res)
+}

--- a/candid/src/de.rs
+++ b/candid/src/de.rs
@@ -5,7 +5,7 @@ use super::types::internal::Opcode;
 use super::{idl_hash, Int, Nat};
 use byteorder::{LittleEndian, ReadBytesExt};
 use leb128::read::{signed as sleb128_decode, unsigned as leb128_decode};
-use serde::de::{self, Visitor, DeserializeOwned};
+use serde::de::{self, DeserializeOwned, Visitor};
 use std::collections::{BTreeMap, VecDeque};
 use std::convert::TryFrom;
 use std::io::Read;
@@ -778,62 +778,57 @@ impl<'de, 'a> de::VariantAccess<'de> for Compound<'a, 'de> {
     }
 }
 
-pub trait DecodeArguments {
-    fn decode_arguments(_de: IDLDeserialize<'_>) -> (IDLDeserialize<'_>, Self);
+pub trait DecodeArguments: Sized {
+    fn decode_arguments(_de: IDLDeserialize<'_>) -> Result<(IDLDeserialize<'_>, Self)>;
+}
+
+// Is this a sensible impl?
+impl DecodeArguments for () {
+    fn decode_arguments(mut de: IDLDeserialize<'_>) -> Result<(IDLDeserialize<'_>, ())> {
+        let a_new = de.get_value()?;
+        Ok((de, (a_new)))
+    }
 }
 
 // This is all pretty mechanical, perhaps we could use code gen?
-impl<
-    A1: DeserializeOwned,
-    > DecodeArguments for (A1,)
-{
-    fn decode_arguments(mut de: IDLDeserialize<'_>) -> (IDLDeserialize<'_>, (A1,)) {
-        let a_new = de.get_value().unwrap();
-        (de, (a_new,))
+impl<A1: DeserializeOwned> DecodeArguments for (A1,) {
+    fn decode_arguments(mut de: IDLDeserialize<'_>) -> Result<(IDLDeserialize<'_>, (A1,))> {
+        let a_new = de.get_value()?;
+        Ok((de, (a_new,)))
     }
 }
 
-impl<
-    A1: DeserializeOwned,
-    A2: DeserializeOwned,
-    > DecodeArguments for (A1, A2)
-{
-    fn decode_arguments(de: IDLDeserialize<'_>) -> (IDLDeserialize<'_>, (A1, A2)) {
-        let (mut de, (a1,)) = DecodeArguments::decode_arguments(de);
-        let a_new = de.get_value().unwrap();
-        (de, (a1, a_new))
+impl<A1: DeserializeOwned, A2: DeserializeOwned> DecodeArguments for (A1, A2) {
+    fn decode_arguments(de: IDLDeserialize<'_>) -> Result<(IDLDeserialize<'_>, (A1, A2))> {
+        let (mut de, (a1,)) = DecodeArguments::decode_arguments(de)?;
+        let a_new = de.get_value()?;
+        Ok((de, (a1, a_new)))
     }
 }
 
-impl<
-    A1: DeserializeOwned,
-    A2: DeserializeOwned,
-    A3: DeserializeOwned,
-    > DecodeArguments for (A1, A2, A3)
+impl<A1: DeserializeOwned, A2: DeserializeOwned, A3: DeserializeOwned> DecodeArguments
+    for (A1, A2, A3)
 {
-    fn decode_arguments(de: IDLDeserialize<'_>) -> (IDLDeserialize<'_>, (A1, A2, A3)) {
-        let (mut de, (a1, a2)) = DecodeArguments::decode_arguments(de);
-        let a_new = de.get_value().unwrap();
-        (de, (a1, a2, a_new))
+    fn decode_arguments(de: IDLDeserialize<'_>) -> Result<(IDLDeserialize<'_>, (A1, A2, A3))> {
+        let (mut de, (a1, a2)) = DecodeArguments::decode_arguments(de)?;
+        let a_new = de.get_value()?;
+        Ok((de, (a1, a2, a_new)))
     }
 }
 
-impl<
-    A1: DeserializeOwned,
-    A2: DeserializeOwned,
-    A3: DeserializeOwned,
-    A4: DeserializeOwned,
-    > DecodeArguments for (A1, A2, A3, A4)
+impl<A1: DeserializeOwned, A2: DeserializeOwned, A3: DeserializeOwned, A4: DeserializeOwned>
+    DecodeArguments for (A1, A2, A3, A4)
 {
-    fn decode_arguments(de: IDLDeserialize<'_>) -> (IDLDeserialize<'_>, (A1, A2, A3, A4)) {
-        let (mut de, (a1, a2, a3)) = DecodeArguments::decode_arguments(de);
-        let a_new = de.get_value().unwrap();
-        (de, (a1, a2, a3, a_new))
+    fn decode_arguments(de: IDLDeserialize<'_>) -> Result<(IDLDeserialize<'_>, (A1, A2, A3, A4))> {
+        let (mut de, (a1, a2, a3)) = DecodeArguments::decode_arguments(de)?;
+        let a_new = de.get_value()?;
+        Ok((de, (a1, a2, a3, a_new)))
     }
 }
 
-pub fn decode_args<IDL: DecodeArguments>(bytes: &[u8]) -> IDL {
-    let de = IDLDeserialize::new(bytes).unwrap();
+pub fn decode_args<IDL: DecodeArguments>(bytes: &[u8]) -> Result<IDL> {
+    let de = IDLDeserialize::new(bytes)?;
     // Should we mark the Deserializer as done here?
-    DecodeArguments::decode_arguments(de).1
+    let res = DecodeArguments::decode_arguments(de)?;
+    Ok(res.1)
 }

--- a/candid/src/de.rs
+++ b/candid/src/de.rs
@@ -12,13 +12,13 @@ use std::io::Read;
 
 const MAGIC_NUMBER: &[u8; 4] = b"DIDL";
 
-/// Use this struct to deserialize a sequence of Rust values (heterogeneous) from IDL binary message.
+/// Use this struct to deserialize a sequence of Rust values (heterogeneous) from Candid binary message.
 pub struct IDLDeserialize<'de> {
     de: Deserializer<'de>,
 }
 
 impl<'de> IDLDeserialize<'de> {
-    /// Create a new deserializer with IDL binary message.
+    /// Create a new deserializer with Candid binary message.
     pub fn new(bytes: &'de [u8]) -> Result<Self> {
         let mut de = Deserializer::from_bytes(bytes);
         de.parse_table().map_err(|e| de.dump_error_state(e))?;
@@ -826,7 +826,7 @@ impl<A1: DeserializeOwned, A2: DeserializeOwned, A3: DeserializeOwned, A4: Deser
     }
 }
 
-pub fn decode_args<IDL: DecodeArguments>(bytes: &[u8]) -> Result<IDL> {
+pub fn decode_args<Candid: DecodeArguments>(bytes: &[u8]) -> Result<Candid> {
     let de = IDLDeserialize::new(bytes)?;
     // Should we mark the Deserializer as done here?
     let res = DecodeArguments::decode_arguments(de)?;

--- a/candid/src/de.rs
+++ b/candid/src/de.rs
@@ -5,7 +5,7 @@ use super::types::internal::Opcode;
 use super::{idl_hash, Int, Nat};
 use byteorder::{LittleEndian, ReadBytesExt};
 use leb128::read::{signed as sleb128_decode, unsigned as leb128_decode};
-use serde::de::{self, Visitor};
+use serde::de::{self, Visitor, DeserializeOwned};
 use std::collections::{BTreeMap, VecDeque};
 use std::convert::TryFrom;
 use std::io::Read;
@@ -776,4 +776,64 @@ impl<'de, 'a> de::VariantAccess<'de> for Compound<'a, 'de> {
             de::Deserializer::deserialize_struct(self.de, "_", fields, visitor)
         }
     }
+}
+
+pub trait DecodeArguments {
+    fn decode_arguments(_de: IDLDeserialize<'_>) -> (IDLDeserialize<'_>, Self);
+}
+
+// This is all pretty mechanical, perhaps we could use code gen?
+impl<
+    A1: DeserializeOwned,
+    > DecodeArguments for (A1,)
+{
+    fn decode_arguments(mut de: IDLDeserialize<'_>) -> (IDLDeserialize<'_>, (A1,)) {
+        let a_new = de.get_value().unwrap();
+        (de, (a_new,))
+    }
+}
+
+impl<
+    A1: DeserializeOwned,
+    A2: DeserializeOwned,
+    > DecodeArguments for (A1, A2)
+{
+    fn decode_arguments(de: IDLDeserialize<'_>) -> (IDLDeserialize<'_>, (A1, A2)) {
+        let (mut de, (a1,)) = DecodeArguments::decode_arguments(de);
+        let a_new = de.get_value().unwrap();
+        (de, (a1, a_new))
+    }
+}
+
+impl<
+    A1: DeserializeOwned,
+    A2: DeserializeOwned,
+    A3: DeserializeOwned,
+    > DecodeArguments for (A1, A2, A3)
+{
+    fn decode_arguments(de: IDLDeserialize<'_>) -> (IDLDeserialize<'_>, (A1, A2, A3)) {
+        let (mut de, (a1, a2)) = DecodeArguments::decode_arguments(de);
+        let a_new = de.get_value().unwrap();
+        (de, (a1, a2, a_new))
+    }
+}
+
+impl<
+    A1: DeserializeOwned,
+    A2: DeserializeOwned,
+    A3: DeserializeOwned,
+    A4: DeserializeOwned,
+    > DecodeArguments for (A1, A2, A3, A4)
+{
+    fn decode_arguments(de: IDLDeserialize<'_>) -> (IDLDeserialize<'_>, (A1, A2, A3, A4)) {
+        let (mut de, (a1, a2, a3)) = DecodeArguments::decode_arguments(de);
+        let a_new = de.get_value().unwrap();
+        (de, (a1, a2, a3, a_new))
+    }
+}
+
+pub fn decode_args<IDL: DecodeArguments>(bytes: &[u8]) -> IDL {
+    let de = IDLDeserialize::new(bytes).unwrap();
+    // Should we mark the Deserializer as done here?
+    DecodeArguments::decode_arguments(de).1
 }

--- a/candid/src/de.rs
+++ b/candid/src/de.rs
@@ -828,7 +828,7 @@ impl<'a, A1: Deserialize<'a>, A2: Deserialize<'a>, A3: Deserialize<'a>, A4: Dese
 
 pub fn decode_args<'a, Candid: DecodeArguments<'a>>(bytes: &'a [u8]) -> Result<Candid> {
     let de = IDLDeserialize::new(bytes)?;
-    // Should we mark the Deserializer as done here?
-    let res = DecodeArguments::decode_arguments(de)?;
-    Ok(res.1)
+    let (de, res) = DecodeArguments::decode_arguments(de)?;
+    de.done()?;
+    Ok(res)
 }

--- a/candid/src/error.rs
+++ b/candid/src/error.rs
@@ -7,6 +7,7 @@ use std::io;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+#[derive(PartialEq, Eq)]
 pub struct Error {
     message: String,
     states: String,

--- a/candid/src/lib.rs
+++ b/candid/src/lib.rs
@@ -38,10 +38,10 @@
 //! We also provide macros for encoding/decoding Candid message in a convenient way.
 //!
 //! ```
-//! use candid::{encode_to_vec, decode_args, Result};
+//! use candid::{encode_args, decode_args, Result};
 //! fn macro_example() -> Result<()> {
 //!   // Serialize two values [(42, "text")] and (42u32, "text")
-//!   let bytes: Vec<u8> = encode_to_vec((&[(42, "text")], &(42u32, "text")))?;
+//!   let bytes: Vec<u8> = encode_args((&[(42, "text")], &(42u32, "text")))?;
 //!   // Deserialize the first value as type Vec<(i32, &str)>,
 //!   // and the second value as type (u32, String)
 //!   let (a, b): (Vec<(i32, &str)>, (u32, String)) = decode_args(&bytes)?;
@@ -52,8 +52,8 @@
 //! }
 //! # macro_example().unwrap();
 //! ```
-//! The [`encode_to_vec`](macro.Encode.html) macro takes a sequence of Rust values, and returns a binary format `Vec<u8>` that can be sent over the wire.
-//! The [`decode_args`](macro.Decode.html) macro takes the binary message and a sequence of Rust types that you want to decode into, and returns a tuple
+//! The [`encode_args`](ser/fn.encode_args.html) function takes a tuple of Rust values, and returns a binary format `Vec<u8>` that can be sent over the wire.
+//! The [`decode_args`](de/fn.decode_args) macro takes the binary message and a sequence of Rust types that you want to decode into, and returns a tuple
 //! of Rust values of the given types.
 //!
 //! Note that a fixed Candid message may be decoded in multiple Rust types. For example,
@@ -69,7 +69,7 @@
 //! This is difficult to achieve in `Serialize`, especially for enum types. Besides serialization, [`CandidType`](types/trait.CandidType.html)
 //! trait also converts Rust type to Candid type defined as [`candid::types::Type`](types/internal/enum.Type.html).
 //! ```
-//! use candid::{encode_to_vec, decode_args, CandidType, Deserialize};
+//! use candid::{encode_args, encode_one, decode_args, decode_one, CandidType, Deserialize};
 //! #[derive(CandidType, Deserialize)]
 //! struct List {
 //!     head: i32,
@@ -77,18 +77,18 @@
 //! }
 //! let list = List { head: 42, tail: None };
 //!
-//! let bytes = encode_to_vec((&list,)).unwrap();
-//! let (res,):(List,) = decode_args(&bytes).unwrap();
+//! let bytes = encode_one(&list).unwrap();
+//! let res:List = decode_one(&bytes).unwrap();
 //! ```
 //!
 //! ## Operating on big integers
 //! To support big integer types [`Candid::Int`](number/struct.Int.html) and [`Candid::Nat`](number/struct.Nat.html),
 //! we use the `num_bigint` crate. We provide interface to convert `i64`, `u64` and `&[u8]` to big integers.
 //! ```
-//! use candid::{Int, Nat, encode_to_vec, decode_args, Result};
+//! use candid::{Int, Nat, encode_args, decode_args, Result};
 //! fn bigint_examples() -> Result<()> {
 //!   let x = Int::parse(b"-10000000000000000000")?;
-//!   let bytes = encode_to_vec((&Nat::from(1024), &x))?;
+//!   let bytes = encode_args((&Nat::from(1024), &x))?;
 //!   let (a, b): (Nat, Int) = decode_args(&bytes)?;
 //!   assert_eq!(a, 1024.into());
 //!   assert_eq!(b, x);
@@ -202,10 +202,10 @@ pub use parser::types::IDLProg;
 pub use parser::value::IDLArgs;
 
 pub mod de;
-pub use de::{decode_args, DecodeArguments};
+pub use de::{decode_args, decode_one, DecodeArguments};
 
 pub mod ser;
-pub use ser::{encode_to_vec, EncodeArguments};
+pub use ser::{encode_args, encode_one, EncodeArguments};
 
 // Candid hash function comes from
 // https://caml.inria.fr/pub/papers/garrigue-polymorphic_variants-ml98.pdf

--- a/candid/src/lib.rs
+++ b/candid/src/lib.rs
@@ -202,10 +202,10 @@ pub use parser::types::IDLProg;
 pub use parser::value::IDLArgs;
 
 pub mod de;
-pub use de::decode_args;
+pub use de::{decode_args, DecodeArguments};
 
 pub mod ser;
-pub use ser::encode_to_vec;
+pub use ser::{encode_to_vec, EncodeArguments};
 
 // Candid hash function comes from
 // https://caml.inria.fr/pub/papers/garrigue-polymorphic_variants-ml98.pdf

--- a/candid/src/lib.rs
+++ b/candid/src/lib.rs
@@ -202,7 +202,10 @@ pub use parser::types::IDLProg;
 pub use parser::value::IDLArgs;
 
 pub mod de;
+pub use de::decode_args;
+
 pub mod ser;
+pub use ser::encode_to_vec;
 
 // Candid hash function comes from
 // https://caml.inria.fr/pub/papers/garrigue-polymorphic_variants-ml98.pdf
@@ -215,38 +218,4 @@ pub fn idl_hash(id: &str) -> u32 {
         s = s.wrapping_mul(223).wrapping_add(c as u32);
     }
     s
-}
-
-/// Encode sequence of Rust values into Candid message of type `candid::Result<Vec<u8>>`.
-#[macro_export]
-macro_rules! Encode {
-    ( $($x:expr),* ) => {{
-        let mut builder = candid::ser::IDLBuilder::new();
-        Encode!(@PutValue builder $($x,)*)
-    }};
-    ( @PutValue $builder:ident $x:expr, $($tail:expr,)* ) => {{
-        $builder.arg($x).and_then(|mut builder| Encode!(@PutValue builder $($tail,)*))
-    }};
-    ( @PutValue $builder:ident ) => {{
-        $builder.serialize_to_vec()
-    }};
-}
-
-/// Decode Candid message into a tuple of Rust values of the given types.
-/// Produces `Err` if the message fails to decode at any given types.
-/// If the message contains only one value, it returns the value directly instead of a tuple.
-#[macro_export]
-macro_rules! Decode {
-    ( $hex:expr $(,$ty:ty)* ) => {{
-        candid::de::IDLDeserialize::new($hex)
-            .and_then(|mut de| Decode!(@GetValue [] de $($ty,)*)
-                      .and_then(|res| de.done().and(Ok(res))))
-    }};
-    (@GetValue [$($ans:ident)*] $de:ident $ty:ty, $($tail:ty,)* ) => {{
-        $de.get_value::<$ty>()
-            .and_then(|val| Decode!(@GetValue [$($ans)* val] $de $($tail,)* ))
-    }};
-    (@GetValue [$($ans:ident)*] $de:ident) => {{
-        Ok(($($ans),*))
-    }};
 }

--- a/candid/src/lib.rs
+++ b/candid/src/lib.rs
@@ -38,13 +38,13 @@
 //! We also provide macros for encoding/decoding Candid message in a convenient way.
 //!
 //! ```
-//! use candid::{Encode, Decode, Result};
+//! use candid::{encode_to_vec, decode_args, Result};
 //! fn macro_example() -> Result<()> {
 //!   // Serialize two values [(42, "text")] and (42u32, "text")
-//!   let bytes: Vec<u8> = Encode!(&[(42, "text")], &(42u32, "text"))?;
+//!   let bytes: Vec<u8> = encode_to_vec((&[(42, "text")], &(42u32, "text")))?;
 //!   // Deserialize the first value as type Vec<(i32, &str)>,
 //!   // and the second value as type (u32, String)
-//!   let (a, b) = Decode!(&bytes, Vec<(i32, &str)>, (u32, String))?;
+//!   let (a, b): (Vec<(i32, &str)>, (u32, String)) = decode_args(&bytes)?;
 //!
 //!   assert_eq!(a, [(42, "text")]);
 //!   assert_eq!(b, (42u32, "text".to_string()));
@@ -52,8 +52,8 @@
 //! }
 //! # macro_example().unwrap();
 //! ```
-//! The [`Encode!`](macro.Encode.html) macro takes a sequence of Rust values, and returns a binary format `Vec<u8>` that can be sent over the wire.
-//! The [`Decode!`](macro.Decode.html) macro takes the binary message and a sequence of Rust types that you want to decode into, and returns a tuple
+//! The [`encode_to_vec`](macro.Encode.html) macro takes a sequence of Rust values, and returns a binary format `Vec<u8>` that can be sent over the wire.
+//! The [`decode_args`](macro.Decode.html) macro takes the binary message and a sequence of Rust types that you want to decode into, and returns a tuple
 //! of Rust values of the given types.
 //!
 //! Note that a fixed Candid message may be decoded in multiple Rust types. For example,
@@ -69,7 +69,7 @@
 //! This is difficult to achieve in `Serialize`, especially for enum types. Besides serialization, [`CandidType`](types/trait.CandidType.html)
 //! trait also converts Rust type to Candid type defined as [`candid::types::Type`](types/internal/enum.Type.html).
 //! ```
-//! use candid::{Encode, Decode, CandidType, Deserialize};
+//! use candid::{encode_to_vec, decode_args, CandidType, Deserialize};
 //! #[derive(CandidType, Deserialize)]
 //! struct List {
 //!     head: i32,
@@ -77,19 +77,19 @@
 //! }
 //! let list = List { head: 42, tail: None };
 //!
-//! let bytes = Encode!(&list).unwrap();
-//! let res = Decode!(&bytes, List);
+//! let bytes = encode_to_vec((&list,)).unwrap();
+//! let (res,):(List,) = decode_args(&bytes).unwrap();
 //! ```
 //!
 //! ## Operating on big integers
 //! To support big integer types [`Candid::Int`](number/struct.Int.html) and [`Candid::Nat`](number/struct.Nat.html),
 //! we use the `num_bigint` crate. We provide interface to convert `i64`, `u64` and `&[u8]` to big integers.
 //! ```
-//! use candid::{Int, Nat, Encode, Decode, Result};
+//! use candid::{Int, Nat, encode_to_vec, decode_args, Result};
 //! fn bigint_examples() -> Result<()> {
 //!   let x = Int::parse(b"-10000000000000000000")?;
-//!   let bytes = Encode!(&Nat::from(1024), &x)?;
-//!   let (a, b) = Decode!(&bytes, Nat, Int)?;
+//!   let bytes = encode_to_vec((&Nat::from(1024), &x))?;
+//!   let (a, b): (Nat, Int) = decode_args(&bytes)?;
 //!   assert_eq!(a, 1024.into());
 //!   assert_eq!(b, x);
 //!   Ok(())

--- a/candid/src/ser.rs
+++ b/candid/src/ser.rs
@@ -353,11 +353,14 @@ impl<A1: CandidType, A2: CandidType, A3: CandidType, A4: CandidType> EncodeArgum
 /// # use candid::{encode_args, decode_args, Result};
 /// # fn main() -> Result<()> {
 /// let zero_arguments = encode_args(())?;
+///
 /// let one_argument = encode_args(("argument 1",))?;
-/// let two_arguments = encode_args(("argument 1", 2))?;
-/// let (s, i) = decode_args::<(&str, i32)>(&two_arguments)?;
+///
+/// let two_arguments = encode_args(("argument 1", (1,2)))?;
+/// let (s, i) = decode_args::<(&str, (i32, i32))>(&two_arguments)?;
+///
 /// assert_eq!(s, "argument 1");
-/// assert_eq!(i, 2);
+/// assert_eq!(i, (1, 2));
 /// # Ok(())
 /// # }
 /// ```
@@ -366,7 +369,7 @@ pub fn encode_args<Tuple: EncodeArguments>(arguments: Tuple) -> Result<Vec<u8>> 
     arguments.encode_arguments(&mut ser)?.serialize_to_vec()
 }
 
-/// Serializes a rust value to a single candid argument.
+/// Serializes a single rust value to a single candid argument.
 ///
 /// Calling this is the equivalent of calling:
 /// ```
@@ -374,7 +377,7 @@ pub fn encode_args<Tuple: EncodeArguments>(arguments: Tuple) -> Result<Vec<u8>> 
 /// # let argument = ();
 /// encode_args((argument,));
 /// ```
-/// Be warned that one argument of type tuple is not the same as multiple arguments:
+/// Be warned that a single argument of type tuple is not the same as multiple arguments:
 /// ```
 /// # use candid::{encode_one, decode_one, decode_args, Result, Error};
 /// let one_arg = encode_one((1,2)).unwrap();

--- a/candid/src/ser.rs
+++ b/candid/src/ser.rs
@@ -303,7 +303,7 @@ pub trait EncodeArguments {
 // Is this a sensible impl?
 impl EncodeArguments for () {
     fn encode_arguments(self, ser: &mut IDLBuilder) -> Result<&mut IDLBuilder> {
-        ser.arg(&self)
+        Ok(ser)
     }
 }
 impl<A1: CandidType> EncodeArguments for (A1,) {

--- a/candid/src/ser.rs
+++ b/candid/src/ser.rs
@@ -341,7 +341,5 @@ impl<A1: CandidType, A2: CandidType, A3: CandidType, A4: CandidType> EncodeArgum
 
 pub fn encode_to_vec<Candid: EncodeArguments>(arguments: Candid) -> Result<Vec<u8>> {
     let mut ser = IDLBuilder::new();
-    arguments
-        .encode_arguments(&mut ser)?
-        .serialize_to_vec()
+    arguments.encode_arguments(&mut ser)?.serialize_to_vec()
 }

--- a/candid/src/ser.rs
+++ b/candid/src/ser.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::io;
 use std::vec::Vec;
 
-/// Use this struct to serialize a sequence of Rust values (heterogeneous) to IDL binary message.
+/// Use this struct to serialize a sequence of Rust values (heterogeneous) to Candid binary message.
 #[derive(Default)]
 pub struct IDLBuilder {
     type_ser: TypeSerialize,
@@ -49,14 +49,14 @@ impl IDLBuilder {
     }
 }
 
-/// A structure for serializing Rust values to IDL.
+/// A structure for serializing Rust values to Candid.
 #[derive(Default)]
 pub struct ValueSerializer {
     value: Vec<u8>,
 }
 
 impl ValueSerializer {
-    /// Creates a new IDL serializer.
+    /// Creates a new Candid serializer.
     #[inline]
     pub fn new() -> Self {
         ValueSerializer { value: Vec::new() }
@@ -159,7 +159,7 @@ impl<'a> types::Compound for Compound<'a> {
     }
 }
 
-/// A structure for serializing Rust values to IDL types.
+/// A structure for serializing Rust values to Candid types.
 #[derive(Default)]
 pub struct TypeSerialize {
     type_table: Vec<Vec<u8>>,
@@ -339,7 +339,7 @@ impl<A1: CandidType, A2: CandidType, A3: CandidType, A4: CandidType> EncodeArgum
     }
 }
 
-pub fn encode_to_vec<IDL: EncodeArguments>(arguments: IDL) -> Result<Vec<u8>> {
+pub fn encode_to_vec<Candid: EncodeArguments>(arguments: Candid) -> Result<Vec<u8>> {
     let mut ser = IDLBuilder::new();
     arguments
         .encode_arguments(&mut ser)?

--- a/candid/tests/serde.rs
+++ b/candid/tests/serde.rs
@@ -374,7 +374,7 @@ fn test_generics() {
 fn test_multiargs() {
     let bytes = encode_to_vec(()).unwrap();
     assert_eq!(bytes, b"DIDL\0\0");
-    let () = decode_args(&bytes).unwrap();
+    decode_args::<()>(&bytes).unwrap();
 
     let bytes = encode_to_vec((
         &Int::from(42),

--- a/candid/tests/serde.rs
+++ b/candid/tests/serde.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, encode_to_vec, Deserialize, decode_args, Int, Nat};
+use candid::{decode_args, encode_to_vec, CandidType, Deserialize, Int, Nat};
 
 #[test]
 fn test_error() {
@@ -107,7 +107,9 @@ fn test_reserved() {
     all_check(res, "4449444c016b02bc8a017bc5fed2016f01000001");
     let bytes = hex("4449444c016b02bc8a017bc5fed2016f010001");
     check_error(
-        || {let _: (Result<u8, Empty>,) = decode_args(&bytes).unwrap();},
+        || {
+            let _: (Result<u8, Empty>,) = decode_args(&bytes).unwrap();
+        },
         "Cannot decode empty type",
     );
 }
@@ -378,7 +380,7 @@ fn test_multiargs() {
         &Int::from(42),
         &Some(Int::from(42)),
         &Some(Int::from(1)),
-        &Some(Int::from(2))
+        &Some(Int::from(2)),
     ))
     .unwrap();
     assert_eq!(bytes, hex("4449444c016e7c047c0000002a012a01010102"));
@@ -439,7 +441,7 @@ fn test_decode<'de, T>(bytes: &'de [u8], expected: &T)
 where
     T: PartialEq + serde::de::Deserialize<'de> + std::fmt::Debug,
 {
-    let (decoded,):(T,) = decode_args(bytes).unwrap();
+    let (decoded,): (T,) = decode_args(bytes).unwrap();
     assert_eq!(decoded, *expected);
 }
 

--- a/candid/tests/value.rs
+++ b/candid/tests/value.rs
@@ -1,5 +1,5 @@
-use candid::parser::value::{IDLArgs, IDLField, IDLValue};
 use candid::decode_args;
+use candid::parser::value::{IDLArgs, IDLField, IDLValue};
 
 #[test]
 fn test_parser() {
@@ -91,7 +91,7 @@ fn test_encode(v: &IDLValue, expected: &[u8]) {
 }
 
 fn test_decode(bytes: &[u8], expected: &IDLValue) {
-    let (decoded,):(IDLValue,) = decode_args(bytes).unwrap();
+    let (decoded,): (IDLValue,) = decode_args(bytes).unwrap();
     assert_eq!(decoded, *expected);
 }
 

--- a/candid/tests/value.rs
+++ b/candid/tests/value.rs
@@ -1,5 +1,5 @@
 use candid::parser::value::{IDLArgs, IDLField, IDLValue};
-use candid::Decode;
+use candid::decode_args;
 
 #[test]
 fn test_parser() {
@@ -91,7 +91,7 @@ fn test_encode(v: &IDLValue, expected: &[u8]) {
 }
 
 fn test_decode(bytes: &[u8], expected: &IDLValue) {
-    let decoded = Decode!(bytes, IDLValue).unwrap();
+    let (decoded,):(IDLValue,) = decode_args(bytes).unwrap();
     assert_eq!(decoded, *expected);
 }
 


### PR DESCRIPTION
I find the macros quite difficult to use in practice, lots of things don't work (type annotations) and they tend to throw horrific errors. I've used type classes to implement something almost identical. Currently this only goes up to 4 argument functions, but I can extend this to more quite easily. Code generation is also a reasonable way of doing this.

While this can sometimes be more verbose, I think the ease of use is worth it.

The docs are still a bit of a mess so I'll work on fixing them up while this gets reviewed.