### PR TITLE
change link to Rust crate

### DIFF
--- a/modules/candid-spec/candid-nav.adoc
+++ b/modules/candid-spec/candid-nav.adoc
@@ -1,2 +1,2 @@
 * xref:IDL.adoc[Candid Specification]
-** link:https://docs.rs/candid/0.2.4/candid[Candid Rust crate]
+** link:https://docs.rs/candid[Candid Rust crate]


### PR DESCRIPTION
**Overview**
Update the link to https://docs.rs/candid (which redirects to the latest version)
