### PR TITLE
Candid test suite: More tests related to references

### DIFF
--- a/test/reference.test.did
+++ b/test/reference.test.did
@@ -19,21 +19,21 @@ assert blob "DIDL\00\01\69\01\03\ca\ff\ee" !: (service {}) "service: not primiti
 assert "(principal \"w7x7r-cok77-xa\")"    !: (service {}) "service: not principal";
 assert blob "DIDL\01\69\00\01\00\01\03\ca\ff\ee" == "(service \"w7x7r-cok77-xa\")" : (service {}) "service";
 assert blob "DIDL\01\69\00\01\00\01\03\ca\ff\ee" == "(service \"w7x7r-cok77-xa\")" : (service {}) "service";
-assert blob "DIDL\02\6a\01\71\01\7d\00\69\01\03\66\6f\6f\00\01\01\01\03\ca\ff\ee"
+assert blob "DIDL\02\6a\01\71\01\7d\00\69\01\03foo\00\01\01\01\03\ca\ff\ee"
   == "(service \"w7x7r-cok77-xa\")" : (service { foo : (text) -> (nat) }) "service";
-assert blob "DIDL\02\6a\01\71\01\7d\00\69\02\03\66\6f\6f\00\04\66\6f\6f\32\00\01\01\01\03\ca\ff\ee"
+assert blob "DIDL\02\6a\01\71\01\7d\00\69\02\03foo\00\04foo\32\00\01\01\01\03\ca\ff\ee"
   == "(service \"w7x7r-cok77-xa\")" : (service { foo : (text) -> (nat); foo2 : (text) -> (nat) }) "service";
   
-assert blob "DIDL\02\6a\01\71\01\7d\00\69\03\03\66\6f\6f\00\04\66\6f\6f\32\00\01\01\01\03\ca\ff\ee" !: (service { foo : (text) -> (nat); foo2 : (text) -> (nat) }) "service: too long";
-assert blob "DIDL\02\6a\01\71\01\7d\00\69\01\03\66\6f\6f\00\04\66\6f\6f\32\00\01\01\01\03\ca\ff\ee" !: (service { foo : (text) -> (nat); foo2 : (text) -> (nat) }) "service: too short";
-assert blob "DIDL\02\6a\01\71\01\7d\00\69\02\04\66\6f\6f\32\00\03\66\6f\6f\00\01\01\01\03\ca\ff\ee" !: (service { foo : (text) -> (nat); foo2 : (text) -> (nat) }) "service: unsorted";
-assert blob "DIDL\02\6a\01\71\01\7d\00\69\02\03\66\6f\6f\00\03\66\6f\6f\00\01\01\01\03\ca\ff\ee" !: (service { foo : (text) -> (nat) }) "service: duplicate";
+assert blob "DIDL\02\6a\01\71\01\7d\00\69\03\03foo\00\04foo\32\00\01\01\01\03\ca\ff\ee" !: (service { foo : (text) -> (nat); foo2 : (text) -> (nat) }) "service: too long";
+assert blob "DIDL\02\6a\01\71\01\7d\00\69\01\03foo\00\04foo\32\00\01\01\01\03\ca\ff\ee" !: (service { foo : (text) -> (nat); foo2 : (text) -> (nat) }) "service: too short";
+assert blob "DIDL\02\6a\01\71\01\7d\00\69\02\04foo\32\00\03foo\00\01\01\01\03\ca\ff\ee" !: (service { foo : (text) -> (nat); foo2 : (text) -> (nat) }) "service: unsorted";
+assert blob "DIDL\02\6a\01\71\01\7d\00\69\02\03foo\00\03foo\00\01\01\01\03\ca\ff\ee" !: (service { foo : (text) -> (nat) }) "service: duplicate";
 
 assert blob "DIDL\05i\02\03foo\01\04\f0\9f\90\82\02j\00\00\01\02j\01\03\01\04\01\01n|l\00\01\00\01\00"
   == "(service \"aaaaa-aa\")" : (service {"🐂":(opt int)->(record{}) query; foo:()->() oneway}) "service: unicode";
-assert blob "DIDL\02\6a\01\71\01\7d\00\69\01\03\66\6f\6f\68\01\01\01\03\ca\ff\ee" !: (service { foo: () -> () }) "service { foo: principal }";
-assert blob "DIDL\02\6e\7e\69\01\03\66\6f\6f\00\01\01\01\03\ca\ff\ee" !: (service { foo: () -> () }) "service { foo: opt bool }";
-assert blob "DIDL\02\69\01\03\66\6f\6f\01\6e\7e\01\01\01\03\ca\ff\ee" !: (service { foo: () -> () }) "service { foo: opt bool }";
+assert blob "DIDL\02\6a\01\71\01\7d\00\69\01\03foo\68\01\01\01\03\ca\ff\ee" !: (service { foo: () -> () }) "service { foo: principal }";
+assert blob "DIDL\02\6e\7e\69\01\03foo\00\01\01\01\03\ca\ff\ee" !: (service { foo: () -> () }) "service { foo: opt bool }";
+assert blob "DIDL\02\69\01\03foo\01\6e\7e\01\01\01\03\ca\ff\ee" !: (service { foo: () -> () }) "service { foo: opt bool }";
 
 // function
 assert blob "DIDL\01\6a\00\00\00\01\00\01\01\03\ca\ff\ee\01\61"
@@ -43,12 +43,19 @@ assert blob "DIDL\01\6a\00\00\00\01\00\01\01\03\ca\ff\ee\01\61"
 assert blob "DIDL\01\6a\00\00\00\01\00\01\00\03\ca\ff\ee\01\61" !: (func () -> ()) "func: wrong tag";  
 assert blob "DIDL\02j\02|}\01\01\01\01i\00\01\00\01\01\00\04\f0\9f\90\82"
   == "(func \"aaaaa-aa\".\"🐂\")"               : (func (int,nat) -> (service {}) query) "func: unicode";
-assert blob "DIDL\01\6a\01\68\01\7d\00\01\00\01\01\03\ca\ff\ee\03\66\6f\6f"
+assert blob "DIDL\01\6a\01\68\01\7d\00\01\00\01\01\03\ca\ff\ee\03foo"
   == "(func \"w7x7r-cok77-xa\".foo)"            : (func (principal) -> (nat)) "func";
-assert blob "DIDL\01\6a\01\71\01\7d\01\01\01\00\01\01\03\ca\ff\ee\03\66\6f\6f"
+assert blob "DIDL\01\6a\01\71\01\7d\01\01\01\00\01\01\03\ca\ff\ee\03foo"
   == "(func \"w7x7r-cok77-xa\".foo)"            : (func (text) -> (nat) query) "func: query";
-assert blob "DIDL\01\6a\01\71\01\7d\01\80\01\01\00\01\01\03\ca\ff\ee\03\66\6f\6f" !: (func (text) -> (nat) query) "func: unknown annotation";
+assert blob "DIDL\01\6a\01\71\01\7d\01\80\01\01\00\01\01\03\ca\ff\ee\03foo" !: (func (text) -> (nat) query) "func: unknown annotation";
 assert blob "DIDL\00\01\6a\01\01\03\ca\ff\ee\01\61" !: (func () -> ()) "func: not primitive";
 assert blob "DIDL\00\01\6a\01\03\ca\ff\ee\01\61"    !: (func () -> ()) "func: no tag";
-assert blob "DIDL\01\6a\01\69\01\7d\00\01\00\01\01\03\ca\ff\ee\03\66\6f\6f" !: (func (service {}) -> (nat)) "func: service not in type table";
-assert blob "DIDL\01\6a\01\71\01\7d\01\03\01\00\01\01\03\ca\ff\ee\03\66\6f\6f" !: (func (text) -> (nat)) "func: invalid annotation";
+assert blob "DIDL\01\6a\01\69\01\7d\00\01\00\01\01\03\ca\ff\ee\03foo" !: (func (service {}) -> (nat)) "func: service not in type table";
+assert blob "DIDL\01\6a\01\71\01\7d\01\03\01\00\01\01\03\ca\ff\ee\03foo" !: (func (text) -> (nat)) "func: invalid annotation";
+
+// coercion does not look at type table
+assert blob "DIDL\01\69\00\01\00\01\03\ca\ff\ee" == "(service \"w7x7r-cok77-xa\")" : (service { foo : (text) -> (nat) }) "service {} decodes at service { foo : (text) -> (nat) }";
+assert blob "DIDL\02\6a\01\71\01\7d\00\69\01\03foo\00\01\01\01\03\ca\ff\ee" == "(service \"w7x7r-cok77-xa\")" : (service {}) "service { foo : (text) -> (nat) } decodes at service {}";
+
+assert blob "DIDL\01\6a\00\00\00\01\00\01\01\03\ca\ff\ee\03foo" == "(func \"w7x7r-cok77-xa\".foo)" : (func (text) -> (nat)) "func () -> () decodes at func (text) -> (nat) }";
+assert blob "DIDL\01\6a\01\71\01\7d\00\01\00\01\01\03\ca\ff\ee\03foo" == "(func \"w7x7r-cok77-xa\".foo)" : (func () -> ()) "func (text) -> (nat) decodes at func () -> () }";


### PR DESCRIPTION
I think we didn’t have any that asserted that a decoder does not do a
subtyping check, which means that any service (func) reference decodes
at any expected service (func) type.