### PR TITLE
refactor label fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "candid"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "byteorder",
  "candid_derive",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",

--- a/candid/Cargo.toml
+++ b/candid/Cargo.toml
@@ -26,7 +26,7 @@ paste = "0.1"
 num_enum = "0.4.3"
 num-bigint = "0.2"
 num-traits = "0.2.7"
-candid_derive = { path = "../candid_derive", version = "0.2.4" }
+candid_derive = { path = "../candid_derive", version = "=0.3.0" }
 lalrpop-util = "0.19.0"
 pretty = "0.10.0"
 hex = "0.3"

--- a/candid/Cargo.toml
+++ b/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."
@@ -26,7 +26,7 @@ paste = "0.1"
 num_enum = "0.4.3"
 num-bigint = "0.2"
 num-traits = "0.2.7"
-candid_derive = { path = "../candid_derive", version = "0.2.3" }
+candid_derive = { path = "../candid_derive", version = "0.2.4" }
 lalrpop-util = "0.19.0"
 pretty = "0.10.0"
 hex = "0.3"

--- a/candid/src/bindings/javascript.rs
+++ b/candid/src/bindings/javascript.rs
@@ -1,7 +1,7 @@
 use super::analysis::{chase_actor, infer_rec};
 use crate::parser::typing::TypeEnv;
 use crate::pretty::*;
-use crate::types::{Field, Function, Type};
+use crate::types::{Field, Function, Label, Type};
 use pretty::RcDoc;
 use std::collections::BTreeSet;
 
@@ -13,7 +13,7 @@ fn is_tuple(t: &Type) -> bool {
                 return false;
             }
             for (i, field) in fs.iter().enumerate() {
-                if field.hash != (i as u32) {
+                if field.id.get_id() != (i as u32) {
                     return false;
                 }
             }
@@ -62,16 +62,20 @@ fn pp_ty(ty: &Type) -> RcDoc {
     }
 }
 
-fn pp_field(field: &Field) -> RcDoc {
-    let name = if field.is_named() {
-        quote_ident(&field.id)
-    } else {
-        str("_")
-            .append(&field.id)
+fn pp_label(id: &Label) -> RcDoc {
+    match id {
+        Label::Named(str) => quote_ident(str),
+        Label::Id(n) | Label::Unnamed(n) => str("_")
+            .append(RcDoc::as_string(n))
             .append("_")
-            .append(RcDoc::space())
-    };
-    name.append(kwd(":")).append(pp_ty(&field.ty))
+            .append(RcDoc::space()),
+    }
+}
+
+fn pp_field(field: &Field) -> RcDoc {
+    pp_label(&field.id)
+        .append(kwd(":"))
+        .append(pp_ty(&field.ty))
 }
 
 fn pp_fields(fs: &[Field]) -> RcDoc {

--- a/candid/src/bindings/javascript.rs
+++ b/candid/src/bindings/javascript.rs
@@ -166,7 +166,7 @@ pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {
             let defs = pp_defs(env, &def_list, &recs);
             let actor = pp_actor(actor, &recs);
             let body = defs.append(actor);
-            let doc = str("({ IDL }) => ").append(enclose_space("{", body, "}"));
+            let doc = str("export default ({ IDL }) => ").append(enclose_space("{", body, "}"));
             doc.pretty(LINE_WIDTH).to_string()
         }
     }

--- a/candid/src/codegen/rust.rs
+++ b/candid/src/codegen/rust.rs
@@ -7,7 +7,8 @@
 //! natural/integer numbers.
 use crate::codegen::LanguageBinding;
 use crate::error::{Error, Result};
-use crate::parser::types::{Binding, Dec, FuncType, IDLType, Label, PrimType, TypeField};
+use crate::parser::types::{Binding, Dec, FuncType, IDLType, PrimType, TypeField};
+use crate::types::Label;
 use crate::{generate_code, idl_hash, IDLProg};
 
 /// Returns true if id is a rust keyword.

--- a/candid/src/parser/grammar.lalrpop
+++ b/candid/src/parser/grammar.lalrpop
@@ -1,7 +1,7 @@
 use super::value::{IDLField, IDLValue, IDLArgs};
-use super::types::{IDLType, PrimType, Label, TypeField, FuncType, FuncMode, Binding, Dec, IDLProg};
+use super::types::{IDLType, PrimType, TypeField, FuncType, FuncMode, Binding, Dec, IDLProg};
 use super::lexer::{Token, LexicalError, TmpIDLField, error};
-use crate::{idl_hash, Principal};
+use crate::{idl_hash, Principal, types::Label};
 
 grammar;
 

--- a/candid/src/parser/grammar.lalrpop
+++ b/candid/src/parser/grammar.lalrpop
@@ -1,6 +1,6 @@
 use super::value::{IDLField, IDLValue, IDLArgs};
 use super::types::{IDLType, PrimType, TypeField, FuncType, FuncMode, Binding, Dec, IDLProg};
-use super::lexer::{Token, LexicalError, TmpIDLField, error};
+use super::lexer::{Token, LexicalError, error};
 use crate::{idl_hash, Principal, types::Label};
 
 grammar;
@@ -55,18 +55,21 @@ pub Arg: IDLValue = {
     "vec" "{" <SepBy<Arg, ";">> "}" => IDLValue::Vec(<>),
     "record" "{" <SepBy<RecordField, ";">> "}" => {
         let mut id: u32 = 0;
-        let mut fs: Vec<IDLField> = <>.iter().map(|f| {
-          if f.has_id {
-            id = f.inner.id.get_id() + 1;
-            f.inner.clone()
-          } else {
-            id = id + 1;
-            IDLField { id: Label::Unnamed(id - 1), val: f.inner.val.clone() }
+        let mut fs: Vec<IDLField> = <>.into_iter().map(|f| {
+          match f.id {
+            Label::Unnamed(_) => {
+              id = id + 1;
+              IDLField { id: Label::Unnamed(id - 1), val: f.val }
+            }
+            _ => {
+              id = f.id.get_id() + 1;
+              f
+            }
           }
         }).collect();
         fs.sort_unstable_by_key(|IDLField { id, .. }| id.get_id());
         IDLValue::Record(fs)
-     },
+    },
     "variant" "{" <VariantField> "}" => IDLValue::Variant(Box::new(<>), 0),
     "principal" <"text"> =>? Ok(IDLValue::Principal(Principal::from_text(<>).map_err(error)?)),
 }
@@ -82,9 +85,9 @@ VariantField: IDLField = {
     "number" =>? Ok(IDLField { id: Label::Id(<>.parse::<u32>().map_err(|_| error("field number out of u32 range"))?), val: IDLValue::Null }),
 }
 
-RecordField: TmpIDLField = {
-    Field => TmpIDLField { has_id: true, inner: <> },
-    Arg => TmpIDLField { has_id: false, inner: IDLField { id: Label::Unnamed(0), val:<> } },
+RecordField: IDLField = {
+    Field => <>,
+    Arg => IDLField { id: Label::Unnamed(0), val:<> },
 }
 
 // Type

--- a/candid/src/parser/grammar.lalrpop
+++ b/candid/src/parser/grammar.lalrpop
@@ -57,14 +57,14 @@ pub Arg: IDLValue = {
         let mut id: u32 = 0;
         let mut fs: Vec<IDLField> = <>.iter().map(|f| {
           if f.has_id {
-            id = f.inner.id + 1;
+            id = f.inner.id.get_id() + 1;
             f.inner.clone()
           } else {
             id = id + 1;
-            IDLField { id: id - 1, val: f.inner.val.clone() }
+            IDLField { id: Label::Unnamed(id - 1), val: f.inner.val.clone() }
           }
         }).collect();
-        fs.sort_unstable_by_key(|IDLField { id, .. }| *id);
+        fs.sort_unstable_by_key(|IDLField { id, .. }| id.get_id());
         IDLValue::Record(fs)
      },
     "variant" "{" <VariantField> "}" => IDLValue::Variant(Box::new(<>), 0),
@@ -72,19 +72,19 @@ pub Arg: IDLValue = {
 }
 
 Field: IDLField = {
-    <n:"number"> "=" <v:Arg> =>? Ok(IDLField { id: n.parse::<u32>().map_err(|_| error("field number out of u32 range"))?, val: v }),
-    <n:Name> "=" <v:Arg> => IDLField { id: idl_hash(&n), val: v },
+    <n:"number"> "=" <v:Arg> =>? Ok(IDLField { id: Label::Id(n.parse::<u32>().map_err(|_| error("field number out of u32 range"))?), val: v }),
+    <n:Name> "=" <v:Arg> => IDLField { id: Label::Named(n), val: v },
 }
 
 VariantField: IDLField = {
     Field => <>,
-    Name => IDLField { id: idl_hash(&<>), val: IDLValue::Null },
-    "number" =>? Ok(IDLField { id: <>.parse::<u32>().map_err(|_| error("field number out of u32 range"))?, val: IDLValue::Null }),
+    Name => IDLField { id: Label::Named(<>), val: IDLValue::Null },
+    "number" =>? Ok(IDLField { id: Label::Id(<>.parse::<u32>().map_err(|_| error("field number out of u32 range"))?), val: IDLValue::Null }),
 }
 
 RecordField: TmpIDLField = {
     Field => TmpIDLField { has_id: true, inner: <> },
-    Arg => TmpIDLField { has_id: false, inner: IDLField { id:0, val:<> } },
+    Arg => TmpIDLField { has_id: false, inner: IDLField { id: Label::Unnamed(0), val:<> } },
 }
 
 // Type

--- a/candid/src/parser/lexer.rs
+++ b/candid/src/parser/lexer.rs
@@ -69,11 +69,6 @@ pub enum Token {
     Boolean(bool),
 }
 
-pub struct TmpIDLField {
-    pub has_id: bool,
-    pub inner: super::value::IDLField,
-}
-
 fn hex_to_char(hex: &str) -> Result<char, LexicalError> {
     let c = u32::from_str_radix(hex, 16).map_err(|_| LexicalError::ParseError(hex.to_owned()))?;
     std::char::from_u32(c).ok_or(LexicalError::OutOfRangeUnicode(c))

--- a/candid/src/parser/types.rs
+++ b/candid/src/parser/types.rs
@@ -101,6 +101,21 @@ impl Label {
     }
 }
 
+impl std::fmt::Display for Label {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Label::Id(n) | Label::Unnamed(n) => write!(f, "{}", n),
+            Label::Named(id) => write!(f, "{}", id),
+        }
+    }
+}
+
+impl PartialEq for Label {
+    fn eq(&self, other: &Self) -> bool {
+        self.get_id() == other.get_id()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TypeField {
     pub label: Label,

--- a/candid/src/parser/types.rs
+++ b/candid/src/parser/types.rs
@@ -1,4 +1,4 @@
-use crate::idl_hash;
+use crate::types::Label;
 use crate::Result;
 use pretty::RcDoc;
 
@@ -81,38 +81,6 @@ impl FuncType {
             }
         }
         false
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum Label {
-    Id(u32),
-    Named(String),
-    Unnamed(u32),
-}
-
-impl Label {
-    pub fn get_id(&self) -> u32 {
-        match *self {
-            Label::Id(n) => n,
-            Label::Named(ref n) => idl_hash(n),
-            Label::Unnamed(n) => n,
-        }
-    }
-}
-
-impl std::fmt::Display for Label {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Label::Id(n) | Label::Unnamed(n) => write!(f, "{}", n),
-            Label::Named(id) => write!(f, "{}", id),
-        }
-    }
-}
-
-impl PartialEq for Label {
-    fn eq(&self, other: &Self) -> bool {
-        self.get_id() == other.get_id()
     }
 }
 

--- a/candid/src/parser/typing.rs
+++ b/candid/src/parser/typing.rs
@@ -168,7 +168,6 @@ fn check_fields(env: &Env, fs: &[TypeField]) -> Result<Vec<Field>> {
         let ty = check_type(env, &f.typ)?;
         let field = Field {
             id: f.label.clone(),
-            hash: f.label.get_id(),
             ty,
         };
         res.push(field);

--- a/candid/src/parser/typing.rs
+++ b/candid/src/parser/typing.rs
@@ -152,7 +152,6 @@ fn check_fields(env: &Env, fs: &[TypeField]) -> Result<Vec<Field>> {
         let mut prev: Option<&TypeField> = None;
         for f in fs.iter() {
             let id = f.label.get_id();
-            // println!("{:?} {}", f.label, f.label.get_id());
             if let Some(prev) = prev {
                 if id == prev.label.get_id() {
                     return Err(Error::msg(format!(
@@ -167,17 +166,10 @@ fn check_fields(env: &Env, fs: &[TypeField]) -> Result<Vec<Field>> {
     }
     for f in fs.iter() {
         let ty = check_type(env, &f.typ)?;
-        let field = match f.label {
-            Label::Id(n) | Label::Unnamed(n) => Field {
-                id: n.to_string(),
-                hash: n,
-                ty,
-            },
-            Label::Named(ref str) => Field {
-                id: str.to_string(),
-                hash: crate::idl_hash(str),
-                ty,
-            },
+        let field = Field {
+            id: f.label.clone(),
+            hash: f.label.get_id(),
+            ty,
         };
         res.push(field);
     }

--- a/candid/src/parser/value.rs
+++ b/candid/src/parser/value.rs
@@ -218,8 +218,10 @@ impl IDLValue {
                 IDLValue::Vec(res)
             }
             (IDLValue::Record(vec), Type::Record(fs)) => {
-                let fs: HashMap<_, _> =
-                    fs.iter().map(|Field { hash, ty, .. }| (hash, ty)).collect();
+                let fs: HashMap<_, _> = fs
+                    .iter()
+                    .map(|Field { id, ty }| (id.get_id(), ty))
+                    .collect();
                 let mut res = Vec::new();
                 for e in vec.iter() {
                     let ty = fs
@@ -235,7 +237,7 @@ impl IDLValue {
             }
             (IDLValue::Variant(v, _), Type::Variant(fs)) => {
                 for (i, f) in fs.iter().enumerate() {
-                    if v.id.get_id() == f.hash {
+                    if v.id.get_id() == f.id.get_id() {
                         let val = v.val.annotate_type(env, &f.ty)?;
                         let field = IDLField {
                             id: v.id.clone(),
@@ -290,7 +292,6 @@ impl IDLValue {
                     .iter()
                     .map(|IDLField { id, val }| Field {
                         id: id.clone(),
-                        hash: id.get_id(),
                         ty: val.value_ty(),
                     })
                     .collect();
@@ -300,7 +301,6 @@ impl IDLValue {
                 assert_eq!(idx, 0);
                 let f = Field {
                     id: v.id.clone(),
-                    hash: v.id.get_id(),
                     ty: v.val.value_ty(),
                 };
                 Type::Variant(vec![f])

--- a/candid/src/parser/value.rs
+++ b/candid/src/parser/value.rs
@@ -1,7 +1,6 @@
 use super::lexer::error;
-use super::types::Label;
 use super::typing::TypeEnv;
-use crate::types::{Field, Type};
+use crate::types::{Field, Label, Type};
 use crate::{Error, Result};
 use crate::{Int, Nat};
 use serde::de;
@@ -290,7 +289,7 @@ impl IDLValue {
                 let fs: Vec<_> = vec
                     .iter()
                     .map(|IDLField { id, val }| Field {
-                        id: id.to_string(),
+                        id: id.clone(),
                         hash: id.get_id(),
                         ty: val.value_ty(),
                     })
@@ -300,7 +299,7 @@ impl IDLValue {
             IDLValue::Variant(ref v, idx) => {
                 assert_eq!(idx, 0);
                 let f = Field {
-                    id: v.id.to_string(),
+                    id: v.id.clone(),
                     hash: v.id.get_id(),
                     ty: v.val.value_ty(),
                 };

--- a/candid/src/parser/value.rs
+++ b/candid/src/parser/value.rs
@@ -218,14 +218,11 @@ impl IDLValue {
                 IDLValue::Vec(res)
             }
             (IDLValue::Record(vec), Type::Record(fs)) => {
-                let fs: HashMap<_, _> = fs
-                    .iter()
-                    .map(|Field { id, ty }| (id.get_id(), ty))
-                    .collect();
+                let fs: HashMap<_, _> = fs.iter().map(|Field { id, ty }| (id, ty)).collect();
                 let mut res = Vec::new();
                 for e in vec.iter() {
                     let ty = fs
-                        .get(&e.id.get_id())
+                        .get(&e.id)
                         .ok_or_else(|| Error::msg(format!("field {} not found", e.id)))?;
                     let v = e.val.annotate_type(env, ty)?;
                     res.push(IDLField {
@@ -237,7 +234,7 @@ impl IDLValue {
             }
             (IDLValue::Variant(v, _), Type::Variant(fs)) => {
                 for (i, f) in fs.iter().enumerate() {
-                    if v.id.get_id() == f.id.get_id() {
+                    if v.id == f.id {
                         let val = v.val.annotate_type(env, &f.ty)?;
                         let field = IDLField {
                             id: v.id.clone(),

--- a/candid/src/ser.rs
+++ b/candid/src/ser.rs
@@ -253,8 +253,8 @@ impl TypeSerialize {
 
                 sleb128_encode(&mut buf, Opcode::Record as i64)?;
                 leb128_encode(&mut buf, fs.len() as u64)?;
-                for Field { hash, ty, .. } in fs.iter() {
-                    leb128_encode(&mut buf, u64::from(*hash))?;
+                for Field { id, ty } in fs.iter() {
+                    leb128_encode(&mut buf, u64::from(id.get_id()))?;
                     self.encode(&mut buf, ty)?;
                 }
             }
@@ -265,8 +265,8 @@ impl TypeSerialize {
 
                 sleb128_encode(&mut buf, Opcode::Variant as i64)?;
                 leb128_encode(&mut buf, fs.len() as u64)?;
-                for Field { hash, ty, .. } in fs.iter() {
-                    leb128_encode(&mut buf, u64::from(*hash))?;
+                for Field { id, ty } in fs.iter() {
+                    leb128_encode(&mut buf, u64::from(id.get_id()))?;
                     self.encode(&mut buf, ty)?;
                 }
             }

--- a/candid/src/types/impls.rs
+++ b/candid/src/types/impls.rs
@@ -153,12 +153,12 @@ where
         Type::Variant(vec![
             // Make sure the field id is sorted by idl_hash
             Field {
-                id: "Ok".to_owned(),
+                id: Label::Named("Ok".to_owned()),
                 hash: 17724u32,
                 ty: T::ty(),
             },
             Field {
-                id: "Err".to_owned(),
+                id: Label::Named("Err".to_owned()),
                 hash: 3_456_837u32,
                 ty: E::ty(),
             },
@@ -227,7 +227,7 @@ macro_rules! tuple_impls {
                 fn id() -> TypeId { TypeId::of::<($($name,)+)>() }
                 fn _ty() -> Type {
                     Type::Record(vec![
-                        $(Field{ id: $n.to_string(), hash: $n, ty: $name::ty() },)+
+                        $(Field{ id: Label::Id($n), hash: $n, ty: $name::ty() },)+
                     ])
                 }
                 fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>

--- a/candid/src/types/impls.rs
+++ b/candid/src/types/impls.rs
@@ -154,12 +154,10 @@ where
             // Make sure the field id is sorted by idl_hash
             Field {
                 id: Label::Named("Ok".to_owned()),
-                hash: 17724u32,
                 ty: T::ty(),
             },
             Field {
                 id: Label::Named("Err".to_owned()),
-                hash: 3_456_837u32,
                 ty: E::ty(),
             },
         ])
@@ -227,7 +225,7 @@ macro_rules! tuple_impls {
                 fn id() -> TypeId { TypeId::of::<($($name,)+)>() }
                 fn _ty() -> Type {
                     Type::Record(vec![
-                        $(Field{ id: Label::Id($n), hash: $n, ty: $name::ty() },)+
+                        $(Field{ id: Label::Id($n), ty: $name::ty() },)+
                     ])
                 }
                 fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>

--- a/candid/src/types/internal.rs
+++ b/candid/src/types/internal.rs
@@ -91,7 +91,6 @@ impl std::hash::Hash for Label {
 #[derive(Debug, PartialEq, Hash, Eq, Clone)]
 pub struct Field {
     pub id: Label,
-    pub hash: u32, // hash is necessary to support field rename attributes
     pub ty: Type,
 }
 
@@ -160,18 +159,16 @@ pub fn unroll(t: &Type) -> Type {
         Vec(ref t) => Vec(Box::new(unroll(t))),
         Record(fs) => Record(
             fs.iter()
-                .map(|Field { id, hash, ty }| Field {
+                .map(|Field { id, ty }| Field {
                     id: id.clone(),
-                    hash: *hash,
                     ty: unroll(ty),
                 })
                 .collect(),
         ),
         Variant(fs) => Variant(
             fs.iter()
-                .map(|Field { id, hash, ty }| Field {
+                .map(|Field { id, ty }| Field {
                     id: id.clone(),
-                    hash: *hash,
                     ty: unroll(ty),
                 })
                 .collect(),

--- a/candid/src/types/internal.rs
+++ b/candid/src/types/internal.rs
@@ -1,4 +1,5 @@
 use super::CandidType;
+use crate::idl_hash;
 use num_enum::TryFromPrimitive;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -49,18 +50,49 @@ pub enum Type {
     Principal,
 }
 
-#[derive(Debug, PartialEq, Hash, Eq, Clone)]
-pub struct Field {
-    pub id: String,
-    pub hash: u32,
-    pub ty: Type,
+#[derive(Debug, Eq, Clone)]
+pub enum Label {
+    Id(u32),
+    Named(String),
+    Unnamed(u32),
 }
 
-impl Field {
-    pub fn is_named(&self) -> bool {
-        // TODO make this more robust
-        crate::idl_hash(&self.id) == self.hash
+impl Label {
+    pub fn get_id(&self) -> u32 {
+        match *self {
+            Label::Id(n) => n,
+            Label::Named(ref n) => idl_hash(n),
+            Label::Unnamed(n) => n,
+        }
     }
+}
+
+impl std::fmt::Display for Label {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Label::Id(n) | Label::Unnamed(n) => write!(f, "{}", n),
+            Label::Named(id) => write!(f, "{}", id),
+        }
+    }
+}
+
+impl PartialEq for Label {
+    fn eq(&self, other: &Self) -> bool {
+        self.get_id() == other.get_id()
+    }
+}
+
+impl std::hash::Hash for Label {
+    fn hash<H: std::hash::Hasher>(&self, _state: &mut H) {
+        self.get_id();
+    }
+}
+
+#[derive(Debug, PartialEq, Hash, Eq, Clone)]
+pub struct Field {
+    pub id: Label,
+    pub hash: u32, // hash is necessary to support field rename attributes
+    pub ty: Type,
 }
 
 #[derive(Debug, PartialEq, Hash, Eq, Clone)]
@@ -129,7 +161,7 @@ pub fn unroll(t: &Type) -> Type {
         Record(fs) => Record(
             fs.iter()
                 .map(|Field { id, hash, ty }| Field {
-                    id: id.to_string(),
+                    id: id.clone(),
                     hash: *hash,
                     ty: unroll(ty),
                 })
@@ -138,7 +170,7 @@ pub fn unroll(t: &Type) -> Type {
         Variant(fs) => Variant(
             fs.iter()
                 .map(|Field { id, hash, ty }| Field {
-                    id: id.to_string(),
+                    id: id.clone(),
                     hash: *hash,
                     ty: unroll(ty),
                 })

--- a/candid/src/types/mod.rs
+++ b/candid/src/types/mod.rs
@@ -9,7 +9,7 @@ use serde::ser::Error;
 mod impls;
 pub mod internal;
 
-pub use self::internal::{get_type, Field, Function, Type, TypeId};
+pub use self::internal::{get_type, Field, Function, Label, Type, TypeId};
 
 pub mod number;
 pub mod principal;

--- a/candid/tests/assets/ok/actor.js
+++ b/candid/tests/assets/ok/actor.js
@@ -1,4 +1,4 @@
-({ IDL }) => {
+export default ({ IDL }) => {
   const o = IDL.Rec();
   const f = IDL.Func([IDL.Int8], [IDL.Int8], []);
   const h = IDL.Func([f], [f], []);

--- a/candid/tests/assets/ok/cyclic.js
+++ b/candid/tests/assets/ok/cyclic.js
@@ -1,4 +1,4 @@
-({ IDL }) => {
+export default ({ IDL }) => {
   const A = IDL.Rec();
   const C = A;
   const B = IDL.Opt(C);

--- a/candid/tests/assets/ok/escape.js
+++ b/candid/tests/assets/ok/escape.js
@@ -1,4 +1,4 @@
-({ IDL }) => {
+export default ({ IDL }) => {
   const t = IDL.Record({
     '\"' : IDL.Nat,
     '\'' : IDL.Nat,

--- a/candid/tests/assets/ok/example.js
+++ b/candid/tests/assets/ok/example.js
@@ -1,4 +1,4 @@
-({ IDL }) => {
+export default ({ IDL }) => {
   const List = IDL.Rec();
   const my_type = IDL.Principal;
   List.fill(IDL.Opt(IDL.Record({ 'head' : IDL.Int, 'tail' : List })));

--- a/candid/tests/assets/ok/fieldnat.js
+++ b/candid/tests/assets/ok/fieldnat.js
@@ -1,4 +1,4 @@
-({ IDL }) => {
+export default ({ IDL }) => {
   return IDL.Service({
     'bab' : IDL.Func([IDL.Int, IDL.Nat], [], []),
     'bar' : IDL.Func([IDL.Record({ '2' : IDL.Int })], [], []),

--- a/candid/tests/assets/ok/recursion.js
+++ b/candid/tests/assets/ok/recursion.js
@@ -1,4 +1,4 @@
-({ IDL }) => {
+export default ({ IDL }) => {
   const B = IDL.Rec();
   const list = IDL.Rec();
   const s = IDL.Rec();

--- a/candid/tests/assets/ok/unicode.js
+++ b/candid/tests/assets/ok/unicode.js
@@ -1,4 +1,4 @@
-({ IDL }) => {
+export default ({ IDL }) => {
   const A = IDL.Record({
     '\u{e000}' : IDL.Nat,
     '📦🍦' : IDL.Nat,

--- a/candid/tests/parse_value.rs
+++ b/candid/tests/parse_value.rs
@@ -1,5 +1,5 @@
-use candid::parser::typing::TypeEnv;
 use candid::parser::value::{IDLArgs, IDLField, IDLValue};
+use candid::parser::{types::Label, typing::TypeEnv};
 use candid::types::Type;
 
 fn parse_args(input: &str) -> IDLArgs {
@@ -116,21 +116,21 @@ fn parse_optional_record() {
             IDLValue::Opt(Box::new(IDLValue::Record(vec![]))),
             IDLValue::Record(vec![
                 IDLField {
-                    id: 1,
+                    id: Label::Id(1),
                     val: IDLValue::Nat(42.into())
                 },
                 IDLField {
-                    id: 2,
+                    id: Label::Id(2),
                     val: IDLValue::Bool(false)
                 },
                 IDLField {
-                    id: 44,
+                    id: Label::Id(44),
                     val: IDLValue::Text("test".to_owned())
                 },
             ]),
             IDLValue::Variant(
                 Box::new(IDLField {
-                    id: 5,
+                    id: Label::Id(5),
                     val: IDLValue::Null
                 }),
                 0
@@ -156,29 +156,29 @@ fn parse_nested_record() {
         args.args,
         vec![IDLValue::Record(vec![
             IDLField {
-                id: 43,
+                id: Label::Id(43),
                 val: IDLValue::Record(vec![
                     IDLField {
-                        id: 5_446_209,
+                        id: Label::Named("msg".to_owned()),
                         val: IDLValue::Text("hello".to_owned())
                     },
                     IDLField {
-                        id: 1_291_438_162,
+                        id: Label::Named("test".to_owned()),
                         val: IDLValue::Text("test".to_owned())
                     }
                 ])
             },
             IDLField {
-                id: 1_350_385_585,
+                id: Label::Named("long_label".to_owned()),
                 val: IDLValue::Opt(Box::new(IDLValue::Null))
             },
             IDLField {
-                id: 1_873_743_348,
+                id: Label::Named("label".to_owned()),
                 val: IDLValue::Nat(42.into())
             }
         ])]
     );
-    assert_eq!(format!("{}", args), "(record { 43 = record { 5446209 = \"hello\"; 1291438162 = \"test\"; }; 1350385585 = opt null; 1873743348 = 42; })");
+    assert_eq!(format!("{}", args), "(record { 43 = record { msg = \"hello\"; test = \"test\"; }; long_label = opt null; label = 42; })");
 }
 
 #[test]
@@ -189,6 +189,6 @@ fn parse_shorthand() {
     let args = parse_args("(variant { 0x2a }, variant { label })");
     assert_eq!(
         format!("{}", args),
-        "(variant { 42 = null }, variant { 1873743348 = null })"
+        "(variant { 42 = null }, variant { label = null })"
     );
 }

--- a/candid/tests/parse_value.rs
+++ b/candid/tests/parse_value.rs
@@ -1,6 +1,6 @@
+use candid::parser::typing::TypeEnv;
 use candid::parser::value::{IDLArgs, IDLField, IDLValue};
-use candid::parser::{types::Label, typing::TypeEnv};
-use candid::types::Type;
+use candid::types::{Label, Type};
 
 fn parse_args(input: &str) -> IDLArgs {
     input.parse().unwrap()

--- a/candid/tests/types.rs
+++ b/candid/tests/types.rs
@@ -1,5 +1,5 @@
 use candid::types::{get_type, Label, Type};
-use candid::{idl_hash, CandidType, Int};
+use candid::{CandidType, Int};
 
 #[test]
 fn test_primitive() {
@@ -84,7 +84,6 @@ fn test_variant() {
 fn field(id: &str, ty: Type) -> candid::types::Field {
     candid::types::Field {
         id: Label::Named(id.to_string()),
-        hash: idl_hash(id),
         ty,
     }
 }
@@ -92,7 +91,6 @@ fn field(id: &str, ty: Type) -> candid::types::Field {
 fn unnamed_field(id: u32, ty: Type) -> candid::types::Field {
     candid::types::Field {
         id: Label::Id(id),
-        hash: id,
         ty,
     }
 }

--- a/candid/tests/types.rs
+++ b/candid/tests/types.rs
@@ -1,4 +1,4 @@
-use candid::types::{get_type, Type};
+use candid::types::{get_type, Label, Type};
 use candid::{idl_hash, CandidType, Int};
 
 #[test]
@@ -83,7 +83,7 @@ fn test_variant() {
 
 fn field(id: &str, ty: Type) -> candid::types::Field {
     candid::types::Field {
-        id: id.to_string(),
+        id: Label::Named(id.to_string()),
         hash: idl_hash(id),
         ty,
     }
@@ -91,7 +91,7 @@ fn field(id: &str, ty: Type) -> candid::types::Field {
 
 fn unnamed_field(id: u32, ty: Type) -> candid::types::Field {
     candid::types::Field {
-        id: id.to_string(),
+        id: Label::Id(id),
         hash: id,
         ty,
     }

--- a/candid/tests/value.rs
+++ b/candid/tests/value.rs
@@ -1,8 +1,9 @@
-use candid::parser::value::{IDLArgs, IDLField, IDLValue};
 use candid::parser::{
-    types::{IDLProg, Label},
+    types::IDLProg,
     typing::{check_prog, TypeEnv},
+    value::{IDLArgs, IDLField, IDLValue},
 };
+use candid::types::Label;
 use candid::Decode;
 
 #[test]

--- a/candid/tests/value.rs
+++ b/candid/tests/value.rs
@@ -1,6 +1,6 @@
 use candid::parser::value::{IDLArgs, IDLField, IDLValue};
 use candid::parser::{
-    types::IDLProg,
+    types::{IDLProg, Label},
     typing::{check_prog, TypeEnv},
 };
 use candid::Decode;
@@ -71,11 +71,11 @@ fn test_value() {
     check(
         Record(vec![
             IDLField {
-                id: 0,
+                id: Label::Id(0),
                 val: Int(42.into()),
             },
             IDLField {
-                id: 1,
+                id: Label::Id(1),
                 val: Text("💩".to_string()),
             },
         ]),
@@ -84,11 +84,11 @@ fn test_value() {
     check(
         Record(vec![
             IDLField {
-                id: 4_895_187,
+                id: Label::Id(4_895_187),
                 val: Bool(true),
             },
             IDLField {
-                id: 5_097_222,
+                id: Label::Id(5_097_222),
                 val: Int(42.into()),
             },
         ]),
@@ -101,7 +101,7 @@ fn test_variant() {
     use IDLValue::*;
     let value = Variant(
         Box::new(IDLField {
-            id: 3_303_859,
+            id: Label::Id(3_303_859),
             val: Null,
         }),
         0,

--- a/candid_derive/Cargo.toml
+++ b/candid_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid_derive"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Macros implementation of #[derive(CandidType)] for the Candid."

--- a/candid_derive/Cargo.toml
+++ b/candid_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid_derive"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Macros implementation of #[derive(CandidType)] for the Candid."

--- a/candid_derive/src/lib.rs
+++ b/candid_derive/src/lib.rs
@@ -295,14 +295,15 @@ fn fields_from_ast(fields: &Punctuated<syn::Field, syn::Token![,]>) -> (Tokens, 
     assert_eq!(unique.len(), fs.len());
     fs.sort_unstable_by_key(|Field { hash, .. }| *hash);
 
-    let id = fs.iter().map(|Field { renamed_ident, .. }| {
-        let id_str = renamed_ident.to_string();
-        match renamed_ident {
-            // TODO
-            Ident::Named(_) => quote! { ::candid::types::Label::Named(#id_str.to_string()) },
+    let id = fs
+        .iter()
+        .map(|Field { renamed_ident, .. }| match renamed_ident {
+            Ident::Named(ref id) => {
+                let name = id.to_string();
+                quote! { ::candid::types::Label::Named(#name.to_string()) }
+            }
             Ident::Unnamed(ref i) => quote! { ::candid::types::Label::Id(#i) },
-        }
-    });
+        });
     let ty = fs.iter().map(|Field { ty, .. }| ty);
     let ty_gen = quote! {
         vec![


### PR DESCRIPTION
We have three different field label types in `parser::types::TypeField`, `parser::values::IDLField`, and `types::internal::Field`. This PR unifies all the `Field` types to use the same `Label` enum.

This refactor also fixes https://github.com/dfinity/candid/issues/48 to give better error messages.
Update the doc to address https://github.com/dfinity/candid/issues/49