### PR TITLE
[Spec] Relax LEB128 decoding

### DIFF
--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -814,7 +814,7 @@ The following notation is used:
 * `.` is the empty byte sequence
 * `x1 x2` is concatenation
 * `t^N`, `t+`, `t*`, `t?` are sequences of `N`, `N>0`, `N>=0`, or `N<=1` repetitions, respectively
-* `leb128` and `sleb128` are the shortest unsigned and signed [LEB128](https://en.wikipedia.org/wiki/LEB128) encodings of a number, respectively
+* `leb128` and `sleb128` are the unsigned and signed [LEB128](https://en.wikipedia.org/wiki/LEB128) encodings of a number, respectively
 * `utf8` is the UTF-8 encoding of a text string (not 0-terminated)
 
 

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -15,7 +15,6 @@ exchange (names, parameter and result formats of service methods)
 * Simple and canonical constructs (C-like; algebraically: sums, products, exponentials)
 * Extensible, backwards-compatible
 * Well-formedness is checkable and guaranteed by the platform
-* Deterministic mapping to serialised representation
 * Human-readable and machine-readable
 * Declarative, usable as input to binding code generators
 

--- a/test/prim.test.did
+++ b/test/prim.test.did
@@ -7,8 +7,8 @@ assert blob ""              !: () "empty";
 assert blob "\00\00"        !: () "no magic bytes";
 assert blob "DADL"          !: () "wrong magic bytes";
 assert blob "DADL\00\00"    !: () "wrong magic bytes";
-assert blob "DIDL\80\00\00" !: () "overlong typ table length";
-assert blob "DIDL\00\80\00" !: () "overlong arg length";
+assert blob "DIDL\80\00\00" : () "overlong typ table length";
+assert blob "DIDL\00\80\00" : () "overlong arg length";
 
 // nullary input
 assert blob "DIDL\00\00"     : ();
@@ -32,8 +32,8 @@ assert blob "DIDL\00\01\7d\7f" == "(127)"       : (nat) "nat: 0x7f";
 assert blob "DIDL\00\01\7d\80\01"  == "(128)"   : (nat) "nat: leb (two bytes)";
 assert blob "DIDL\00\01\7d\ff\7f"  == "(16383)" : (nat) "nat: leb (two bytes, all bits)";
 assert blob "DIDL\00\01\7d\80"                 !: (nat) "nat: leb too short";
-assert blob "DIDL\00\01\7d\80\00"              !: (nat) "nat: leb overlong";
-assert blob "DIDL\00\01\7d\ff\00"              !: (nat) "nat: leb overlong";
+assert blob "DIDL\00\01\7d\80\00" == "(0)"      : (nat) "nat: leb overlong";
+assert blob "DIDL\00\01\7d\ff\00" == "(1)"      : (nat) "nat: leb overlong";
 
 assert blob "DIDL\00\01\7c\00" == "(0)"         : (int) "int: 0";
 assert blob "DIDL\00\01\7c\01" == "(1)"         : (int) "int: 1";
@@ -41,8 +41,8 @@ assert blob "DIDL\00\01\7c\7f" == "(-1)"        : (int) "int: -1";
 assert blob "DIDL\00\01\7c\40" == "(-64)"       : (int) "int: -64";
 assert blob "DIDL\00\01\7c\80\01"  == "(128)"   : (int) "int: leb (two bytes)";
 assert blob "DIDL\00\01\7c\80"                 !: (int) "int: leb too short";
-assert blob "DIDL\00\01\7c\80\00"              !: (int) "int: leb overlong (0s)";
-assert blob "DIDL\00\01\7c\ff\7f"              !: (int) "int: leb overlong (1s)";
+assert blob "DIDL\00\01\7c\80\00" == "(0)"      : (int) "int: leb overlong (0s)";
+assert blob "DIDL\00\01\7c\ff\7f" == "(1)"      : (int) "int: leb overlong (1s)";
 assert blob "DIDL\00\01\7c\ff\00" == "(127)"    : (int) "int: leb not overlong when signed";
 assert blob "DIDL\00\01\7c\80\7f" == "(-128)"   : (int) "int: leb not overlong when signed";
 
@@ -134,7 +134,7 @@ assert blob "DIDL\00\01\71\00" == "(\"\")"             : (text) "text: empty str
 assert blob "DIDL\00\01\71\06Motoko" == "(\"Motoko\")" : (text) "text: Motoko";
 assert blob "DIDL\00\01\71\05Motoko"                  !: (text) "text: too long";
 assert blob "DIDL\00\01\71\07Motoko"                  !: (text) "text: too short";
-assert blob "DIDL\00\01\71\86\00Motoko"               !: (text) "text: too overlong length leb";
+assert blob "DIDL\00\01\71\86\00Motoko"                : (text) "text: overlong length leb";
 assert blob "DIDL\00\01\71\03\e2\98\83" == "(\"☃\")"   : (text) "text: Unicode";
 assert "(\"\\u{2603}\")" == "(\"☃\")"                  : (text) "text: Unicode escape";
 assert "(\"\\u{2603\")"                               !: (text) "text: Unicode escape (unclosed)";


### PR DESCRIPTION
As discussed in https://github.com/dfinity/candid/pull/73#discussion_r468460144, LEB128 spec allows redundant bytes, and all existing libraries on LEB128 decodes redundant bytes properly.  Removing the restriction encourages code reuse and an easier implementation.