### PR TITLE
[spec] Reverse subtyping

### DIFF
--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -677,8 +677,8 @@ service : {
   h2 : (f2 : t -> ()) -> ();      // might call f2({x = 5})
 }
 ```
-If type `t` is later extended with a new optional field, then an existing client passing some function to `f1` or `f2` that is not yet aware of this change will still work correctly.
-This works at any order, for example, `t` can safely be extended with a new optional field in the following scenario:
+If type `t` is later extended with a new optional field, then an existing client passing some function for `f1` or `f2` that is not yet aware of this change will still work correctly.
+This applies at any order, for example, `t` can safely be extended with a new optional field in the following scenario:
 ```
 type t = {x : nat};
 type f = t -> ();
@@ -707,6 +707,11 @@ To summarize, the subtyping relation for validating upgrades is designed with th
 * Non-coercive Deserialisation: Deserialisation of a value is invariant across super- and sub-types.
 
 * Type Erasure: Deserialised values do not require carrying dynamic type information on the language side.
+
+* No covert channels: Serialisation never includes any fields in the value that the sender is not aware of. Specifically, when passing on a value to a third party that the sender previously received itself, then that will only contain fields that the sender intends to send out per its type.
+
+However, something has to give, so one seemingly desirable property that is not maintained is *transitive coherence*, i.e., when deserialising and reserialising a value and then deserialising that again at a different supertype, it might yield another result than it would if the original value was deserialised at the later supertype.
+However, the only possible difference can be one of getting `null` for an option vs a non-null value.
 
 
 ### Rules

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -673,8 +673,8 @@ Such extensibility also extends to *higher-order* examples, where functions them
 ```
 type t = {x : nat};
 service : {
-  h1 : (f1 : () -> t) -> ();      // might call f() and expects a t
-  h2 : (f2 : t -> ()) -> ();      // might call f({x = 5})
+  h1 : (f1 : () -> t) -> ();      // might call f1() and expects a t
+  h2 : (f2 : t -> ()) -> ();      // might call f2({x = 5})
 }
 ```
 If type `t` is later extended with a new optional field, then an existing client passing some function to `f1` or `f2` that is not yet aware of this change will still work correctly.
@@ -777,7 +777,7 @@ A later step might legally re-add a field of the same name but with a different 
 A client having missed the intermediate step will have to upgrade directly from the original to the newest version of the type.
 If two option type do not match up, its value will be treated as `null`.
 
-In practice, users are strongly discouraged to ever remove a record field or ariant tag and later re-add it with a different meaning.
+In practice, users are strongly discouraged to ever remove a record field or a variant tag and later re-add it with a different meaning.
 However, there is no general way for the type system to prevent this, since it cannot know the history of a type definition.
 Consequently, the rule above is needed for technical more than for practical reasons.
 Implementations of static upgrade checking are encouraged to warn if this rule is used.
@@ -803,7 +803,7 @@ record { <fieldtype>;* } <: record { <fieldtype'>;* }
 ----------------------------------------------------------------------------------------------
 record { <fieldtype>;* } <: record { <nat> : opt <datatype'>; <fieldtype'>;* }
 ```
-*Note:* This rule is unusual form a regular subtyping perspective, but necessary in practice.
+*Note:* This rule is unusual from a regular subtyping perspective, but necessary in practice.
 Together with the previous rule, it allows extending any record with optional fields in an upgrade, regardless of how it is used.
 Any party not aware of the extension will treat the field as `null`.
 
@@ -828,7 +828,7 @@ opt variant { <fieldtype>;* } <: opt variant { <fieldtype'>;* }
 ----------------------------------------------------------------------------------------------
 opt variant { <nat> : opt <datatype>; <fieldtype>;* } <: opt variant { <fieldtype'>;* }
 ```
-*Note:* This rule is unusual form a regular subtyping perspective, but it is the dual to the one for records.
+*Note:* This rule is unusual from a regular subtyping perspective, but it is the dual to the one for records.
 Together with the previous rule, it allows extending any optional variant with new tags in an upgrade, regardless of how it is used.
 Any party not aware of the extension will treat the new case as `null`.
 
@@ -912,7 +912,7 @@ opt <datatype> <: opt <datatype'>
   ~> \x.join_opt (\y.
        if (exists <datatype''>.
           y : <datatype''> /\
-          <datatype''> <: <datatype> /\
+          <datatype''> <: <datatype'> /\
           <datatype''> <: <datatype> ~> f)
        then ?(f y)
        else null)
@@ -927,7 +927,7 @@ The effect of this rule is that decoders do not need to perform a subtype check 
 Instead, they can simply try to deserialise, and if they encounter a mismatch abort, to the innermost option type, returning `null`.
 
 *Note:* The working assumption is that the type describing its incoming value is typically *principal*, i.e., the most precise type assignable to the value (in a sense that could be made precise).
-In that case, `<datatype''>` will equal `<datatype>` and deserialisation succeeds exactly if the types match.
+In that case, `<datatype''>` equals `<datatype>` and deserialization succeeds exactly if the types match.
 For example, to be principal, an empty vector would need to have type `vec empty`, `null` could only have type `null`, and a variant would only be allowed to include tags that actually occur in the value.
 
 However, in practice it would be costly to enforce the requirement that all type descriptions in a serialised value are principal, for both encoder (who would need to compute the principal type) and decoders (who would need to check it).

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -710,7 +710,7 @@ To summarize, the subtyping relation for validating upgrades is designed with th
 
 * No covert channels: Serialisation never includes any fields in the value that the sender is not aware of. Specifically, when passing on a value to a third party that the sender previously received itself, then that will only contain fields that the sender intends to send out per its type.
 
-However, something has to give, so one seemingly desirable property that is not maintained is *transitive coherence*, i.e., when deserialising and reserialising a value and then deserialising that again at a different supertype, it might yield another result than it would if the original value was deserialised at the later supertype.
+However, something has to give, so one seemingly desirable property that is not maintained is *transitive coherence*, i.e., given a value serialized at some type, deserialized and serialized at a supertype, and then again deserialized at a supertype of the supertype may yield a diferent result than deserialised directly at the later supertype.
 However, the only possible difference can be one of getting `null` for an option vs a non-null value.
 
 
@@ -782,7 +782,7 @@ A later step might legally re-add a field of the same name but with a different 
 A client having missed the intermediate step will have to upgrade directly from the original to the newest version of the type.
 If two option type do not match up, its value will be treated as `null`.
 
-In practice, users are strongly discouraged to ever remove a record field or a variant tag and later re-add it with a different meaning.
+In practice, users are strongly discouraged to ever remove an optional record field or a variant tag and later re-add it with a different meaning. Instead of removing an optional record field, it should be replaced with `opt empty`, to prevent re-use of that field.
 However, there is no general way for the type system to prevent this, since it cannot know the history of a type definition.
 Consequently, the rule above is needed for technical more than for practical reasons.
 Implementations of static upgrade checking are encouraged to warn if this rule is used.

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -804,8 +804,9 @@ record { <nat> : <datatype>; <fieldtype>;* } <: record { <nat> : <datatype'>; <f
 
 In order to be able to evolve and extend record types that also occur in inbound position (i.e., are used both as function results and function parameters), the subtype relation also supports *removing* fields from records, provided they are optional.
 ```
+<nat> not in <fieldtype>;*
 record { <fieldtype>;* } <: record { <fieldtype'>;* }
-----------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------
 record { <fieldtype>;* } <: record { <nat> : opt <datatype'>; <fieldtype'>;* }
 ```
 *Note:* This rule is unusual from a regular subtyping perspective, but necessary in practice.
@@ -829,8 +830,9 @@ variant { <nat> : <datatype>; <fieldtype>;* } <: variant { <nat> : <datatype'>; 
 
 In order to be able to evolve and extend variant types that also occur in outbound position (i.e., are used both as function results and function parameters), the subtype relation also supports *adding* tags to variants, provided the variant itself is optional.
 ```
+<nat> not in <fieldtype'>;*
 opt variant { <fieldtype>;* } <: opt variant { <fieldtype'>;* }
-----------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------
 opt variant { <nat> : opt <datatype>; <fieldtype>;* } <: opt variant { <fieldtype'>;* }
 ```
 *Note:* This rule is unusual from a regular subtyping perspective, but it is the dual to the one for records.
@@ -952,8 +954,9 @@ record { <fieldtype>;* } <: record { <fieldtype'>;* } ~> f2
 record { <nat> : <datatype>; <fieldtype>;* } <: record { <nat> : <datatype'>; <fieldtype'>;* }
   ~> \x.{f2 x with <nat> = f1 x.<nat>}
 
+<nat> not in <fieldtype>;*
 record { <fieldtype>;* } <: record { <fieldtype'>;* } ~> f
-----------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------
 record { <fieldtype>;* } <: record { <nat> : opt <datatype'>; <fieldtype'>;* }
   ~> \x.{f x with <nat> = null}
 ```
@@ -972,8 +975,9 @@ variant { <fieldtype>;* } <: variant { <fieldtype'>;* } ~> f2
 variant { <nat> : <datatype>; <fieldtype>;* } <: variant { <nat> : <datatype'>; <fieldtype'>;* }
   ~> \x.case x of <nat> y => <nat> (f1 y) | _ => f2 x
 
+<nat> not in <fieldtype'>;*
 opt variant { <fieldtype>;* } <: opt variant { <fieldtype'>;* } ~> f
-----------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------
 opt variant { <nat> : opt <datatype>; <fieldtype>;* } <: opt variant { <fieldtype'>;* }
   ~> \x.join_opt (map_opt (\y.case y of <nat> z => null | _ => ?(f x)))
 ```


### PR DESCRIPTION
This (finally) adds the ability to do reverse subtyping on records and variants. I tried to include various motivation, explanation, and some simple examples to make those rather exotic rules clearer.

Also filled in the missing pieces of lexical syntax for values.