### PR TITLE
export init args in js binding

### DIFF
--- a/rust/candid/src/bindings/analysis.rs
+++ b/rust/candid/src/bindings/analysis.rs
@@ -54,6 +54,15 @@ pub fn chase_actor<'a>(env: &'a TypeEnv, actor: &'a Type) -> crate::Result<Vec<&
     Ok(res)
 }
 
+pub fn chase_types<'a>(env: &'a TypeEnv, tys: &'a [Type]) -> crate::Result<Vec<&'a str>> {
+    let mut seen = BTreeSet::new();
+    let mut res = Vec::new();
+    for t in tys.iter() {
+        chase_type(&mut seen, &mut res, env, &t)?;
+    }
+    Ok(res)
+}
+
 /// Given a `def_list` produced by the `chase_actor` function, infer which types are recursive
 pub fn infer_rec<'a>(
     env: &'a TypeEnv,

--- a/rust/candid/tests/assets/ok/actor.js
+++ b/rust/candid/tests/assets/ok/actor.js
@@ -4,7 +4,6 @@ export default ({ IDL }) => {
   const h = IDL.Func([f], [f], []);
   const g = f;
   o.fill(IDL.Opt(o));
-  const __init = [];
   return IDL.Service({
     'f' : IDL.Func([IDL.Nat], [h], []),
     'g' : f,
@@ -12,3 +11,4 @@ export default ({ IDL }) => {
     'o' : IDL.Func([o], [o], []),
   });
 };
+export init ({ IDL }) => { return []; };

--- a/rust/candid/tests/assets/ok/class.js
+++ b/rust/candid/tests/assets/ok/class.js
@@ -1,9 +1,13 @@
 export default ({ IDL }) => {
   const List = IDL.Rec();
   List.fill(IDL.Opt(IDL.Tuple(IDL.Int, List)));
-  const __init = [IDL.Int, List];
   return IDL.Service({
     'get' : IDL.Func([], [List], []),
     'set' : IDL.Func([List], [List], []),
   });
+};
+export init ({ IDL }) => {
+  const List = IDL.Rec();
+  List.fill(IDL.Opt(IDL.Tuple(IDL.Int, List)));
+  return [IDL.Int, List];
 };

--- a/rust/candid/tests/assets/ok/cyclic.js
+++ b/rust/candid/tests/assets/ok/cyclic.js
@@ -6,6 +6,6 @@ export default ({ IDL }) => {
   const Z = A;
   const Y = Z;
   const X = Y;
-  const __init = [];
   return IDL.Service({ 'f' : IDL.Func([A, B, C, X, Y, Z], [], []) });
 };
+export init ({ IDL }) => { return []; };

--- a/rust/candid/tests/assets/ok/escape.js
+++ b/rust/candid/tests/assets/ok/escape.js
@@ -5,6 +5,6 @@ export default ({ IDL }) => {
     '\"\'' : IDL.Nat,
     '\\\n\'\"' : IDL.Nat,
   });
-  const __init = [];
   return IDL.Service({ '\n\'\"\'\'\"\"\r\t' : IDL.Func([t], [], []) });
 };
+export init ({ IDL }) => { return []; };

--- a/rust/candid/tests/assets/ok/example.js
+++ b/rust/candid/tests/assets/ok/example.js
@@ -33,7 +33,6 @@ export default ({ IDL }) => {
       [IDL.Opt(List)],
       [],
     );
-  const __init = [];
   return IDL.Service({
     'f' : IDL.Func([IDL.Vec(IDL.Nat8), IDL.Opt(IDL.Bool)], [], ['oneway']),
     'g' : IDL.Func(
@@ -53,3 +52,4 @@ export default ({ IDL }) => {
     'i' : f,
   });
 };
+export init ({ IDL }) => { return []; };

--- a/rust/candid/tests/assets/ok/fieldnat.js
+++ b/rust/candid/tests/assets/ok/fieldnat.js
@@ -1,5 +1,4 @@
 export default ({ IDL }) => {
-  const __init = [];
   return IDL.Service({
     'bab' : IDL.Func([IDL.Int, IDL.Nat], [], []),
     'bar' : IDL.Func([IDL.Record({ '2' : IDL.Int })], [], []),
@@ -25,3 +24,4 @@ export default ({ IDL }) => {
       ),
   });
 };
+export init ({ IDL }) => { return []; };

--- a/rust/candid/tests/assets/ok/recursion.js
+++ b/rust/candid/tests/assets/ok/recursion.js
@@ -26,6 +26,6 @@ export default ({ IDL }) => {
   s.fill(
     IDL.Service({ 'f' : t, 'g' : IDL.Func([list], [B, tree, stream], []) })
   );
-  const __init = [];
   return s.getType();
 };
+export init ({ IDL }) => { return []; };

--- a/rust/candid/tests/assets/ok/recursive_class.js
+++ b/rust/candid/tests/assets/ok/recursive_class.js
@@ -1,6 +1,10 @@
 export default ({ IDL }) => {
   const s = IDL.Rec();
   s.fill(IDL.Service({ 'next' : IDL.Func([], [s], []) }));
-  const __init = [s];
   return s.getType();
+};
+export init ({ IDL }) => {
+  const s = IDL.Rec();
+  s.fill(IDL.Service({ 'next' : IDL.Func([], [s], []) }));
+  return [s];
 };

--- a/rust/candid/tests/assets/ok/unicode.js
+++ b/rust/candid/tests/assets/ok/unicode.js
@@ -11,7 +11,6 @@ export default ({ IDL }) => {
     '  空的  ' : IDL.Null,
     '1⃣️2⃣️3⃣️' : IDL.Null,
   });
-  const __init = [];
   return IDL.Service({
     '' : IDL.Func([IDL.Nat], [IDL.Nat], []),
     '✈️  🚗 ⛱️ ' : IDL.Func([], [], ['oneway']),
@@ -19,3 +18,4 @@ export default ({ IDL }) => {
     '函数名' : IDL.Func([A], [B], []),
   });
 };
+export init ({ IDL }) => { return []; };


### PR DESCRIPTION
There are some duplications in the type definitions when exporting init argument, but this ensures a non-breaking change.