### PR TITLE
Lg/antora yml file

### DIFF
--- a/.github/antora.yml
+++ b/.github/antora.yml
@@ -1,0 +1,2 @@
+name: docs
+version: 'master'


### PR DESCRIPTION
**Overview**
This file allows us to include Candid doc in the SDK website. Adding Candid doc to the SDK website would be cool because it would then be indexed and searchable.

**Requirements**
To make the doc accessible in the website given the current toolchain, the markdown files need to be converted to .adoc, but this PR just adds the file that flags the repo as a content source.

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
