### PR TITLE
eq, clone and hash for bigint; fix scoping bug in candid_derive

### DIFF
--- a/candid/src/number.rs
+++ b/candid/src/number.rs
@@ -7,9 +7,9 @@ use serde::de::{Deserialize, Visitor};
 use std::convert::From;
 use std::{fmt, io};
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone, Hash)]
 pub struct Int(pub BigInt);
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone, Hash)]
 pub struct Nat(pub BigUint);
 
 impl From<i64> for Int {

--- a/candid_derive/src/lib.rs
+++ b/candid_derive/src/lib.rs
@@ -28,7 +28,7 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
             }
             fn id() -> candid::types::TypeId { candid::types::TypeId::of::<#name #ty_generics>() }
 
-            fn idl_serialize<__S>(&self, __serializer: __S) -> Result<(), __S::Error>
+            fn idl_serialize<__S>(&self, __serializer: __S) -> std::result::Result<(), __S::Error>
                 where
                 __S: candid::types::Serializer,
                 {

--- a/candid_derive/src/lib.rs
+++ b/candid_derive/src/lib.rs
@@ -22,15 +22,15 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
         Data::Union(_) => unimplemented!("doesn't derive union type"),
     };
     let gen = quote! {
-        impl #impl_generics candid::types::CandidType for #name #ty_generics #where_clause {
-            fn _ty() -> candid::types::Type {
+        impl #impl_generics ::candid::types::CandidType for #name #ty_generics #where_clause {
+            fn _ty() -> ::candid::types::Type {
                 #ty_body
             }
-            fn id() -> candid::types::TypeId { candid::types::TypeId::of::<#name #ty_generics>() }
+            fn id() -> ::candid::types::TypeId { ::candid::types::TypeId::of::<#name #ty_generics>() }
 
-            fn idl_serialize<__S>(&self, __serializer: __S) -> std::result::Result<(), __S::Error>
+            fn idl_serialize<__S>(&self, __serializer: __S) -> ::std::result::Result<(), __S::Error>
                 where
-                __S: candid::types::Serializer,
+                __S: ::candid::types::Serializer,
                 {
                     #ser_body
                 }
@@ -129,9 +129,9 @@ fn enum_from_ast(
     let hash = fs.iter().map(|Variant { hash, .. }| hash);
     let ty = fs.iter().map(|Variant { ty, .. }| ty);
     let ty_gen = quote! {
-        candid::types::Type::Variant(
+        ::candid::types::Type::Variant(
             vec![
-                #(candid::types::Field {
+                #(::candid::types::Field {
                     id: #id.to_owned(),
                     hash: #hash,
                     ty: #ty }
@@ -151,7 +151,7 @@ fn enum_from_ast(
             (
                 pattern,
                 quote! {
-                    #(candid::types::Compound::serialize_element(&mut ser, #id)?;)*
+                    #(::candid::types::Compound::serialize_element(&mut ser, #id)?;)*
                 },
             )
         })
@@ -172,7 +172,7 @@ fn serialize_struct(idents: &[Ident]) -> Tokens {
     let id = idents.iter().map(|ident| ident.to_token());
     quote! {
         let mut ser = __serializer.serialize_struct()?;
-        #(candid::types::Compound::serialize_element(&mut ser, &self.#id)?;)*
+        #(::candid::types::Compound::serialize_element(&mut ser, &self.#id)?;)*
         Ok(())
     }
 }
@@ -181,13 +181,13 @@ fn struct_from_ast(fields: &syn::Fields) -> (Tokens, Vec<Ident>) {
     match *fields {
         syn::Fields::Named(ref fields) => {
             let (fs, idents) = fields_from_ast(&fields.named);
-            (quote! { candid::types::Type::Record(#fs) }, idents)
+            (quote! { ::candid::types::Type::Record(#fs) }, idents)
         }
         syn::Fields::Unnamed(ref fields) => {
             let (fs, idents) = fields_from_ast(&fields.unnamed);
-            (quote! { candid::types::Type::Record(#fs) }, idents)
+            (quote! { ::candid::types::Type::Record(#fs) }, idents)
         }
-        syn::Fields::Unit => (quote! { candid::types::Type::Null }, Vec::new()),
+        syn::Fields::Unit => (quote! { ::candid::types::Type::Null }, Vec::new()),
     }
 }
 
@@ -244,7 +244,7 @@ fn fields_from_ast(fields: &Punctuated<syn::Field, syn::Token![,]>) -> (Tokens, 
     let ty = fs.iter().map(|Field { ty, .. }| ty);
     let ty_gen = quote! {
         vec![
-            #(candid::types::Field {
+            #(::candid::types::Field {
                 id: #id.to_owned(),
                 hash: #hash,
                 ty: #ty }
@@ -257,7 +257,7 @@ fn fields_from_ast(fields: &Punctuated<syn::Field, syn::Token![,]>) -> (Tokens, 
 
 fn derive_type(t: &syn::Type) -> Tokens {
     quote! {
-        <#t as candid::types::CandidType>::ty()
+        <#t as ::candid::types::CandidType>::ty()
     }
 }
 


### PR DESCRIPTION
**Overview**
1. Derive common operations for numbers (eq, clone and hash)
2. Fix a type scoping issue that leads to cryptic errors for certain uses

**Requirements**
People can define composite types that include these types `Nat` and `Int` that derive these traits automatically.

**Considered Solutions**
Use derive to define things automatically

**Recommended Solution**
Use derive to define things automatically

**Considerations**
Slightly more compile time, but worth it.
