### PR TITLE
Fix: candiff accepts unary tuples as default

### DIFF
--- a/tools/candiff/src/lib.rs
+++ b/tools/candiff/src/lib.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 
 pub use ::candid::parser::value::IDLField as Field;
 pub use ::candid::parser::value::IDLValue as Value;
+pub use ::candid::parser::value::IDLArgs as ArgTuple;
 
 pub use ::candid::types::{Field as TypeField, Label, Type};
 pub use ::candid::Nat;


### PR DESCRIPTION
The candid values saved by`dfx` via `didc` were not accepted by `candiff` to diff, because of some mismatch of input being a tuple versus a (bare) un-tupled value.

This PR fixes this issue by changing the default behavior:
 - introduces an unimplemented flag for accepted bare values (the old default).
 - the new default matches what `didc` produces.

We can implement the old behavior when it blocks something.  The missing code path traps as `unimplemented`.

