### PR TITLE
Spec: Refactor description of deserialization

### DIFF
--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -875,7 +875,7 @@ not (∃ v'. <v> :? <t> ~> v')
 <v> !: <t >
 ```
 
-Here `V` models an untyped values, and form an abstract data model of both the message in transit (`V`), as well as the the message . In the following, we re-use the syntax of the textual representation, with the following changes to make it free of overloading:
+Here `V` models untyped values, which form an abstract data model of both the message in transit (`V`), as well as the the message. In the following, we re-use the syntax of the textual representation, with the following changes to make it free of overloading:
 
  * Number literals (`<primval>`) must be immediately enclosed with an `<annval>` that clarifies the precise number type.
  * The value of type `reserved` is expressed as `(null : reserved)`.
@@ -983,7 +983,7 @@ variant { <nat> = <v> } :? variant { <nat> = <t>; _;* } ~> variant { <nat> = <v'
 
 #### References
 
-Function and services references decode unconditoinally
+Function and services references decode unconditionally
 
 ```
 -------------------------------------------------------
@@ -1002,7 +1002,7 @@ principal <text> :? principal ~> principal <text>
 
 #### Tuple types
 
-Whole argument and result sequences are decoded with the same rules are tuple-like records. In particular, extra arguments are ignored, and optional parameters read as as `null` if the argument is missing or fails to decode:
+Whole argument and result sequences are decoded with the same rules as tuple-like records. In particular, extra arguments are ignored, and optional parameters read as as `null` if the argument is missing or fails to decode:
 
 ```
 record {<v>;*} :? record {<t>;*} ~> record {<v'>,*}
@@ -1046,13 +1046,13 @@ The relations above have certain properties. To express them, we need the relati
 
 * Transitivity of subtyping:
   ```
-  T <: T2, T2 <: T3 ⇒ T <: T3
+  T1 <: T2, T2 <: T3 ⇒ T1 <: T3
   ```
 
 * Transitive coherence does not hold:
   ```
-  T <: T2, T2 <: T3
-  v1 : T
+  T1 <: T2, T2 <: T3
+  v1 : T1
   v1 :? T3 ~> v3
   v1 :? T2 ~> v2, v2 :? T3 ~> v3'
   ```
@@ -1313,5 +1313,4 @@ These measures allow the serialisation format to be extended with new types in t
 * Support default field values?
 * Support generic type definitions?
 * Namespaces for imports?
-
 

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1032,7 +1032,16 @@ The relations above have certain properties. To express them, we need the relati
 
 * Soundness of subtyping:
   ```
-  v : T, T <: T' ⇒ ∃ v'. v :? T ~> v'
+  T <: T' ⇒ ∀ v : T. ∃ v'. v :? T ~> v'
+  ```
+
+* Higher-order soundness of subtyping
+  See <./IDL-Soundness.md>, with the following instanstatiations:
+  ```
+  s1 ~> s2 ≔ s2 <: s1
+  t1 <: t2 ≔ (∀ v. t1: v :? t2 ~> _)
+  s1 in t1 <: s2 in t2 ≔ (to be done)
+  s1 <:h s2 ≔ (host-language dependent)
   ```
 
 * Transitivity of subtyping:
@@ -1044,9 +1053,8 @@ The relations above have certain properties. To express them, we need the relati
   ```
   T <: T2, T2 <: T3
   v1 : T
-  v1 :? T2 ~> v2
   v1 :? T3 ~> v3
-  v2 :? T3 ~> v3'
+  v1 :? T2 ~> v2, v2 :? T3 ~> v3'
   ```
   does not imply `v3 = v3'`.
 

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -872,11 +872,11 @@ service { <methtype>;* } <: service { <methtype'>;* }
 service { <name> : <functype>; <methtype>;* } <: service { <name> : <functype'>; <methtype'>;* }
 ```
 
-### Coercing
+### Coercion
 
-This subtyping is implemented during the deserialization of Candid at an expected type. As as described in [Section Deserialisation](#deserialization), the binary value is conceptually first _decoded_ into an abstract value, and then _coerced_ to the expected type.
+This subtyping is implemented during the deserialization of Candid at an expected type. As described in [Section Deserialisation](#deserialization), the binary value is conceptually first _decoded_ into an abstract value, and then _coerced_ to the expected type.
 
-This section describes the covercion, as ternary relation `V ~> V' : T` to describe when a value `V` can be coerced to a value `V'` of type `T`. The fields `V` and `T` can be understood as inputs and `V'` as the output of this relation.
+This section describes the covercion, as a ternary relation `V ~> V' : T` to describe when a value `V` can be coerced to a value `V'` of type `T`. The fields `V` and `T` can be understood as inputs and `V'` as the output of this relation.
 
 Here `V` models untyped values, which form an abstract data model of both the message in transit (`V`), as well as the result of the coercion (`V'`). In the following, we re-use the syntax of the textual representation, with the following changes to make it free of overloading:
 
@@ -900,8 +900,8 @@ false ~> false : bool
 -----------------------
 <text> ~> <text> : text
 
---------------------
-null :? null ~> null
+-------------------
+null ~> null : null 
 ```
 
 Values of type `nat` coerce successfully at type `int`:
@@ -969,7 +969,7 @@ Only records coerce at record type. Missing fields of option or reserved type tu
 In the following rule, the `<nat1>*` field names are those present in both the value and the type, the `<nat2>*` field names only those in the value, and `<nat3>*` are those only in the type.
 ```
 <v1> ~> <v1'> : <t1>
-<t3> = opt _ ∨ <t3> = reserved
+opt empty <: <t3>
 ---------------------------------------------------------------------------------------------------------------------------------------
 record { <nat1> = <v1>;* <nat2> = <v2>;* } ~> record { <nat1> = <v1'>;* <nat3> = null;* } : record {  <nat1> = <t1>;* <nat3> = <t3>;* }
 ```
@@ -1032,7 +1032,7 @@ The relations above have certain properties. To express them, we need the relati
 
 * Uniqueness of decoding:
   ```
-  v ~> v1 : T, v ~> v2 : T ⇒ v1 = v2
+  v ~> v1 : T ∧ v ~> v2 : T ⇒ v1 = v2
   ```
 
 * Soundness of subtyping:
@@ -1044,7 +1044,7 @@ The relations above have certain properties. To express them, we need the relati
   See <./IDL-Soundness.md>, with the following instantiations:
   ```
   s1 ~> s2 ≔ s2 <: s1
-  t1 <: t2 ≔ (∀ v. v : t1 ⇒ v ~> _:? t2 )
+  t1 <: t2 ≔ (∀ v. v : t1 ⇒ v ~> _ : t2 )
   s1 in t1 <: s2 in t2 ≔ (to be done)
   s1 <:h s2 ≔ (host-language dependent)
   ```
@@ -1318,4 +1318,3 @@ These measures allow the serialisation format to be extended with new types in t
 * Support default field values?
 * Support generic type definitions?
 * Namespaces for imports?
-

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -807,12 +807,13 @@ record { <fieldtype>;* } <: record { <fieldtype'>;* }
 record { <nat> : <datatype>; <fieldtype>;* } <: record { <nat> : <datatype'>; <fieldtype'>;* }
 ```
 
-In order to be able to evolve and extend record types that also occur in inbound position (i.e., are used both as function results and function parameters), the subtype relation also supports *removing* fields from records, provided they are optional.
+In order to be able to evolve and extend record types that also occur in inbound position (i.e., are used both as function results and function parameters), the subtype relation also supports *removing* fields from records, provided they are optional (or `reserved`).
 ```
 <nat> not in <fieldtype>;*
 record { <fieldtype>;* } <: record { <fieldtype'>;* }
+opt empty <: <datatype'>
 ------------------------------------------------------------------------------
-record { <fieldtype>;* } <: record { <nat> : opt <datatype'>; <fieldtype'>;* }
+record { <fieldtype>;* } <: record { <nat> : <datatype'>; <fieldtype'>;* }
 ```
 *Note:* This rule is unusual from a regular subtyping perspective, but necessary in practice.
 Together with the previous rule, it allows extending any record with optional fields in an upgrade, regardless of how it is used.

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1056,11 +1056,13 @@ Other design goals are not satisfied (or hard to express formally?):
 
 * Completeness of subtyping:
 
-  It seems the formulation could be that if all values of a type `T` decode at type `T'`, then `T` is a subtype of `T'`.
+  A rigorous formulation of completeness could be that `<:` is the largest transitive and sound relation (in the above sense), i.e. that
   ```
-  (∀ v : T. ∃ v'. v :? T ~> v') ⇒ T <: T'
+  (∀ v. v :? T ~> _ ⇒ v :? T' ~> _) ⇒ T <: T'
   ```
-  But for example we do not have `opt empty <: null`, or `Empty <: t` where `type Empty = rec { Empty }`. Nor do we relate arbitray function types.
+  This does not hold as state, because of counter examples involving the empty type. For example we do not have `opt empty <: null`, or `Empty <: t` where `type Empty = rec { Empty }`
+
+  Nor do we relate arbitray function types (where decoding always succeeds).
 
 
 ## Binary Format

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -876,7 +876,7 @@ service { <name> : <functype>; <methtype>;* } <: service { <name> : <functype'>;
 
 This subtyping is implemented during the deserialization of Candid at an expected type. As described in [Section Deserialisation](#deserialization), the binary value is conceptually first _decoded_ into an abstract value, and then _coerced_ to the expected type.
 
-This section describes the covercion, as a ternary relation `V ~> V' : T` to describe when a value `V` can be coerced to a value `V'` of type `T`. The fields `V` and `T` can be understood as inputs and `V'` as the output of this relation.
+This section describes the coercion, as a ternary relation `V ~> V' : T` to describe when a value `V` can be coerced to a value `V'` of type `T`. The fields `V` and `T` can be understood as inputs and `V'` as the output of this relation.
 
 Here `V` models untyped values, which form an abstract data model of both the message in transit (`V`), as well as the result of the coercion (`V'`). In the following, we re-use the syntax of the textual representation, with the following changes to make it free of overloading:
 
@@ -1288,7 +1288,7 @@ Deserialisation at an expected type sequence `(<t'>,*)` proceeds by
 
  * checking for the magic number `DIDL`
  * using the inverse of the `T` function to decode the type definitions `(<t>*)`
- * using the inverse of the `M` function, indexed by `ts`, to decode the values `(<v>*)`
+ * using the inverse of the `M` function, indexed by `(<t>*)`, to decode the values `(<v>*)`
  * use the coercion relation `(<v>,*) ~> (<v'>,*) : (<t'>,*)` to try to understand the decoded values at the expected type.
 
 ### Deserialisation of future types

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -894,13 +894,13 @@ Values of primitive types coerce successfully at their own type:
 -------------------
 true ~> true : bool
 
-----------------------
+---------------------
 false ~> false : bool
 
 -----------------------
 <text> ~> <text> : text
 
-------------------------
+--------------------
 null :? null ~> null
 ```
 
@@ -924,7 +924,7 @@ NB: No rule is needed for type `empty`, because there are no values of that type
 Only vectors coerce at vector types, and only if all elements coerce successfully.
 
 ```
-<v>  ~> <v'> : <t>
+<v> ~> <v'> : <t>
 -----------------------------------------
 vec { <v>;* } ~> vec { <v'>;* } : vec <t>
 ```

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -864,142 +864,199 @@ service { <methtype>;* } <: service { <methtype'>;* }
 service { <name> : <functype>; <methtype>;* } <: service { <name> : <functype'>; <methtype'>;* }
 ```
 
-### Elaboration
+### Decoding
 
-To define the actual coercion function used during deserialisation of a value, we extend the subtyping relation to a ternary *elaboration* relation `T <: T' ~> f`, where `f` is a suitable coercion function of type `T -> T'`.
+This subtyping is implemented when decoding a Candid value. We provide a ternary relation `V :? T ~> V'` to describe when a value `V` can be decoded at type `T` to a value `V'` of type `T`.
 
+The binary relation `V !: T` describes that a value cannot be decoded at type `T`, and is defined as
+```
+not (∃ v'. <v> :? <t> ~> v')
+------
+<v> !: <t >
+```
+
+Here `V` models an untyped values, and form an abstract data model of both the message in transit (`V`), as well as the the message . In the following, we re-use the syntax of the textual representation, with the following changes to make it free of overloading:
+
+ * Number literals (`<primval>`) must be immediately enclosed with an `<annval>` that clarifies the precise number type.
+ * The value of type `reserved` is expressed as `(null : reserved)`.
+ * No other use of `<annval>`.
 
 #### Primitive Types
 
+Values of primitive types decode successfully at their own type:
+```
+<t> ∈ {nat, int, nat8, nat16, nat32, nat64, int8, int16, int32, int64, float32, float64 }
+-------------------------------------
+(<x> : <t>) :? <t> ~> (<x> : <t>)
+
+--------------------
+true :? bool ~> true
+
+----------------------
+false :? bool ~> false
+
+------------------------
+<text> :? text ~> <text>
+
+------------------------
+null :? null ~> null
 ```
 
---------------------------------
-<primtype> <: <primtype> ~> \x.x
-
-
-------------------
-Nat <: Int ~> \x.x
-
-
-------------------------------
-<datatype> <: reserved ~> \x.x
-
-
-------------------------------
-empty <: <datatype> ~> \_.unreachable
+Values of type `nat` decode at type `int`:
 ```
-
-#### Options and Vectors
-
-```
-<datatype> <: <datatype'> ~> f
----------------------------------------------------
-vec <datatype> <: vec <datatype'> ~> \x.map_vec f x
-
-not (null <: <datatype>)
 ---------------------------------
-null <: opt <datatype> ~> \x.null
+(<x> : nat) :? int ~> (<x> : int)
+```
 
-not (null <: <datatype>)
-<datatype> <: <datatype'> ~> f
+Any value decodes at type `reserved`, producing the canonical value of type `reserved`:
+
+```
+------------------------------
+<v> :? reserved ~> null : reserved
+```
+
+NB: No rule needed for type `empty`, because there are no values of that type. By definition, `<v> !: empty`.
+
+#### Vectors
+
+Only vectors decode at vector types, and only if all elements decode successfully.
+
+```
+<v> :? <t'> ~> <v'>
 ------------------------------------------
-<datatype> <: opt <datatype'> ~> \x.?(f x)
-
-<datatype''> <: <datatype>
-<datatype''> <: <datatype'> ~> f
----------------------------------
-opt <datatype> <: opt <datatype'>
-  ~> \x.case x of () => null | ?y => if f y = _|_ then null else ?(f y)
-
-not (null <: <datatype>)
-<datatype''> <: <datatype>
-<datatype''> <: <datatype'> ~> f
----------------------------------
-<datatype> <: opt <datatype'>
-  ~> \x.if f x = _|_ then null else ?(f x)
+vec { <v>;* } :? vec <t> ~> vec { <v'>;* }
 ```
-The last two rules cover both cases of subtyping on options.
-It *optimistically* tries to decode an option value
-and succceeds if there would have been a valid type `<datatype''>` for the input value that is a subtype of both types.
-(As formulated, the rule would be non-deterministic in the choice of `<datatype''>`, but the intention is to pick the largest type that makes `f y` succeed if possible. We take the liberty to hand-wave over the formulation of this detail here.)
 
-The effect of this rule is that decoders do not actually need to perform separate subtype checks during deserialisation.
-Instead, they can simply try to deserialise, and if they encounter a mismatch abort to the innermost option type, returning `null`.
+#### Options
 
-*Note:* The working assumption is that the type describing an incoming value ought to be *principal*, i.e., the most precise type assignable to the value (in a sense that could be made precise).
-In that case, `<datatype''>` equals `<datatype>` and deserialization succeeds exactly if the types match.
+The null value decodes at any option type:
+```
+-----------------------
+null :? opt <t> ~> null
+```
 
-However, in practice it would be costly to enforce the requirement that all type descriptions in a serialised value are principal, for both encoder (who would need to compute the principal type) and decoders (who would need to check it).
-For example, to be principal, an empty vector would need to have type `vec empty`, `null` could only have type `null`, and a variant would only be allowed to include tags that actually occur in the value.
-Consequently, the semantics allows for the possibility that the encoder ascribes a less specific type `<datatype>` with some redundant information, and allows the decoder to ignore redundant information (by going to `<datatype''>`) like the element type of empty arrays, of null options, or unused variant tags.
+An optional value decodes at an option type, if the value decodes at the constituent type:
+```
+<v> :? <t'> ~> <v'>
+-----------------------
+opt <v> :? opt <t> ~> opt <v'>
+```
+
+If an optional value _fails_ to decode at an optional type, the result is `null`, not failure:
+```
+<v> !: <t'>
+-----------------------
+opt <v> :? opt <t> ~> null
+```
+
+Decoding a non-null, non-optional and non-reserved value at an option type implicitly wraps it in `opt`:
+```
+<v> ≠ null
+<v> ≠ (null : reserved)
+<v> ≠ opt _
+opt <v> :? opt <t> ~> <v'>
+-----------------------
+<v> :? opt <t> ~> <v'>
+```
 
 
 #### Records
 
+Only records decode at record type. Missing fields of option type turn into `null`.
+
+In the following rule, the `<nat1>*` field names are those present in both the value and the type, `<nat2>*` field names only in the value, `<nat3>` only in the type.
 ```
-
-------------------------------------------------
-record { <fieldtype'>;* } <: record { } ~> \x.{}
-
-<datatype> <: <datatype'> ~> f1
-record { <fieldtype>;* } <: record { <fieldtype'>;* } ~> f2
-----------------------------------------------------------------------------------------------
-record { <nat> : <datatype>; <fieldtype>;* } <: record { <nat> : <datatype'>; <fieldtype'>;* }
-  ~> \x.{f2 x with <nat> = f1 x.<nat>}
-
-<nat> not in <fieldtype>;*
-record { <fieldtype>;* } <: record { <fieldtype'>;* } ~> f
-------------------------------------------------------------------------------
-record { <fieldtype>;* } <: record { <nat> : opt <datatype'>; <fieldtype'>;* }
-  ~> \x.{f x with <nat> = null}
+<v1> :? <t1> ~> <v1'>
+--------------------------------------------------------------------------------------------------------------------------------------------
+record { <nat1> = <v1>;* <nat2> = <v2>;* } :? record {  <nat1> = <t1>;* <nat3> = opt <t2>;* } ~> record { <nat1> = <v1'>;* <nat3> = null;* }
 ```
 
 
 #### Variants
 
 ```
-
--------------------------------------------------
-variant { } <: variant { <fieldtype'>;* } ~> \x.x
-
-<datatype> <: <datatype'> ~> f1
-variant { <fieldtype>;* } <: variant { <fieldtype'>;* } ~> f2
-------------------------------------------------------------------------------------------------
-variant { <nat> : <datatype>; <fieldtype>;* } <: variant { <nat> : <datatype'>; <fieldtype'>;* }
-  ~> \x.case x of <nat> y => <nat> (f1 y) | _ => f2 x
+<v> :? <t> ~> <v'>
+----------------------------------------------------------------------------------
+variant { <nat> = <v> } :? variant { <nat> = <t>;* _ } ~> variant { <nat> = <v'> }
 ```
 
 
-#### Functions
+#### References
+
+Function and services references decode as they are
 
 ```
-record { N1':<datatype1'>;* } <: record { N1:<datatype1>;* } ~> f1
-record { N2:<datatype2>;* } <: record { N2':<datatype2'>;* } ~> f2
-------------------------------------------------------------------------------------------------------------------
-func ( <datatype1>,* ) -> ( <datatype2>,* ) <funcann>* <: func ( <datatype1'>,* ) -> ( <datatype2'>,* ) <funcann>*
-  ~> \x.\y.f2 (x (f1 y))
+-------------------------------------------------------
+func <text>.<id> :? func <functype> ~> func <text>.<id>
 ```
 
-#### Services
-
+```
+-------------------------------------------------------
+service <text> :? service <actortype> ~> service <text>
 ```
 
--------------------------------------------------
-service { <methtype'>;* } <: service { } ~> \x.{}
+```
+-------------------------------------------------------
+principal <text> :? principal ~> principal <text>
+```
 
-<functype> <: <functype'> ~> f1
-service { <methtype>;* } <: service { <methtype'>;* } ~> f2
-------------------------------------------------------------------------------------------------
-service { <name> : <functype>; <methtype>;* } <: service { <name> : <functype'>; <methtype'>;* }
-  ~> \x.{f1 x; <name> = f2 x.<name>}
+#### Tuple types
+
+Whole argument and result sequences are decoded with the same rules are tuple-like records. In particular, extra arguments are ignored, and optional arguments treated as `null` if decoding fails, and missing optional arguments treated at `null`:
+
+```
+record {<v>;*} :? record {<t>;*} ~> record {<v'>,*}
+---------------------------------------------------
+(<v>,*) :? (<t>,*) ~> (<v'>,*)
 ```
 
 
-## Open Questions
+## Properties
 
-* Support default field values?
-* Support generic type definitions?
-* Namespaces for imports?
+The relations above have certain properties. To express them, we need the relation `V : T`, expressing that `V` has inherently type `T`. Instead of listing the rules of that relation, we define it via the first property below;
+
+* Correctness and completeness of decoding:
+  ```
+  (v : T) ⟺ (v :? T ~> v)
+  ```
+
+* Uniqueness of decoding:
+  ```
+  v :? T ~> v1, v :? T ~> v2 ⇒ v1 = v2
+  ```
+
+* Soundness of subtyping:
+  ```
+  v : T, T <: T' ⇒ ∃ v'. v :? T ~> v'
+  ```
+
+* Transitivity of subtyping:
+  ```
+  T <: T2, T2 <: T3 ⇒ T <: T3
+  ```
+
+* Transitive coherence does not hold:
+  ```
+  T <: T2, T2 <: T3
+  v1 : T
+  v :? T2 ~> v2
+  v :? T3 ~> v3
+  v2 :? T3 ~> v3'
+  ```
+  does not imply `v3 = v3'`.
+
+  Can prove that `R(v3,v3')` for the smallest homomorphic relation `R` that is reflexive and satsified `∀ v. R(opt v, null)`.
+
+Other design goals are not satisfied (or hard to express forally).
+
+* Completeness of subtyping:
+
+  It seems the fomulation could be that if all values of a type `T` decode at type `T'`, then `T` is a subtype of `T'`.
+  ```
+  (∀ v : T. ∃ v'. v :? T ~> v') =>, T <: T'
+  ```
+
+  But we don't have `opt empty <: null`, or `Empty <: t` where `type Empty = rec { Empty }`…
 
 
 ## Binary Format
@@ -1195,17 +1252,6 @@ Note:
 * It is unspecified how references *r* are represented, neither internally nor externally. When binding to Wasm, their internal representation is expected to be based on Wasm reference types, i.e., `anyref` or subtypes thereof. It is up to the system how to represent or translate the reference table on the wire.
 
 
-### Deserialisation
-
-Deserialisation is the parallel application of the inverse functions of `T`, `M`, and `R` defined above, with the following mechanism for robustness towards future extensions:
-
-* A serialised type may be headed by an opcode other than the ones defined above (i.e., less than -24). Any such opcode is followed by an LEB128-encoded count, and then a number of bytes corresponding to this count. A type represented that way is called a *future type*.
-
-* A value corresponding to a future type is called a *future value*. It is represented by two LEB128-encoded counts, *m* and *n*, followed by a *m* bytes in the memory representation M and accompanied by *n* corresponding references in R.
-
-These measures allow the serialisation format to be extended with new types in the future, as long as their representation and the representation of the corresponding values include a length prefix matching the above scheme, and thereby allowing an older deserialiser not understanding them to skip over them. The subtyping rules ensure that upgradability is maintained in this situation, i.e., an old deserialiser has no need to understand the encoded data.
-
-
 ### Parameters and Results
 
 `A` defines the argument mapping. Essentially, an argument list is serialised into the triple (T,M,R) as if it was a single closed record. T and M are combined into a single byte stream B, where they are preceded by the string "DIDL" as a magic number and a possible list of type definitions.
@@ -1227,3 +1273,31 @@ The same representation is used for function results.
 Note:
 
 * It is unspecified how the pair (B,R) representing a serialised value is bundled together in an external environment.
+
+### Deserialisation
+
+Deserialisation at an expected type sequence `(<t'>,*)` proceeds by
+
+ * checking for the magic number `DIDL`
+ * using the inverse of the `T` function to parse the type definitions `(<t>*)`
+ * using the inverse of the `M` function, indexed by `ts`, to parse the values `(<v>*)`
+ * use the decoding relation `(<v>,*) :? (<t'>,*) ~> (<v'>,*)` to try to understand the parsed values at the expected type.
+
+### Deserialisation of future types
+
+Deserialisation uses the following mechanism for robustness towards future extensions:
+
+* A serialised type may be headed by an opcode other than the ones defined above (i.e., less than -24). Any such opcode is followed by an LEB128-encoded count, and then a number of bytes corresponding to this count. A type represented that way is called a *future type*.
+
+* A value corresponding to a future type is called a *future value*. It is represented by two LEB128-encoded counts, *m* and *n*, followed by a *m* bytes in the memory representation M and accompanied by *n* corresponding references in R.
+
+These measures allow the serialisation format to be extended with new types in the future, as long as their representation and the representation of the corresponding values include a length prefix matching the above scheme, and thereby allowing an older deserialiser not understanding them to skip over them. The subtyping rules ensure that upgradability is maintained in this situation, i.e., an old deserialiser has no need to understand the encoded data.
+
+
+## Open Questions
+
+* Support default field values?
+* Support generic type definitions?
+* Namespaces for imports?
+
+

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1065,18 +1065,7 @@ The relations above have certain properties. To express them, we need the relati
 
   However, it implies that `R(v3,v3')`, where `R` is the smallest homomorphic, reflexive relation `R` that satisfies `∀ v. R(opt v, null)`.
 
-Other design goals are not satisfied (or hard to express formally?):
-
-* Completeness of subtyping:
-
-  A rigorous formulation of completeness could be that `<:` is the largest transitive and sound relation (in the above sense), i.e. that
-  ```
-  (∀ v. v ~> _ : T ⇒ v' ~> _ : T') ⇒ T <: T'
-  ```
-  This does not hold as state, because of counter examples involving the empty type. For example we do not have `opt empty <: null`, or `Empty <: t` where `type Empty = rec { Empty }`
-
-  Nor do we relate arbitray function types (where decoding always succeeds).
-
+The goal of “subtyping completeness” has not been cast into a formal formulation yet.
 
 ## Binary Format
 


### PR DESCRIPTION
This is a significant rewirte of the section in the spec describing
deserialization. Some points worth noting:

 * This replaces the elaboration relation with one that takes a value
   and a type as input, and returns a value. This makes it clearer that
   there is no “input _type_” of deeper relevance.

 * One great benefit: No more long prose about how the rules assume
   these types to be principal, even if they aren’t.

   This clarifies questions like [this
   one](https://github.com/dfinity/candid/pull/126#discussion_r515248927)

 * Also, the existing rules about “elaborating function values” were
   kinda bogus, as function values are just accepted as they are. This
   is much easier now, also good.

 * Unfortuantely for this application, our textual representation has
   overloading. Instead of defining yet another abstract value algebra,
   I did a bit of hand-waving, and defined an “overloading-free
   fragment” of the textual format for this section.

 * A fair number of rules becomes simpler. Promising!

 * I was able to phrase some interesting properties more formally. Also
   promising! Didn’t actually prove them, though, although we should.

 * Still unclear to me what we mean with “subtyping is complete”, see
   the section there.

 * Decoding is still an inductive relation, so not fully algorithmic.
   This may be an issue with a stright-forward formalization; not all
   theorem provers like negative occurrences of inductive relations in
   their rules.

 * Syntax of the relations up for discussion.