### PR TITLE
fix: do not run build.rs everytime we build

### DIFF
--- a/candid/build.rs
+++ b/candid/build.rs
@@ -1,11 +1,13 @@
 fn main() {
+    // Make sure we only rerun the build script if we need to.
+    eprintln!("cargo:rerun-if-changed=src/parser/grammar.lalrpop");
+    eprintln!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/parser/grammar.lalrpop");
+    println!("cargo:rerun-if-changed=build.rs");
+
     lalrpop::Configuration::new()
         .use_cargo_dir_conventions()
         .emit_rerun_directives(true)
         .process_file("src/parser/grammar.lalrpop")
         .unwrap();
-
-    // Make sure we only rerun the build script if we need to.
-    eprintln!("cargo:rerun-if-changed=src/parser/grammar.lalrpop");
-    eprintln!("cargo:rerun-if-changed=build.rs");
 }

--- a/candid/build.rs
+++ b/candid/build.rs
@@ -6,6 +6,6 @@ fn main() {
         .unwrap();
 
     // Make sure we only rerun the build script if we need to.
-    println!("cargo:rerun-if-changed=src/parser/grammar.lalrpop");
-    println!("cargo:rerun-if-changed=build.rs");
+    eprintln!("cargo:rerun-if-changed=src/parser/grammar.lalrpop");
+    eprintln!("cargo:rerun-if-changed=build.rs");
 }

--- a/candid/build.rs
+++ b/candid/build.rs
@@ -4,4 +4,8 @@ fn main() {
         .emit_rerun_directives(true)
         .process_file("src/parser/grammar.lalrpop")
         .unwrap();
+
+    // Make sure we only rerun the build script if we need to.
+    println!("cargo:rerun-if-changed=src/parser/grammar.lalrpop");
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
This includes building crates that depend on candid.
