### PR TITLE
[spec] facilitate message authentication with candid serialization

### DIFF
--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1127,6 +1127,11 @@ Note:
 `M` maps an Candid value to a byte sequence representing that value. The definition is indexed by type.
 We assume that the fields in a record value are sorted by increasing id.
 
+Given a fixed type, we guarantee that there is a one-to-one mapping between the Candid value and the byte sequence.
+This property ensures that we can use `M` for message authentication when both the sender and receiver agree on the same type. 
+As a corollary, the `leb128` and `sleb128` encodings should be deterministic for serialization, 
+preferably using the shortest encoding. For deserialization, we can decode any valid `leb128` or `sleb128` encoding.
+
 ```
 M : <val> -> <primtype> -> i8*
 M(n : nat)      = leb128(n)


### PR DESCRIPTION
As discussed with @timohanke, we would like to explore using the value part (`M`) of Candid message for computing/verifying user-defined signature scheme.

This requires `M` to be a one-to-one mapping between value and bytes given a fixed type. Besides the non-determinism of `leb128`, this is already the case. We would like to add a statement in the spec to make sure it doesn't change in the future.

For the authentication to work, we assume the following:
* Both sides agree on the method type (not sure how realistic this assumption is)
* Both sides use the same/deterministic `leb128` encoder
* Canister code has access to the raw serialized bytes
* Use domain separator to prevent replaying the message in other context