### PR TITLE
fix record_nesting_depth for native Rust types

### DIFF
--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -460,6 +460,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             return self.deserialize_identifier(visitor);
         }
         let t = self.peek_type()?;
+        if t != Opcode::Record {
+            self.record_nesting_depth = 0;
+        }
         match t {
             Opcode::Int => self.deserialize_int(visitor),
             Opcode::Nat => self.deserialize_nat(visitor),
@@ -497,6 +500,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             return self.deserialize_identifier(visitor);
         }
         let t = self.peek_type()?;
+        if t != Opcode::Record {
+            self.record_nesting_depth = 0;
+        }
         match t {
             Opcode::Int => self.deserialize_int(visitor),
             Opcode::Nat => self.deserialize_nat(visitor),

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -520,7 +520,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 let old_nesting = self.record_nesting_depth;
                 self.record_nesting_depth += 1;
                 if self.record_nesting_depth > self.table.len() {
-                    return Err(Error::msg("There is an infinite loop in the record definition, the type is isomorphic to an empty type"));
+                    return Err(Error::msg(format!("There is an infinite loop in the record definition, the type is isomorphic to an empty type {}/{}", self.record_nesting_depth, self.table.len())));
                 }
                 self.check_type(Opcode::Record)?;
                 let len = self.pop_current_type()?.get_u32()?;
@@ -682,7 +682,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         let old_nesting = self.record_nesting_depth;
         self.record_nesting_depth += 1;
         if self.record_nesting_depth > self.table.len() {
-            return Err(Error::msg("There is an infinite loop in the record definition, the type is isomorphic to an empty type"));
+            return Err(Error::msg(format!("There is an infinite loop in the record definition, the type is isomorphic to an empty type {}/{}", self.record_nesting_depth, self.table.len())));
         }
         self.check_type(Opcode::Record)?;
         let len = self.pop_current_type()?.get_u32()?;

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -521,7 +521,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 let old_nesting = self.record_nesting_depth;
                 self.record_nesting_depth += 1;
                 if self.record_nesting_depth > self.table.len() {
-                    return Err(Error::msg(format!("There is an infinite loop in the record definition, the type is isomorphic to an empty type {}/{}", self.record_nesting_depth, self.table.len())));
+                    return Err(Error::msg("There is an infinite loop in the record definition, the type is isomorphic to an empty type"));
                 }
                 self.check_type(Opcode::Record)?;
                 let len = self.pop_current_type()?.get_u32()?;
@@ -693,7 +693,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         let old_nesting = self.record_nesting_depth;
         self.record_nesting_depth += 1;
         if self.record_nesting_depth > self.table.len() {
-            return Err(Error::msg(format!("There is an infinite loop in the record definition, the type is isomorphic to an empty type {}/{}", self.record_nesting_depth, self.table.len())));
+            return Err(Error::msg("There is an infinite loop in the record definition, the type is isomorphic to an empty type"));
         }
         self.check_type(Opcode::Record)?;
         let len = self.pop_current_type()?.get_u32()?;


### PR DESCRIPTION
All `deserialize_T` functions can be entry points for deserialization. We have to reset the counter for `record_nesting_depth` for all these functions to track the empty record type properly.