### PR TITLE
New textual representation of Principals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "candid"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "base32",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
+name = "base32"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,9 +158,10 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 name = "candid"
 version = "0.4.2"
 dependencies = [
+ "base32",
  "byteorder",
  "candid_derive",
- "crc8",
+ "crc32fast",
  "goldenfile",
  "hex",
  "lalrpop",
@@ -203,10 +210,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
-name = "crc8"
-version = "0.1.1"
+name = "crc32fast"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31d2174830f395fd7e413c2f8a119252de36356982f805f495269331e97559e"
+checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-utils"

--- a/candid/Cargo.toml
+++ b/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."

--- a/candid/Cargo.toml
+++ b/candid/Cargo.toml
@@ -21,7 +21,9 @@ lalrpop = "0.19.0"
 [dependencies]
 leb128 = "0.2.4"
 serde = "1.0"
+base32 = "0.4.0"
 byteorder = "1.3"
+crc32fast = "1.2.0"
 paste = "0.1"
 num_enum = "0.4.3"
 num-bigint = "0.2"
@@ -30,7 +32,6 @@ candid_derive = { path = "../candid_derive", version = "=0.3.0" }
 lalrpop-util = "0.19.0"
 pretty = "0.10.0"
 hex = "0.3"
-crc8 = "0.1"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/candid/src/types/principal.rs
+++ b/candid/src/types/principal.rs
@@ -64,9 +64,6 @@ impl Principal {
         write!(string_format, "{}", s).unwrap();
         string_format
     }
-    pub fn as_bytes(&self) -> &[u8] {
-        self.0.as_slice()
-    }
 }
 
 impl fmt::Display for Principal {

--- a/candid/tests/serde.rs
+++ b/candid/tests/serde.rs
@@ -116,8 +116,8 @@ fn test_reserved() {
 fn test_principal() {
     use candid::Principal;
     all_check(
-        Principal::from_text("n7urw-bkejf-ceyaa-bnaaq-hsx75-y").unwrap(),
-        "4449444c000168010c4449444c0001680103caffee",
+        Principal::from_text("w7x7r-cok77-xa").unwrap(),
+        "4449444c0001680103caffee",
     );
 }
 

--- a/candid/tests/serde.rs
+++ b/candid/tests/serde.rs
@@ -116,8 +116,8 @@ fn test_reserved() {
 fn test_principal() {
     use candid::Principal;
     all_check(
-        Principal::from_text("ic:caffee59").unwrap(),
-        "4449444c0001680103caffee",
+        Principal::from_text("n7urw-bkejf-ceyaa-bnaaq-hsx75-y").unwrap(),
+        "4449444c000168010c4449444c0001680103caffee",
     );
 }
 

--- a/candid/tests/value.rs
+++ b/candid/tests/value.rs
@@ -18,7 +18,7 @@ fn test_parser() {
     parse_check(
         "(variant { cons=record{ 42; variant { cons=record{43; variant { nil=record{} }} } } })",
     );
-    parse_check("(principal \"n7urw-bkejf-ceyaa-bnaaq-hsx75-y\")");
+    parse_check("(principal \"w7x7r-cok77-xa\")");
 }
 
 #[test]

--- a/candid/tests/value.rs
+++ b/candid/tests/value.rs
@@ -18,7 +18,7 @@ fn test_parser() {
     parse_check(
         "(variant { cons=record{ 42; variant { cons=record{43; variant { nil=record{} }} } } })",
     );
-    parse_check("(principal \"ic:caffee59\")");
+    parse_check("(principal \"n7urw-bkejf-ceyaa-bnaaq-hsx75-y\")");
 }
 
 #[test]


### PR DESCRIPTION
**Overview**
The textual representation for Principals has changed from `ic:xxxx` to `xxxxx-xxx`


**Considerations**
This is a breaking change with regard to Principal textual format thus `from_text` and `to_text` will no longer work with the old format i.e `ic:xxxx`