### PR TITLE
various small fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "candid"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base32",
  "byteorder",

--- a/candid/Cargo.toml
+++ b/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."

--- a/candid/src/bindings/candid.rs
+++ b/candid/src/bindings/candid.rs
@@ -18,6 +18,72 @@ fn is_tuple(t: &Type) -> bool {
     }
 }
 
+static KEYWORDS: [&str; 29] = [
+    "import",
+    "service",
+    "func",
+    "type",
+    "opt",
+    "vec",
+    "record",
+    "variant",
+    "blob",
+    "principal",
+    "nat",
+    "nat8",
+    "nat16",
+    "nat32",
+    "nat64",
+    "int",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "float32",
+    "float64",
+    "bool",
+    "text",
+    "null",
+    "reserved",
+    "empty",
+    "oneway",
+    "query",
+];
+
+fn is_keyword(id: &str) -> bool {
+    KEYWORDS.contains(&id)
+}
+
+fn is_valid_as_id(id: &str) -> bool {
+    if id.is_empty() || !id.is_ascii() {
+        return false;
+    }
+    for (i, c) in id.char_indices() {
+        if i == 0 {
+            if !c.is_ascii_alphabetic() && c != '_' {
+                return false;
+            }
+        } else if !c.is_ascii_alphanumeric() && c != '_' {
+            return false;
+        }
+    }
+    true
+}
+
+fn needs_quote(id: &str) -> bool {
+    !is_valid_as_id(id) || is_keyword(id)
+}
+
+fn pp_text(id: &str) -> RcDoc {
+    if needs_quote(id) {
+        str("\"")
+            .append(format!("{}", id.escape_debug()))
+            .append("\"")
+    } else {
+        str(id)
+    }
+}
+
 fn pp_ty(ty: &Type) -> RcDoc {
     use Type::*;
     match *ty {
@@ -59,9 +125,7 @@ fn pp_ty(ty: &Type) -> RcDoc {
 
 fn pp_label(id: &Label) -> RcDoc {
     match id {
-        Label::Named(id) => str("\"")
-            .append(format!("{}", id.escape_debug()))
-            .append("\""),
+        Label::Named(id) => pp_text(id),
         Label::Id(n) | Label::Unnamed(n) => RcDoc::as_string(n),
     }
 }
@@ -107,7 +171,7 @@ fn pp_service(serv: &[(String, Type)]) -> RcDoc {
                 Type::Var(_) => pp_ty(func),
                 _ => unreachable!(),
             };
-            doublequote_ident(id).append(kwd(":")).append(func_doc)
+            pp_text(id).append(kwd(" :")).append(func_doc)
         }),
         ";",
     );

--- a/candid/src/parser/lexer.rs
+++ b/candid/src/parser/lexer.rs
@@ -243,7 +243,7 @@ impl<'input> Iterator for Lexer<'input> {
                     Some(Ok((i, Token::Number(res), i + len)))
                 }
             }
-            Some((i, c)) if c.is_ascii_alphabetic() => {
+            Some((i, c)) if c.is_ascii_alphabetic() || c == '_' => {
                 // Parse keywords and identifiers
                 let mut res = c.to_string();
                 while let Some((_, c)) = self.peek() {

--- a/candid/src/pretty.rs
+++ b/candid/src/pretty.rs
@@ -87,10 +87,3 @@ pub fn quote_ident(id: &str) -> RcDoc {
         .append("'")
         .append(RcDoc::space())
 }
-
-pub fn doublequote_ident(id: &str) -> RcDoc {
-    str("\"")
-        .append(format!("{}", id.escape_debug()))
-        .append("\"")
-        .append(RcDoc::space())
-}

--- a/candid/src/types/principal.rs
+++ b/candid/src/types/principal.rs
@@ -12,7 +12,7 @@ impl Principal {
     pub fn from_text<S: std::string::ToString + AsRef<[u8]>>(text: S) -> crate::Result<Self> {
         let mut s = text.to_string();
         s.make_ascii_lowercase();
-        s.retain(|c| c.is_ascii_alphanumeric());
+        s.retain(|c| c != '-');
         match base32::decode(base32::Alphabet::RFC4648 { padding: false }, &s) {
             Some(mut bytes) => {
                 if bytes.len() < 4 {

--- a/candid/tests/assets/fieldnat.did
+++ b/candid/tests/assets/fieldnat.did
@@ -1,8 +1,8 @@
 service Foo: 
 {
-  foo : (record {2 : int}) -> ();
+  foo : (record {2 : int}) -> (record { 2 : int; _2 : int});
   bar : (record {"2" : int}) -> ();
-  baz : (record {2: int; "2": nat}) -> (record {});
+  baz : (record {2_: int; "2": nat}) -> (record {});
   bab : (two: int, "2": nat) -> ();
   bas : (record { int; int }) -> (record {1:nat; 0:text});
   bib : (record { int }) -> (variant { 0:int });

--- a/candid/tests/assets/ok/actor.did
+++ b/candid/tests/assets/ok/actor.did
@@ -2,4 +2,4 @@ type f = func (int8) -> (int8);
 type g = f;
 type h = func (f) -> (f);
 type o = opt o;
-service : { "f" : (nat) -> (h); "g" : f; "h" : g; "o" : (o) -> (o) }
+service : { f : (nat) -> (h); g : f; h : g; o : (o) -> (o) }

--- a/candid/tests/assets/ok/cyclic.did
+++ b/candid/tests/assets/ok/cyclic.did
@@ -4,4 +4,4 @@ type C = A;
 type X = Y;
 type Y = Z;
 type Z = A;
-service : { "f" : (A, B, C, X, Y, Z) -> () }
+service : { f : (A, B, C, X, Y, Z) -> () }

--- a/candid/tests/assets/ok/example.did
+++ b/candid/tests/assets/ok/example.did
@@ -1,6 +1,6 @@
-type List = opt record { "head" : int; "tail" : List };
+type List = opt record { head : int; tail : List };
 type broker = service {
-  "find" : (text) -> (service { "up" : () -> (); "current" : () -> (nat32) });
+  find : (text) -> (service { up : () -> (); current : () -> (nat32) });
 };
 type f = func (List, func (int32) -> (int64)) -> (opt List);
 type my_type = principal;
@@ -10,14 +10,14 @@ type nested = record {
   2 : record { nat; int };
   3 : record { 0 : nat; 42 : nat; 43 : nat8 };
   40 : nat;
-  41 : variant { 42; "A"; "B"; "C" };
+  41 : variant { 42; A; B; C };
   42 : nat;
 };
 service : {
-  "f" : (vec nat8, opt bool) -> () oneway;
-  "g" : (my_type, List, opt List, nested) -> (int, broker) query;
-  "h" : (vec opt text, variant { "A" : nat; "B" : opt text }, opt List) -> (
-      record { 42 : record {}; "id" : nat },
+  f : (vec nat8, opt bool) -> () oneway;
+  g : (my_type, List, opt List, nested) -> (int, broker) query;
+  h : (vec opt text, variant { A : nat; B : opt text }, opt List) -> (
+      record { 42 : record {}; id : nat },
     );
-  "i" : f;
+  i : f;
 }

--- a/candid/tests/assets/ok/fieldnat.did
+++ b/candid/tests/assets/ok/fieldnat.did
@@ -4,5 +4,5 @@ service : {
   "bas" : (record { int; int }) -> (record { text; nat });
   "baz" : (record { 2 : int; "2" : nat }) -> (record {});
   "bib" : (record { int }) -> (variant { 0 : int });
-  "foo" : (record { 2 : int }) -> ();
+  "foo" : (record { 2 : int }) -> (record { 2 : int; "_2" : int });
 }

--- a/candid/tests/assets/ok/fieldnat.did
+++ b/candid/tests/assets/ok/fieldnat.did
@@ -1,8 +1,8 @@
 service : {
-  "bab" : (int, nat) -> ();
-  "bar" : (record { "2" : int }) -> ();
-  "bas" : (record { int; int }) -> (record { text; nat });
-  "baz" : (record { 2 : int; "2" : nat }) -> (record {});
-  "bib" : (record { int }) -> (variant { 0 : int });
-  "foo" : (record { 2 : int }) -> (record { 2 : int; "_2" : int });
+  bab : (int, nat) -> ();
+  bar : (record { "2" : int }) -> ();
+  bas : (record { int; int }) -> (record { text; nat });
+  baz : (record { 2 : int; "2" : nat }) -> (record {});
+  bib : (record { int }) -> (variant { 0 : int });
+  foo : (record { 2 : int }) -> (record { 2 : int; _2 : int });
 }

--- a/candid/tests/assets/ok/fieldnat.js
+++ b/candid/tests/assets/ok/fieldnat.js
@@ -17,6 +17,10 @@ export default ({ IDL }) => {
         [IDL.Variant({ _0_ : IDL.Int })],
         [],
       ),
-    'foo' : IDL.Func([IDL.Record({ _2_ : IDL.Int })], [], []),
+    'foo' : IDL.Func(
+        [IDL.Record({ _2_ : IDL.Int })],
+        [IDL.Record({ _2_ : IDL.Int, '_2' : IDL.Int })],
+        [],
+      ),
   });
 };

--- a/candid/tests/assets/ok/recursion.did
+++ b/candid/tests/assets/ok/recursion.did
@@ -1,12 +1,12 @@
 type A = B;
 type B = opt A;
 type list = opt node;
-type node = record { "head" : nat; "tail" : list };
-type s = service { "f" : t; "g" : (list) -> (B, tree, stream) };
-type stream = opt record { "head" : nat; "next" : func () -> (stream) query };
+type node = record { head : nat; tail : list };
+type s = service { f : t; g : (list) -> (B, tree, stream) };
+type stream = opt record { head : nat; next : func () -> (stream) query };
 type t = func (s) -> ();
 type tree = variant {
-  "branch" : record { "val" : int; "left" : tree; "right" : tree };
-  "leaf" : int;
+  branch : record { val : int; left : tree; right : tree };
+  leaf : int;
 };
 service : s

--- a/candid/tests/parse_type.rs
+++ b/candid/tests/parse_type.rs
@@ -52,6 +52,9 @@ fn compiler_test(resource: &str) {
             {
                 let mut output = mint.new_goldenfile(filename.with_extension("did")).unwrap();
                 let content = candid_export::compile(&env, &actor);
+                // Type check output
+                let ast = content.parse::<IDLProg>().unwrap();
+                check_prog(&mut TypeEnv::new(), &ast).unwrap();
                 writeln!(output, "{}", content).unwrap();
             }
             {


### PR DESCRIPTION
* allow `_` prefix for identifier
* fix principal text format
* candid pretty printer: only quote field names when necessary