### PR TITLE
Feature: add all conversions and operators to Nat/Int

### DIFF
--- a/candid/src/lib.rs
+++ b/candid/src/lib.rs
@@ -90,7 +90,7 @@
 //!   let x = "-10000000000000000000".parse::<Int>()?;
 //!   let bytes = Encode!(&Nat::from(1024), &x)?;
 //!   let (a, b) = Decode!(&bytes, Nat, Int)?;
-//!   assert_eq!(a, 1024);
+//!   assert_eq!(a + 1, 1025);
 //!   assert_eq!(b, Int::parse(b"-10000000000000000000")?);
 //!   Ok(())
 //! }

--- a/candid/src/lib.rs
+++ b/candid/src/lib.rs
@@ -90,7 +90,7 @@
 //!   let x = "-10000000000000000000".parse::<Int>()?;
 //!   let bytes = Encode!(&Nat::from(1024), &x)?;
 //!   let (a, b) = Decode!(&bytes, Nat, Int)?;
-//!   assert_eq!(a, 1024.into());
+//!   assert_eq!(a, 1024);
 //!   assert_eq!(b, Int::parse(b"-10000000000000000000")?);
 //!   Ok(())
 //! }

--- a/candid/src/number.rs
+++ b/candid/src/number.rs
@@ -327,7 +327,7 @@ macro_rules! define_op_assign {
         // Implement A * B
         impl $imp<$scalar> for $res {
             #[inline]
-            fn $method(&mut self, other: $scalar) -> () {
+            fn $method(&mut self, other: $scalar) {
                 $imp::$method(&mut self.0, other)
             }
         }
@@ -380,7 +380,7 @@ macro_rules! define_op_0_assign {
         // Implement A * B
         impl $imp<$scalar> for $res {
             #[inline]
-            fn $method(&mut self, other: $scalar) -> () {
+            fn $method(&mut self, other: $scalar) {
                 $imp::$method(&mut self.0, other.0)
             }
         }
@@ -432,12 +432,12 @@ impl std::ops::Add<i32> for Nat {
 
     #[inline]
     fn add(self, other: i32) -> Self {
-        (self.0 + &(other as u32)).into()
+        (self.0 + (other as u32)).into()
     }
 }
 impl std::ops::AddAssign<i32> for Nat {
     #[inline]
-    fn add_assign(&mut self, other: i32) -> () {
+    fn add_assign(&mut self, other: i32) {
         self.0 += other as u32
     }
 }
@@ -447,12 +447,12 @@ impl std::ops::Sub<i32> for Nat {
 
     #[inline]
     fn sub(self, other: i32) -> Self {
-        (self.0 - &(other as u32)).into()
+        (self.0 - (other as u32)).into()
     }
 }
 impl std::ops::SubAssign<i32> for Nat {
     #[inline]
-    fn sub_assign(&mut self, other: i32) -> () {
+    fn sub_assign(&mut self, other: i32) {
         self.0 -= other as u32
     }
 }
@@ -462,12 +462,12 @@ impl std::ops::Mul<i32> for Nat {
 
     #[inline]
     fn mul(self, other: i32) -> Self {
-        (self.0 * &(other as u32)).into()
+        (self.0 * (other as u32)).into()
     }
 }
 impl std::ops::MulAssign<i32> for Nat {
     #[inline]
-    fn mul_assign(&mut self, other: i32) -> () {
+    fn mul_assign(&mut self, other: i32) {
         self.0 *= other as u32
     }
 }
@@ -477,12 +477,12 @@ impl std::ops::Div<i32> for Nat {
 
     #[inline]
     fn div(self, other: i32) -> Self {
-        (self.0 / &(other as u32)).into()
+        (self.0 / (other as u32)).into()
     }
 }
 impl std::ops::DivAssign<i32> for Nat {
     #[inline]
-    fn div_assign(&mut self, other: i32) -> () {
+    fn div_assign(&mut self, other: i32) {
         self.0 /= other as u32
     }
 }
@@ -492,12 +492,12 @@ impl std::ops::Rem<i32> for Nat {
 
     #[inline]
     fn rem(self, other: i32) -> Self {
-        (self.0 % &(other as u32)).into()
+        (self.0 % (other as u32)).into()
     }
 }
 impl std::ops::RemAssign<i32> for Nat {
     #[inline]
-    fn rem_assign(&mut self, other: i32) -> () {
+    fn rem_assign(&mut self, other: i32) {
         self.0 %= other as u32
     }
 }

--- a/candid/tests/number.rs
+++ b/candid/tests/number.rs
@@ -64,6 +64,36 @@ fn random_u64() {
     }
 }
 
+#[test]
+fn operators() {
+    macro_rules! test_type {
+        ($res: ty, $( $t: ty )*) => ($(
+            let x: $t = 1;
+            let value = <$res>::from(x + 1);
+
+            assert_eq!(value.clone() + x, 3);
+            assert_eq!(value.clone() - x, 1);
+            assert_eq!(value.clone() * x, 2);
+            assert_eq!(value.clone() / x, 2);
+            assert_eq!(value.clone() % x, 0);
+
+            assert_eq!(x + value.clone(), 3);
+            assert_eq!(x - value.clone(), 1);
+            assert_eq!(x * value.clone(), 2);
+            assert_eq!(x / value.clone(), 2);
+            assert_eq!(x % value.clone(), 0);
+
+            assert!(value.clone() < <$res>::from(x + 2));
+            assert!(<$res>::from(x + 2) > value.clone());
+            assert!(x < <$res>::from(x + 2));
+            assert!(<$res>::from(x + 2) > x);
+        )*)
+    }
+
+    test_type!( Nat, usize u8 u16 u32 u64 u128 );
+    test_type!( Int, usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 );
+}
+
 fn check(num: &str, int_hex: &str, nat_hex: &str) {
     let v = num.parse::<Int>().unwrap();
     let bytes = hex::decode(int_hex).unwrap();

--- a/candid/tests/number.rs
+++ b/candid/tests/number.rs
@@ -64,6 +64,7 @@ fn random_u64() {
     }
 }
 
+#[allow(clippy::cognitive_complexity)]
 #[test]
 fn operators() {
     macro_rules! test_type {

--- a/candid/tests/serde.rs
+++ b/candid/tests/serde.rs
@@ -384,7 +384,7 @@ fn test_multiargs() {
     assert_eq!(bytes, hex("4449444c016e7c047c0000002a012a01010102"));
 
     let (a, b, c, d) = Decode!(&bytes, Int, Option<Int>, Option<Int>, Option<Int>).unwrap();
-    assert_eq!(a, 42.into());
+    assert_eq!(a, 42);
     assert_eq!(b, Some(42.into()));
     assert_eq!(c, Some(1.into()));
     assert_eq!(d, Some(2.into()));


### PR DESCRIPTION
This includes a lot of native types operators, like `+= 1`.

It also includes conversions from all unsigned types to Nat,
all signed types to Int and i32 to Nat.

Added tests that will always pass but at least check that those
operators are still working as expected. It should really only
break at compile time.
