### PR TITLE
test suite for JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ A list of community maintained Candid libraries:
 * [didc](tools/didc): Candid CLI
 * [candiff](tools/candiff): Diff Candid values structurally
 
+## Tests
+
+We provide a [test suite](test/) to check Candid implementations for compliance.
+
 ## Contribution
 
 The Internet Computer is a new technology stack that is unhackable, fast, scales to billions of users around the world, and supports a new kind of autonomous software that promises to reverse Big Tech’s monopolization of the internet. It allows developers to take on the monopolization of the internet, and return the internet back to its free and open roots. We're committed to connecting those who believe the same through our events, content, and discussions.

--- a/rust/candid/src/bindings/analysis.rs
+++ b/rust/candid/src/bindings/analysis.rs
@@ -2,47 +2,49 @@ use crate::parser::typing::TypeEnv;
 use crate::types::Type;
 use std::collections::BTreeSet;
 
+/// Same as chase_actor, with seen set as part of the type. Used for chasing type names from type definitions.
+pub fn chase_type<'a>(
+    seen: &mut BTreeSet<&'a str>,
+    res: &mut Vec<&'a str>,
+    env: &'a TypeEnv,
+    t: &'a Type,
+) -> crate::Result<()> {
+    use Type::*;
+    match t {
+        Var(id) => {
+            if seen.insert(id) {
+                let t = env.find_type(id)?;
+                chase_type(seen, res, env, t)?;
+                res.push(id);
+            }
+        }
+        Opt(ty) | Vec(ty) => chase_type(seen, res, env, ty)?,
+        Record(fs) | Variant(fs) => {
+            for f in fs.iter() {
+                chase_type(seen, res, env, &f.ty)?;
+            }
+        }
+        Func(f) => {
+            for ty in f.args.iter().chain(f.rets.iter()) {
+                chase_type(seen, res, env, ty)?;
+            }
+        }
+        Service(ms) => {
+            for (_, ty) in ms.iter() {
+                chase_type(seen, res, env, ty)?;
+            }
+        }
+        _ => (),
+    }
+    Ok(())
+}
+
 /// Gather type definitions mentioned in actor, return the non-recursive type names in topological order.
 /// Recursive types can appear in any order.
 pub fn chase_actor<'a>(env: &'a TypeEnv, actor: &'a Type) -> crate::Result<Vec<&'a str>> {
     let mut seen = BTreeSet::new();
     let mut res = Vec::new();
-    fn chase<'a>(
-        seen: &mut BTreeSet<&'a str>,
-        res: &mut Vec<&'a str>,
-        env: &'a TypeEnv,
-        t: &'a Type,
-    ) -> crate::Result<()> {
-        use Type::*;
-        match t {
-            Var(id) => {
-                if seen.insert(id) {
-                    let t = env.find_type(id)?;
-                    chase(seen, res, env, t)?;
-                    res.push(id);
-                }
-            }
-            Opt(ty) | Vec(ty) => chase(seen, res, env, ty)?,
-            Record(fs) | Variant(fs) => {
-                for f in fs.iter() {
-                    chase(seen, res, env, &f.ty)?;
-                }
-            }
-            Func(f) => {
-                for ty in f.args.iter().chain(f.rets.iter()) {
-                    chase(seen, res, env, ty)?;
-                }
-            }
-            Service(ms) => {
-                for (_, ty) in ms.iter() {
-                    chase(seen, res, env, ty)?;
-                }
-            }
-            _ => (),
-        }
-        Ok(())
-    }
-    chase(&mut seen, &mut res, env, actor)?;
+    chase_type(&mut seen, &mut res, env, actor)?;
     Ok(res)
 }
 

--- a/rust/candid/src/parser/test.rs
+++ b/rust/candid/src/parser/test.rs
@@ -93,6 +93,7 @@ impl HostTest {
                 } else {
                     let bytes = parsed.to_bytes_with_types(env, &types).unwrap();
                     asserts.push(Encode(parsed.clone(), types.clone(), true, bytes.clone()));
+                    // round tripping
                     let vals = parsed.annotate_types(env, &types).unwrap();
                     asserts.push(Decode(bytes, types, true, vals));
                 }
@@ -105,7 +106,9 @@ impl HostTest {
                     asserts.push(NotDecode(bytes, types));
                 } else {
                     let args = IDLArgs::from_bytes_with_types(&bytes, env, &types).unwrap();
-                    asserts.push(Decode(bytes.clone(), types.clone(), true, args));
+                    asserts.push(Decode(bytes.clone(), types.clone(), true, args.clone()));
+                    // round tripping
+                    asserts.push(Encode(args, types.clone(), true, bytes.clone()));
                     if let Some(right) = &assert.right {
                         let expected = right.parse(env, &types).unwrap();
                         if let Input::Blob(blob) = right {

--- a/rust/candid/src/parser/test.rs
+++ b/rust/candid/src/parser/test.rs
@@ -20,6 +20,16 @@ pub struct Assert {
     pub desc: Option<String>,
 }
 
+impl Assert {
+    pub fn desc(&self) -> String {
+        match &self.desc {
+            None => "",
+            Some(desc) => desc,
+        }
+        .to_string()
+    }
+}
+
 #[derive(Debug)]
 pub enum Input {
     Text(String),
@@ -27,7 +37,7 @@ pub enum Input {
 }
 
 impl Input {
-    fn parse(&self, env: &TypeEnv, types: &[Type]) -> Result<IDLArgs> {
+    pub fn parse(&self, env: &TypeEnv, types: &[Type]) -> Result<IDLArgs> {
         match self {
             Input::Text(ref s) => s.parse::<IDLArgs>()?.annotate_types(env, types),
             Input::Blob(ref bytes) => Ok(IDLArgs::from_bytes_with_types(bytes, env, types)?),
@@ -61,7 +71,7 @@ pub fn check(test: Test) -> Result<()> {
     check_prog(&mut env, &prog)?;
     let mut count = 0;
     for (i, assert) in test.asserts.iter().enumerate() {
-        print!("Checking {}:{:?}...", i + 1, assert.desc);
+        print!("Checking {} {}...", i + 1, assert.desc());
         let mut types = Vec::new();
         for ty in assert.typ.iter() {
             types.push(env.ast_to_type(ty)?);

--- a/rust/candid/src/parser/value.rs
+++ b/rust/candid/src/parser/value.rs
@@ -353,17 +353,17 @@ pub mod pretty {
 
     pub use crate::bindings::candid::pp_label;
 
-    pub fn pp_idl_field(field: &IDLField) -> RcDoc {
+    fn pp_idl_field(field: &IDLField) -> RcDoc {
         pp_label(&field.id)
             .append(kwd(" ="))
             .append(pp_value(&field.val))
     }
 
-    pub fn pp_idl_fields(fields: &[IDLField]) -> RcDoc {
+    fn pp_record_fields(fields: &[IDLField]) -> RcDoc {
         concat(fields.iter().map(|f| pp_idl_field(f)), ";")
     }
 
-    pub fn pp_variant_field(field: &IDLField) -> RcDoc {
+    fn pp_variant_field(field: &IDLField) -> RcDoc {
         pp_label(&field.id)
             .append(kwd(" ="))
             .append(pp_value(&field.val))
@@ -372,42 +372,22 @@ pub mod pretty {
     pub fn pp_value(v: &IDLValue) -> RcDoc {
         use super::IDLValue::*;
         match &*v {
-            Bool(b) => RcDoc::as_string(b),
-            Null => str("null"),
-            None => str("none"),
-            Int(i) => RcDoc::as_string(i),
-            Nat(n) => RcDoc::as_string(n),
-            Nat8(n) => RcDoc::as_string(n),
-            Nat16(n) => RcDoc::as_string(n),
-            Nat32(n) => RcDoc::as_string(n),
-            Nat64(n) => RcDoc::as_string(n),
-            Int8(i) => RcDoc::as_string(i),
-            Int16(i) => RcDoc::as_string(i),
-            Int32(i) => RcDoc::as_string(i),
-            Int64(i) => RcDoc::as_string(i),
-            Float32(f) => RcDoc::as_string(f), // todo
-            Float64(f) => RcDoc::as_string(f),
-            Number(t) => str(t),
-            Text(t) => RcDoc::as_string(format!("{:?}", t)), // to do -- enough quoting here?
             Opt(v) => kwd("opt").append(enclose_space("{", pp_value(v), "}")),
             Vec(vs) => {
-                let mut body = RcDoc::nil();
-                let mut is_first = true;
-                for v in vs.iter() {
-                    if is_first {
-                        is_first = false;
-                    } else {
-                        body = body.append(RcDoc::space())
-                    }
-                    body = body.append(pp_value(v).append(RcDoc::text(";")))
-                }
+                let body = concat(vs.iter().map(|v| pp_value(v)), ";");
                 kwd("vec").append(enclose_space("{", body, "}"))
             }
-            Record(fields) => kwd("record").append(enclose_space("{", pp_idl_fields(&fields), "}")),
+            Record(fields) => {
+                kwd("record").append(enclose_space("{", pp_record_fields(&fields), "}"))
+            }
             Variant(v, _) => kwd("variant").append(enclose_space("{", pp_variant_field(&v), "}")),
-            // to do -- the other cases
-            _ => unimplemented!("{:?}", v),
+            _ => RcDoc::as_string(v),
         }
+    }
+
+    pub fn pp_args(args: &IDLArgs) -> RcDoc {
+        let body = concat(args.args.iter().map(pp_value), ",");
+        enclose("(", body, ")")
     }
 }
 

--- a/rust/candid/src/parser/value.rs
+++ b/rust/candid/src/parser/value.rs
@@ -353,20 +353,14 @@ pub mod pretty {
 
     pub use crate::bindings::candid::pp_label;
 
-    fn pp_idl_field(field: &IDLField) -> RcDoc {
+    fn pp_field(field: &IDLField) -> RcDoc {
         pp_label(&field.id)
             .append(kwd(" ="))
             .append(pp_value(&field.val))
     }
 
-    fn pp_record_fields(fields: &[IDLField]) -> RcDoc {
-        concat(fields.iter().map(|f| pp_idl_field(f)), ";")
-    }
-
-    fn pp_variant_field(field: &IDLField) -> RcDoc {
-        pp_label(&field.id)
-            .append(kwd(" ="))
-            .append(pp_value(&field.val))
+    fn pp_fields(fields: &[IDLField]) -> RcDoc {
+        concat(fields.iter().map(|f| pp_field(f)), ";")
     }
 
     pub fn pp_value(v: &IDLValue) -> RcDoc {
@@ -377,10 +371,8 @@ pub mod pretty {
                 let body = concat(vs.iter().map(|v| pp_value(v)), ";");
                 kwd("vec").append(enclose_space("{", body, "}"))
             }
-            Record(fields) => {
-                kwd("record").append(enclose_space("{", pp_record_fields(&fields), "}"))
-            }
-            Variant(v, _) => kwd("variant").append(enclose_space("{", pp_variant_field(&v), "}")),
+            Record(fields) => kwd("record").append(enclose_space("{", pp_fields(&fields), "}")),
+            Variant(v, _) => kwd("variant").append(enclose_space("{", pp_field(&v), "}")),
             _ => RcDoc::as_string(v),
         }
     }

--- a/rust/candid/tests/test_suite.rs
+++ b/rust/candid/tests/test_suite.rs
@@ -10,3 +10,15 @@ fn decode_test(resource: &str) {
     let ast = test.parse::<Test>().unwrap();
     check(ast).unwrap();
 }
+
+#[test_generator::test_resources("test/*.test.did")]
+fn js_test(resource: &str) {
+    use candid::bindings::javascript::test_generate;
+    let path = std::env::current_dir()
+        .unwrap()
+        .join("../../")
+        .join(resource);
+    let test = std::fs::read_to_string(path).unwrap();
+    let ast = test.parse::<Test>().unwrap();
+    println!("{}", test_generate(ast));
+}

--- a/rust/candid/tests/test_suite.rs
+++ b/rust/candid/tests/test_suite.rs
@@ -13,7 +13,7 @@ fn decode_test(resource: &str) {
 
 #[test_generator::test_resources("test/*.test.did")]
 fn js_test(resource: &str) {
-    use candid::bindings::javascript::test_generate;
+    use candid::bindings::javascript::test::test_generate;
     let path = std::env::current_dir()
         .unwrap()
         .join("../../")

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -136,7 +136,7 @@ fn main() -> Result<(), ExitFailure> {
                 .map_err(|_| Error::msg(format!("could not read file {}", input.display())))?;
             let ast = test.parse::<candid::parser::test::Test>()?;
             let content = match target.as_str() {
-                "js" => candid::bindings::javascript::test_generate(ast),
+                "js" => candid::bindings::javascript::test::test_generate(ast),
                 "did" => {
                     candid::parser::test::check(ast)?;
                     "".to_string()


### PR DESCRIPTION
We add round tripping in the JS test generation, which may not work well with subtyping. Will revisit when we have more tests.

```
assert blob "DIDL\00\01\7e\ff"             !: (bool) "bool: out of range";
assert blob "DIDL\00\01\7d\00" == "(0)"         : (nat) "nat: 0";
```

```
test('17 bool: out of range', () => {
  expect(
    () => IDL.decode([IDL.Bool], Buffer.from('4449444c00017eff', 'hex'))
  ).toThrow();
});
test('18 nat: 0', () => {
  expect(IDL.decode([IDL.Nat], Buffer.from('4449444c00017d00', 'hex'))).toEqual(
    [new BigNumber('0')]
  );
  expect(
    IDL.decode([IDL.Nat], IDL.encode([IDL.Nat], [new BigNumber('0')]))
  ).toEqual(IDL.decode([IDL.Nat], Buffer.from('4449444c00017d00', 'hex')));
});
```