### PR TITLE
debug print for values

### DIFF
--- a/rust/candid/src/bindings/candid.rs
+++ b/rust/candid/src/bindings/candid.rs
@@ -59,14 +59,16 @@ fn needs_quote(id: &str) -> bool {
     !is_valid_as_id(id) || is_keyword(id)
 }
 
-pub(crate) fn pp_text(id: &str) -> RcDoc {
+pub(crate) fn ident_string(id: &str) -> String {
     if needs_quote(id) {
-        str("\"")
-            .append(format!("{}", id.escape_debug()))
-            .append("\"")
+        format!("\"{}\"", id.escape_debug())
     } else {
-        str(id)
+        id.to_string()
     }
+}
+
+fn pp_text(id: &str) -> RcDoc {
+    RcDoc::text(ident_string(id))
 }
 
 pub fn pp_ty(ty: &Type) -> RcDoc {

--- a/rust/candid/src/bindings/candid.rs
+++ b/rust/candid/src/bindings/candid.rs
@@ -59,7 +59,7 @@ fn needs_quote(id: &str) -> bool {
     !is_valid_as_id(id) || is_keyword(id)
 }
 
-fn pp_text(id: &str) -> RcDoc {
+pub(crate) fn pp_text(id: &str) -> RcDoc {
     if needs_quote(id) {
         str("\"")
             .append(format!("{}", id.escape_debug()))

--- a/rust/candid/src/parser/value.rs
+++ b/rust/candid/src/parser/value.rs
@@ -385,26 +385,6 @@ pub mod pretty {
             return RcDoc::as_string(format!("{:?}", v));
         }
         match v {
-            Null
-            | None
-            | Reserved
-            | Bool(_)
-            | Number(_)
-            | Int(_)
-            | Nat(_)
-            | Nat8(_)
-            | Nat16(_)
-            | Nat32(_)
-            | Nat64(_)
-            | Int8(_)
-            | Int16(_)
-            | Int32(_)
-            | Int64(_)
-            | Float32(_)
-            | Float64(_)
-            | Principal(_)
-            | Service(_)
-            | Func(_, _) => RcDoc::as_string(format!("{:?}", v)),
             Text(ref s) => RcDoc::as_string(format!("\"{}\"", s)),
             Opt(v) => kwd("opt").append(pp_value(depth - 1, v)),
             Vec(vs) => {
@@ -428,6 +408,7 @@ pub mod pretty {
             Variant(v, _) => {
                 kwd("variant").append(enclose_space("{", pp_field(depth, &v, true), "}"))
             }
+            _ => RcDoc::as_string(format!("{:?}", v)),
         }
     }
 

--- a/rust/candid/src/parser/value.rs
+++ b/rust/candid/src/parser/value.rs
@@ -341,7 +341,6 @@ pub mod pretty {
     use ::pretty::RcDoc;
 
     pub use crate::bindings::candid::pp_label;
-    use crate::bindings::candid::pp_text;
 
     // The definition of tuple is language specific.
     pub(crate) fn is_tuple(t: &IDLValue) -> bool {
@@ -386,11 +385,27 @@ pub mod pretty {
             return RcDoc::as_string(format!("{:?}", v));
         }
         match v {
-            Null | None | Reserved | Bool(_) | Number(_) | Int(_) | Nat(_) | Nat8(_) | Nat16(_)
-            | Nat32(_) | Nat64(_) | Int8(_) | Int16(_) | Int32(_) | Int64(_) | Float32(_)
-            | Float64(_) | Principal(_) | Service(_) => RcDoc::as_string(format!("{:?}", v)),
+            Null
+            | None
+            | Reserved
+            | Bool(_)
+            | Number(_)
+            | Int(_)
+            | Nat(_)
+            | Nat8(_)
+            | Nat16(_)
+            | Nat32(_)
+            | Nat64(_)
+            | Int8(_)
+            | Int16(_)
+            | Int32(_)
+            | Int64(_)
+            | Float32(_)
+            | Float64(_)
+            | Principal(_)
+            | Service(_)
+            | Func(_, _) => RcDoc::as_string(format!("{:?}", v)),
             Text(ref s) => RcDoc::as_string(format!("\"{}\"", s)),
-            Func(id, meth) => RcDoc::as_string(format!("func \"{}\".", id)).append(pp_text(meth)),
             Opt(v) => kwd("opt").append(pp_value(depth - 1, v)),
             Vec(vs) => {
                 if let Some(Nat8(_)) = vs.first() {
@@ -464,7 +479,12 @@ impl fmt::Debug for IDLValue {
             Reserved => write!(f, "reserved"),
             Principal(id) => write!(f, "principal \"{}\"", id),
             Service(id) => write!(f, "service \"{}\"", id),
-            Func(id, meth) => write!(f, "func \"{}\".\"{}\"", id, meth),
+            Func(id, meth) => write!(
+                f,
+                "func \"{}\".{}",
+                id,
+                crate::bindings::candid::ident_string(meth)
+            ),
             Opt(v) => write!(f, "opt {:?}", v),
             Vec(vs) => {
                 if let Some(Nat8(_)) = vs.first() {

--- a/rust/candid/src/parser/value.rs
+++ b/rust/candid/src/parser/value.rs
@@ -387,21 +387,9 @@ pub mod pretty {
             Opt(v) => kwd("opt").append(pp_value(v)),
             Vec(vs) => {
                 if let Some(Nat8(_)) = vs.first() {
-                    let mut s = String::new();
-                    for v in vs.iter() {
-                        match v {
-                            Nat8(v) => s.push_str(&pp_char(*v)),
-                            _ => unreachable!(),
-                        }
-                    }
-                    RcDoc::text(format!("blob \"{}\"", s))
+                    RcDoc::as_string(format!("{:?}", v))
                 } else if vs.len() > MAX_ELEMENTS_FOR_PRETTY_PRINT {
-                    let body = vs
-                        .iter()
-                        .map(|v| v.to_string())
-                        .collect::<std::vec::Vec<_>>()
-                        .join("; ");
-                    RcDoc::text(format!("vec {{ {} }}", body))
+                    RcDoc::as_string(format!("{:?}", v))
                 } else {
                     let body = concat(vs.iter().map(|v| pp_value(v)), ";");
                     kwd("vec").append(enclose_space("{", body, "}"))

--- a/tools/candiff/src/lib.rs
+++ b/tools/candiff/src/lib.rs
@@ -58,7 +58,7 @@ pub mod pretty {
         use ValueEdit::*;
         match &*edit.0 {
             Skip => str("skip"),
-            Put(v) => kwd("put").append(enclose_space("{", pp_value(&v), "}")),
+            Put(v) => kwd("put").append(enclose_space("{", pp_value(20, &v), "}")),
             Opt(ve) => kwd("opt").append(enclose_space("{", value_edit(&ve), "}")),
             Vec(edits) => kwd("vec").append(enclose_space("{", vec_edits(&edits), "}")),
             Record(edits) => kwd("record").append(enclose_space("{", record_edits(&edits), "}")),
@@ -73,7 +73,7 @@ pub mod pretty {
                 "{",
                 RcDoc::as_string(n)
                     .append(RcDoc::space())
-                    .append(pp_value(v)),
+                    .append(pp_value(20, v)),
                 "}",
             )),
             EditValue(n, v) => kwd("edit").append(enclose_space(

--- a/tools/candiff/tests/candiff.rs
+++ b/tools/candiff/tests/candiff.rs
@@ -29,7 +29,7 @@ mod echo {
         let mut cmd = candiff();
         cmd.arg("echo").arg("1").arg("-d");
         cmd.assert()
-            .stdout(predicate::eq(b"Number(\"1\")\n" as &[u8]))
+            .stdout(predicate::eq(b"1\n" as &[u8]))
             .success();
     }
 
@@ -38,7 +38,7 @@ mod echo {
         let mut cmd = candiff();
         cmd.arg("echo").arg("1").arg("-t nat").arg("-d");
         cmd.assert()
-            .stdout(predicate::eq(b"Nat(Nat(BigUint { data: [1] }))\n" as &[u8]))
+            .stdout(predicate::eq(b"1\n" as &[u8]))
             .success();
     }
 
@@ -47,9 +47,7 @@ mod echo {
         let mut cmd = candiff();
         cmd.arg("echo").arg("1").arg("-t int").arg("-d");
         cmd.assert()
-            .stdout(predicate::eq(
-                b"Int(Int(BigInt { sign: Plus, data: BigUint { data: [1] } }))\n" as &[u8],
-            ))
+            .stdout(predicate::eq(b"1\n" as &[u8]))
             .success();
     }
 

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -49,8 +49,8 @@ enum Command {
         #[structopt(flatten)]
         annotate: TypeAnnotation,
         #[structopt(short, long)]
-        /// Pretty print the result
-        pretty: bool,
+        /// Disable pretty printing
+        flat: bool,
     },
     /// Diff two Candid values
     Diff {
@@ -190,7 +190,7 @@ fn main() -> Result<()> {
         Command::Decode {
             blob,
             annotate,
-            pretty,
+            flat,
         } => {
             let bytes = hex::decode(&blob)?;
             let value = if annotate.is_empty() {
@@ -199,7 +199,7 @@ fn main() -> Result<()> {
                 let (env, types) = annotate.get_types(Mode::Decode)?;
                 IDLArgs::from_bytes_with_types(&bytes, &env, &types)?
             };
-            if pretty {
+            if !flat {
                 println!("{}", value);
             } else {
                 println!("{:?}", value);

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -48,6 +48,9 @@ enum Command {
         blob: String,
         #[structopt(flatten)]
         annotate: TypeAnnotation,
+        #[structopt(short, long)]
+        /// Pretty print the result
+        pretty: bool,
     },
     /// Diff two Candid values
     Diff {
@@ -184,7 +187,11 @@ fn main() -> Result<()> {
             };
             println!("{}", hex);
         }
-        Command::Decode { blob, annotate } => {
+        Command::Decode {
+            blob,
+            annotate,
+            pretty,
+        } => {
             let bytes = hex::decode(&blob)?;
             let value = if annotate.is_empty() {
                 IDLArgs::from_bytes(&bytes)?
@@ -192,7 +199,11 @@ fn main() -> Result<()> {
                 let (env, types) = annotate.get_types(Mode::Decode)?;
                 IDLArgs::from_bytes_with_types(&bytes, &env, &types)?
             };
-            println!("{}", value);
+            if pretty {
+                println!("{}", value);
+            } else {
+                println!("{:?}", value);
+            }
         }
         Command::Diff {
             values1,


### PR DESCRIPTION
The default pretty printer is too slow for large values. Implements a `Debug` trait for `IDLValue`