### PR TITLE
release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "candid"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "byteorder",
  "candid_derive",

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,14 +3,14 @@
 
 ## 2020-09-02
 
-### Rust (0.5.4)
+### Rust (0.6.0)
 
+* Use `ic-types` for Principal (breaking change)
 * Support type annotations in parsing Candid values
 * Support float e notation
 * Support nested comments
 * Pretty print decoded candid values
 * New lexer using the `logos` crate
-* Use `ic-types` for Principal
 * Use `codespan-reporting` to report Rust-like parsing errors
 
 ## 2020-08-24

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."


### PR DESCRIPTION
Release 0.6.0 and yank 0.5.4, as the use of `ic-types` is a breaking change