### PR TITLE
Spec: Change subtype-to-constituent rule

### DIFF
--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -968,9 +968,18 @@ Coercing a non-null, non-optional and non-reserved value at an option type treat
 <v> ≠ (null : reserved)
 <v> ≠ opt _
 not (null <: <t>)
-opt <v> ~> <v'> : opt <t>
+<v> ~> <v'> : <t>
 -------------------------
-<v> ~> <v'> : opt <t>
+<v> ~> opt <v'> : opt <t>
+```
+Again, failure to coerce the value turns into `null`:
+```
+<v> ≠ null
+<v> ≠ (null : reserved)
+<v> ≠ opt _
+null <: <t> ∨ not (<v> ~> _ : <t>)
+----------------------------------
+<v> ~> null : opt <t>
 ```
 
 


### PR DESCRIPTION
the coq formalization in #147 shows that the old rule didn’t quite work
(it was confused about `5 ~> ? : opt null` I believe), but this variant
does. I think all implemnetations do the right thing anways (so maybe
rewriting this as a partial coercion _function_ would be helpful)