### PR TITLE
improve pretty printing for values

### DIFF
--- a/rust/candid/src/bindings/candid.rs
+++ b/rust/candid/src/bindings/candid.rs
@@ -134,7 +134,7 @@ pub fn pp_ty(ty: &Type) -> RcDoc {
 pub fn pp_label(id: &Label) -> RcDoc {
     match id {
         Label::Named(id) => pp_text(id),
-        Label::Id(n) | Label::Unnamed(n) => RcDoc::as_string(n),
+        Label::Id(_) | Label::Unnamed(_) => RcDoc::as_string(id),
     }
 }
 

--- a/rust/candid/src/parser/value.rs
+++ b/rust/candid/src/parser/value.rs
@@ -360,11 +360,11 @@ pub mod pretty {
             Principal(ref id) => RcDoc::as_string(format!("principal \"{}\"", id)),
             Opt(v) => kwd("opt").append(pp_value(v)),
             Vec(vs) => {
-                if let Some(IDLValue::Nat8(_)) = vs.first() {
+                if let Some(Nat8(_)) = vs.first() {
                     let mut s = String::new();
                     for v in vs.iter().take(MAX_VEC_ELEMENTS) {
                         match v {
-                            IDLValue::Nat8(v) => s.push_str(&format!("\\{:02x}", v)),
+                            Nat8(v) => s.push_str(&format!("\\{:02x}", v)),
                             _ => unreachable!(),
                         }
                     }

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -77,7 +77,9 @@ impl Label {
 impl std::fmt::Display for Label {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Label::Id(n) | Label::Unnamed(n) => write!(f, "{}", n),
+            Label::Id(n) | Label::Unnamed(n) => {
+                write!(f, "{}", super::number::pp_num_str(&n.to_string()))
+            }
             Label::Named(id) => write!(f, "{}", id),
         }
     }

--- a/rust/candid/src/types/number.rs
+++ b/rust/candid/src/types/number.rs
@@ -77,15 +77,31 @@ impl std::str::FromStr for Nat {
     }
 }
 
+pub(crate) fn pp_num_str(s: &str) -> String {
+    let mut groups = Vec::new();
+    for chunk in s.as_bytes().rchunks(3) {
+        let str = String::from_utf8_lossy(chunk);
+        groups.push(str);
+    }
+    groups.reverse();
+    if "-" == groups.first().unwrap() {
+        "-".to_string() + &groups[1..].join("_")
+    } else {
+        groups.join("_")
+    }
+}
+
 impl fmt::Display for Int {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0.to_str_radix(10))
+        let s = self.0.to_str_radix(10);
+        f.write_str(&pp_num_str(&s))
     }
 }
 
 impl fmt::Display for Nat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0.to_str_radix(10))
+        let s = self.0.to_str_radix(10);
+        f.write_str(&pp_num_str(&s))
     }
 }
 

--- a/rust/candid/tests/assets/ok/collision_fields2.fail
+++ b/rust/candid/tests/assets/ok/collision_fields2.fail
@@ -1,1 +1,1 @@
-Candid parser error: label '📦🍦' hash collision with '1832283146'
+Candid parser error: label '📦🍦' hash collision with '1_832_283_146'

--- a/rust/candid/tests/number.rs
+++ b/rust/candid/tests/number.rs
@@ -27,6 +27,19 @@ fn test_numbers() {
 }
 
 #[test]
+fn pretty_print_numbers() {
+    assert_eq!(format!("{}", Nat::from(42)), "42");
+    assert_eq!(format!("{}", Nat::from(100)), "100");
+    assert_eq!(format!("{}", Nat::from(100000)), "100_000");
+    assert_eq!(format!("{}", Nat::from(1_234_567_890)), "1_234_567_890");
+    assert_eq!(format!("{}", Int::from(0)), "0");
+    assert_eq!(format!("{}", Int::from(-1)), "-1");
+    assert_eq!(format!("{}", Int::from(-123)), "-123");
+    assert_eq!(format!("{}", Int::from(-12345678)), "-12_345_678");
+    assert_eq!(format!("{}", Int::from(12345678)), "12_345_678");
+}
+
+#[test]
 fn random_i64() {
     use rand::Rng;
     let mut rng = rand::thread_rng();

--- a/rust/candid/tests/parse_value.rs
+++ b/rust/candid/tests/parse_value.rs
@@ -59,7 +59,7 @@ fn parse_string_literals() {
     let args = parse_args("(blob \"DIDL\\00\\01\\7d\\80\\00\")");
     assert_eq!(
         format!("{}", args),
-        "(vec { 68; 73; 68; 76; 0; 1; 125; 128; 0 })"
+        r#"(blob "\44\49\44\4c\00\01\7d\80\00")"#
     );
     let args = parse_args_err("(\"DIDL\\00\\01\\7d\\80\\00\")");
     assert_eq!(

--- a/rust/candid/tests/value.rs
+++ b/rust/candid/tests/value.rs
@@ -26,7 +26,7 @@ fn test_typed_parser() {
     let candid = r#"
 type List = List1;
 type List1 = List2;
-type List2 = opt record { head: nat8; tail: List1 };
+type List2 = opt record { head: int16; tail: List1 };
 type byte = nat8;
 type f = func (byte, int, nat, int8) -> (List);
 service : {
@@ -52,15 +52,15 @@ service : {
         );
     }
     {
-        let str = "(opt record { head = 1; tail = opt record {head = 2; tail = null}})";
+        let str = "(opt record { head = 1000; tail = opt record {head = -2000; tail = null}})";
         let args = str.parse::<IDLArgs>().unwrap();
         let encoded = args.to_bytes_with_types(&env, &method.rets).unwrap();
         let decoded = IDLArgs::from_bytes(&encoded).unwrap();
-        assert_eq!(decoded.to_string(), "(\n  opt record {\n    1158359328 = 1;\n    1291237008 = opt record { 1158359328 = 2; 1291237008 = null };\n  },\n)");
+        assert_eq!(decoded.to_string(), "(\n  opt record {\n    1_158_359_328 = 1_000;\n    1_291_237_008 = opt record { 1_158_359_328 = -2_000; 1_291_237_008 = null };\n  },\n)");
         let decoded = IDLArgs::from_bytes_with_types(&encoded, &env, &method.rets).unwrap();
         assert_eq!(
             decoded.to_string(),
-            "(opt record { head = 1; tail = opt record { head = 2; tail = null } })"
+            "(opt record { head = 1_000; tail = opt record { head = -2_000; tail = null } })"
         );
         let decoded = IDLArgs::from_bytes_with_types(&encoded, &env, &[]).unwrap();
         assert_eq!(decoded.to_string(), "()");


### PR DESCRIPTION
* Underscore for numerals
* Blob shorthand for `vec nat8`
* Show first 20 elements in `vec t`