### PR TITLE
refactor error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,6 @@ dependencies = [
  "candid",
  "candiff",
  "clap",
- "codespan-reporting",
  "hex",
  "pretty-hex",
  "structopt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
  "base32",
  "byteorder",
  "candid_derive",
+ "codespan-reporting",
  "crc32fast",
  "goldenfile",
  "hex",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -31,6 +31,7 @@ num-traits = "0.2.12"
 candid_derive = { path = "../candid_derive", version = "=0.4.0" }
 lalrpop-util = "0.19.0"
 logos = "0.11.4"
+codespan-reporting = "0.9.5"
 pretty = "0.10.0"
 hex = "0.4.2"
 

--- a/rust/candid/src/error.rs
+++ b/rust/candid/src/error.rs
@@ -26,7 +26,7 @@ impl Error {
         match self {
             Error::Parse(e) => {
                 use lalrpop_util::ParseError::*;
-                let diag = Diagnostic::error().with_message("parser error");
+                let mut diag = Diagnostic::error().with_message("parser error");
                 let mut labels = Vec::new();
                 let msg = format!("{}", e);
                 match e {
@@ -42,8 +42,12 @@ impl Error {
                     } => {
                         labels.push(Label::primary((), *location..location + 1).with_message(msg));
                     }
-                    UnrecognizedToken { token, expected: _ } => {
-                        labels.push(Label::primary((), token.0..token.2).with_message(msg))
+                    UnrecognizedToken { token, expected } => {
+                        let msg = format!("Unrecognized token {:?}", token.1);
+                        let mut expects = vec!["expect one of".to_owned()];
+                        expects.extend_from_slice(expected);
+                        labels.push(Label::primary((), token.0..token.2).with_message(msg));
+                        diag = diag.with_notes(expects);
                     }
                     ExtraToken { token } => {
                         labels.push(Label::primary((), token.0..token.2).with_message(msg))

--- a/rust/candid/src/lib.rs
+++ b/rust/candid/src/lib.rs
@@ -228,7 +228,7 @@ pub use codegen::generate_code;
 pub mod bindings;
 
 pub mod error;
-pub use error::{Error, Result};
+pub use error::{pretty_parse, Error, Result};
 
 pub mod types;
 pub use types::CandidType;

--- a/rust/candid/src/parser/token.rs
+++ b/rust/candid/src/parser/token.rs
@@ -194,7 +194,10 @@ impl<'input> Iterator for Tokenizer<'input> {
                         }
                         Some(Comment::Start) => nesting += 1,
                         None => {
-                            return Some(Err(LexicalError::new("Unclosed comment", lex.span())))
+                            return Some(Err(LexicalError::new(
+                                "Unclosed comment",
+                                span.start..lex.span().end,
+                            )))
                         }
                     }
                 }
@@ -265,7 +268,12 @@ impl<'input> Iterator for Tokenizer<'input> {
                                 lex.span(),
                             )))
                         }
-                        None => return Some(Err(LexicalError::new("Unclosed string", lex.span()))),
+                        None => {
+                            return Some(Err(LexicalError::new(
+                                "Unclosed string",
+                                span.start..lex.span().end,
+                            )))
+                        }
                     }
                 }
                 self.lex = lex.morph::<Token>();

--- a/rust/candid/tests/assets/bad_comment.did
+++ b/rust/candid/tests/assets/bad_comment.did
@@ -3,8 +3,7 @@
 jgfkg
 */
 type id/**/ =/* gfj
-*/ nat8;
-/*
+*/ nat8;/*
 fgjgf
 /*
 */

--- a/rust/candid/tests/assets/ok/bad_comment.fail
+++ b/rust/candid/tests/assets/ok/bad_comment.fail
@@ -1,1 +1,1 @@
-Candid parser error: Unclosed comment at 76..76
+Candid parser error: Unclosed comment at 62..76

--- a/rust/candid/tests/assets/ok/bad_comment.fail
+++ b/rust/candid/tests/assets/ok/bad_comment.fail
@@ -1,1 +1,1 @@
-Candid parser error: Unclosed comment at 62..76
+Candid parser error: Unclosed comment at 61..75

--- a/tools/didc/Cargo.toml
+++ b/tools/didc/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 candid = { path = "../../rust/candid" }
 candiff = { path = "../candiff" }
 clap = "2.33.3"
-codespan-reporting = "0.9.5"
 structopt = "0.3.16"
 pretty-hex = "0.1.1"
 hex = "0.4.2"

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -118,8 +118,7 @@ fn parse_args(str: &str) -> Result<IDLArgs, Error> {
             let writer = StandardStream::stderr(term::termcolor::ColorChoice::Auto);
             let config = term::Config::default();
             let file = SimpleFile::new("candid arguments", str);
-            let diag = as_diagnostic(e);
-            term::emit(&mut writer.lock(), &config, &file, &diag)?;
+            term::emit(&mut writer.lock(), &config, &file, &e.report())?;
             std::process::exit(1);
         }
     }
@@ -130,19 +129,6 @@ fn check_file(env: &mut TypeEnv, file: &Path) -> candid::Result<Option<Type>> {
         .map_err(|_| Error::msg(format!("could not read file {}", file.display())))?;
     let ast = prog.parse::<IDLProg>()?;
     check_prog(env, &ast)
-}
-
-use codespan_reporting::diagnostic::{Diagnostic, Label};
-fn as_diagnostic(err: candid::Error) -> Diagnostic<()> {
-    if err.span.start == 0 && err.span.end == 0 {
-        Diagnostic::error().with_message(err.message)
-    } else {
-        Diagnostic::error()
-            .with_message("Syntax error")
-            .with_labels(vec![
-                Label::primary((), err.span.clone()).with_message(err.message)
-            ])
-    }
 }
 
 fn main() -> Result<()> {
@@ -157,8 +143,7 @@ fn main() -> Result<()> {
                 Err(e) => {
                     let file =
                         SimpleFile::new(input.to_str().unwrap(), std::fs::read_to_string(&input)?);
-                    let diag = as_diagnostic(e);
-                    term::emit(&mut writer.lock(), &config, &file, &diag)?;
+                    term::emit(&mut writer.lock(), &config, &file, &e.report())?;
                 }
             }
         }


### PR DESCRIPTION
* `report` function to convert `Error` to `Diagnostic`
* `pretty_parse` to report Rust-like error messages from parser