### PR TITLE
Add generic functions to encode/decode around a tuple

### DIFF
--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -1,5 +1,3 @@
-#![allow(unused_attributes)]
-#![rustfmt::skip::macros(decode_impl)]
 //! Deserialize Candid binary format to Rust data structures
 
 use super::error::{Error, Result};
@@ -887,15 +885,98 @@ decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G);
 decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H);
 decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I);
 decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J);
-decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K);
-decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L);
-decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M);
-decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N);
 decode_impl!(
-    a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K
 );
 decode_impl!(
-    a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L
+);
+decode_impl!(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M
+);
+decode_impl!(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N
+);
+decode_impl!(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O
+);
+decode_impl!(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P
 );
 
 /// Decode a series of arguments, represented as a tuple. There is a maximum of 16 arguments

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -1,3 +1,5 @@
+#![allow(unused_attributes)]
+#![rustfmt::skip::macros(decode_impl)]
 //! Deserialize Candid binary format to Rust data structures
 
 use super::error::{Error, Result};
@@ -5,7 +7,7 @@ use super::types::internal::Opcode;
 use super::{idl_hash, Int, Nat};
 use byteorder::{LittleEndian, ReadBytesExt};
 use leb128::read::{signed as sleb128_decode, unsigned as leb128_decode};
-use serde::de::{self, Visitor};
+use serde::de::{self, Deserialize, Visitor};
 use std::collections::{BTreeMap, VecDeque};
 use std::convert::TryFrom;
 use std::io::Read;
@@ -842,4 +844,102 @@ impl<'de, 'a> de::VariantAccess<'de> for Compound<'a, 'de> {
             de::Deserializer::deserialize_struct(self.de, "_", fields, visitor)
         }
     }
+}
+
+/// Allow decoding of any sized argument.
+pub trait ArgumentDecoder<'a>: Sized {
+    /// Decodes a value of type [Self], modifying the deserializer (values are consumed).
+    fn decode(de: &mut IDLDeserialize<'a>) -> Result<Self>;
+}
+
+/// Decode an empty tuple.
+impl<'a> ArgumentDecoder<'a> for () {
+    fn decode(_de: &mut IDLDeserialize<'a>) -> Result<()> {
+        Ok(())
+    }
+}
+
+// Create implementation of [ArgumentDecoder] for up to 16 value tuples.
+macro_rules! decode_impl {
+    ( $($id: ident : $typename: ident),* ) => {
+        impl<'a, $( $typename ),*> ArgumentDecoder<'a> for ($($typename,)*)
+        where
+            $( $typename: Deserialize<'a> ),*
+        {
+            fn decode(de: &mut IDLDeserialize<'a>) -> Result<Self> {
+                $(
+                let $id: $typename = de.get_value()?;
+                )*
+
+                Ok(($( $id, )*))
+            }
+        }
+    }
+}
+
+decode_impl!(a: A);
+decode_impl!(a: A, b: B);
+decode_impl!(a: A, b: B, c: C);
+decode_impl!(a: A, b: B, c: C, d: D);
+decode_impl!(a: A, b: B, c: C, d: D, e: E);
+decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F);
+decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G);
+decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H);
+decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I);
+decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J);
+decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K);
+decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L);
+decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M);
+decode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N);
+decode_impl!(
+    a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O
+);
+decode_impl!(
+    a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P
+);
+
+/// Decode a series of arguments, represented as a tuple. There is a maximum of 16 arguments
+/// supported.
+///
+/// Example:
+///
+/// ```
+/// # use candid::Encode;
+/// # use candid::de::decode_args;
+/// let golden1 = 123u64;
+/// let golden2 = "456";
+/// let bytes = Encode!(&golden1, &golden2).unwrap();
+/// let (value1, value2): (u64, String) = decode_args(&bytes).unwrap();
+///
+/// assert_eq!(golden1, value1);
+/// assert_eq!(golden2, value2);
+/// ```
+pub fn decode_args<'a, Tuple>(bytes: &'a [u8]) -> Result<Tuple>
+where
+    Tuple: ArgumentDecoder<'a>,
+{
+    let mut de = IDLDeserialize::new(bytes)?;
+    let res = ArgumentDecoder::decode(&mut de)?;
+    Ok(res)
+}
+
+/// Decode a single argument.
+///
+/// Example:
+///
+/// ```
+/// # use candid::Encode;
+/// # use candid::de::decode_one;
+/// let golden1 = 123u64;
+/// let bytes = Encode!(&golden1).unwrap();
+/// let value1: u64 = decode_one(&bytes).unwrap();
+///
+/// assert_eq!(golden1, value1);
+/// ```
+pub fn decode_one<'a, T>(bytes: &'a [u8]) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    let (res,) = decode_args(bytes)?;
+    Ok(res)
 }

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -1001,6 +1001,7 @@ where
 {
     let mut de = IDLDeserialize::new(bytes)?;
     let res = ArgumentDecoder::decode(&mut de)?;
+    de.done()?;
     Ok(res)
 }
 

--- a/rust/candid/src/lib.rs
+++ b/rust/candid/src/lib.rs
@@ -32,6 +32,21 @@
 //! # Ok::<(), candid::Error>(())
 //! ```
 //!
+//! Candid provides functions for encoding/decoding a Candid message in a type-safe way.
+//!
+//! ```
+//! use candid::{encode_args, decode_args};
+//! // Serialize two values [(42, "text")] and (42u32, "text")
+//! let bytes: Vec<u8> = encode_args((&[(42, "text")], &(42u32, "text")))?;
+//! // Deserialize the first value as type Vec<(i32, &str)>,
+//! // and the second value as type (u32, String)
+//! let (a, b): (Vec<(i32, &str)>, (u32, String)) = decode_args(&bytes)?;
+//!
+//! assert_eq!(a, [(42, "text")]);
+//! assert_eq!(b, (42u32, "text".to_string()));
+//! # Ok::<(), candid::Error>(())
+//! ```
+//!
 //! We also provide macros for encoding/decoding Candid message in a convenient way.
 //!
 //! ```
@@ -46,6 +61,7 @@
 //! assert_eq!(b, (42u32, "text".to_string()));
 //! # Ok::<(), candid::Error>(())
 //! ```
+//!
 //! The [`Encode!`](macro.Encode.html) macro takes a sequence of Rust values, and returns a binary format `Vec<u8>` that can be sent over the wire.
 //! The [`Decode!`](macro.Decode.html) macro takes the binary message and a sequence of Rust types that you want to decode into, and returns a tuple
 //! of Rust values of the given types.
@@ -244,7 +260,9 @@ pub use parser::typing::{check_prog, TypeEnv};
 pub use parser::value::IDLArgs;
 
 pub mod de;
+pub use de::{decode_args, decode_one};
 pub mod ser;
+pub use ser::{encode_args, encode_one};
 
 pub mod pretty;
 

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -1,5 +1,3 @@
-#![allow(unused_attributes)]
-#![rustfmt::skip::macros(encode_impl)]
 //! Serialize a Rust data structure to Candid binary format
 
 use super::error::{Error, Result};
@@ -392,15 +390,98 @@ encode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G);
 encode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H);
 encode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I);
 encode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J);
-encode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K);
-encode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L);
-encode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M);
-encode_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N);
 encode_impl!(
-    a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K
 );
 encode_impl!(
-    a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L
+);
+encode_impl!(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M
+);
+encode_impl!(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N
+);
+encode_impl!(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O
+);
+encode_impl!(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P
 );
 
 /// Serialize an encoding of a tuple and write it to a [Write] buffer.

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Decode, Deserialize, Encode, Int, Nat};
+use candid::{encode_one, CandidType, Decode, Deserialize, Encode, Int, Nat};
 
 #[test]
 fn test_error() {
@@ -492,7 +492,11 @@ where
 }
 
 fn encode<T: CandidType>(value: &T) -> Vec<u8> {
-    Encode!(&value).unwrap()
+    let encode_one = encode_one(value).unwrap();
+    let encode_macro = Encode!(&value).unwrap();
+
+    assert_eq!(encode_one, encode_macro);
+    encode_fn
 }
 
 fn check_error<F: FnOnce() -> R + std::panic::UnwindSafe, R>(f: F, str: &str) {

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -496,7 +496,7 @@ fn encode<T: CandidType>(value: &T) -> Vec<u8> {
     let encode_macro = Encode!(&value).unwrap();
 
     assert_eq!(encode_one, encode_macro);
-    encode_fn
+    encode_one
 }
 
 fn check_error<F: FnOnce() -> R + std::panic::UnwindSafe, R>(f: F, str: &str) {

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -1,4 +1,4 @@
-use candid::{encode_one, CandidType, Decode, Deserialize, Encode, Int, Nat};
+use candid::{decode_one, encode_one, CandidType, Decode, Deserialize, Encode, Int, Nat};
 
 #[test]
 fn test_error() {
@@ -487,8 +487,10 @@ fn test_decode<'de, T>(bytes: &'de [u8], expected: &T)
 where
     T: PartialEq + serde::de::Deserialize<'de> + std::fmt::Debug,
 {
-    let decoded = Decode!(bytes, T).unwrap();
-    assert_eq!(decoded, *expected);
+    let decoded_one = decode_one::<T>(bytes).unwrap();
+    let decoded_macro = Decode!(bytes, T).unwrap();
+    assert_eq!(decoded_one, *expected);
+    assert_eq!(decoded_macro, *expected);
 }
 
 fn encode<T: CandidType>(value: &T) -> Vec<u8> {

--- a/rust/candid/tests/value.rs
+++ b/rust/candid/tests/value.rs
@@ -4,7 +4,7 @@ use candid::parser::{
     value::{IDLArgs, IDLField, IDLValue},
 };
 use candid::types::Label;
-use candid::Decode;
+use candid::{decode_args, decode_one, Decode};
 
 #[test]
 fn test_parser() {
@@ -147,8 +147,12 @@ fn test_encode(v: &IDLValue, expected: &[u8]) {
 }
 
 fn test_decode(bytes: &[u8], expected: &IDLValue) {
-    let decoded = Decode!(bytes, IDLValue).unwrap();
-    assert_eq!(decoded, *expected);
+    let decoded_macro = Decode!(bytes, IDLValue).unwrap();
+    let (decoded_fn,): (IDLValue,) = decode_args(bytes).unwrap();
+    let decoded_one: IDLValue = decode_one(bytes).unwrap();
+    assert_eq!(decoded_macro, *expected);
+    assert_eq!(decoded_fn, *expected);
+    assert_eq!(decoded_one, *expected);
 }
 
 fn int_vec(v: &[i64]) -> IDLValue {


### PR DESCRIPTION
This is follow-up and update to PR #38. It is backward-compatible, but
we may want to deprecate the macros as they are harder to use and non
type safe in some edge cases.

Tests were modified to ensure that the macros and new decode/encode
functions are fully compatible.

Please note that we don't verify that the decoder decoded all values, as decoding should be covariant on arguments.
