### PR TITLE
Bump spec version

### DIFF
--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1,6 +1,6 @@
 # Candid Specification
 
-Version: 0.1.1
+Version: 0.2
 
 Date: Aug 25, 2020
 

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1,6 +1,6 @@
 # Candid Specification
 
-Version: 0.2
+Version: 0.1.2
 
 Date: Aug 25, 2020
 


### PR DESCRIPTION
the changes in https://github.com/dfinity/candid/pull/110 are definitely
more than editorial, so even if we don’t bump the Magic Bytes, I think
we should definitely bump the version of the spec.