### PR TITLE
candid asts as candid data

### DIFF
--- a/rust/candid/src/parser/types.rs
+++ b/rust/candid/src/parser/types.rs
@@ -1,22 +1,33 @@
 use crate::types::Label;
 use crate::Result;
 use pretty::RcDoc;
+use crate::{CandidType, Deserialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Hash)]
 pub enum IDLType {
+    #[serde(rename(serialize = "prim", deserialize = "prim"))]
     PrimT(PrimType),
+    #[serde(rename(serialize = "var", deserialize = "var"))]
     VarT(String),
+    #[serde(rename(serialize = "func", deserialize = "func"))]
     FuncT(FuncType),
+    #[serde(rename(serialize = "opt", deserialize = "opt"))]
     OptT(Box<IDLType>),
+    #[serde(rename(serialize = "vec", deserialize = "vec"))]
     VecT(Box<IDLType>),
+    #[serde(rename(serialize = "record", deserialize = "record"))]
     RecordT(Vec<TypeField>),
+    #[serde(rename(serialize = "variant", deserialize = "variant"))]
     VariantT(Vec<TypeField>),
+    #[serde(rename(serialize = "service", deserialize = "service"))]
     ServT(Vec<Binding>),
+    #[serde(rename(serialize = "class", deserialize = "class"))]
     ClassT(Vec<IDLType>, Box<IDLType>),
+    #[serde(rename(serialize = "principal", deserialize = "principal"))]
     PrincipalT,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Hash)]
 pub struct IDLTypes {
     pub args: Vec<IDLType>,
 }
@@ -25,7 +36,7 @@ macro_rules! enum_to_doc {
     (pub enum $name:ident {
         $($variant:ident),*,
     }) => {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
         pub enum $name {
             $($variant),*
         }
@@ -72,7 +83,7 @@ pub enum FuncMode {
     Query,
 }}
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Hash)]
 pub struct FuncType {
     pub modes: Vec<FuncMode>,
     pub args: Vec<IDLType>,
@@ -90,25 +101,25 @@ impl FuncType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Hash)]
 pub struct TypeField {
     pub label: Label,
     pub typ: IDLType,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Hash)]
 pub enum Dec {
     TypD(Binding),
     ImportD(String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Hash)]
 pub struct Binding {
     pub id: String,
     pub typ: IDLType,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Hash)]
 pub struct IDLProg {
     pub decs: Vec<Dec>,
     pub actor: Option<IDLType>,

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -4,6 +4,7 @@ use num_enum::TryFromPrimitive;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
+use crate::Deserialize;
 
 // This is a re-implementation of std::any::TypeId to get rid of 'static constraint.
 // The current TypeId doesn't consider lifetime while computing the hash, which is
@@ -212,7 +213,7 @@ impl fmt::Display for Type {
     }
 }
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Eq, Clone, Deserialize)]
 pub enum Label {
     Id(u32),
     Named(String),


### PR DESCRIPTION
- [x] derive equality and cloning for ASTs of candid types (type `IDLType` and related types)
- [x] derive (binary) deserializer for ASTs of candid types
- [ ] derive (binary) serializer for ASTs of candid types --- had trouble using the directive, because of a crate-path issue?

#### Back story

Note that this is asking for candid asts in Rust to be usable as candid data, not as a plaintext string.  Plaintext forms for candid types are supported in Rust, but not in every language (not in Motoko).  By converting these ASTs, as data, into candid binary form, we can send them to canisters that act on them as ASTs (as data, not as strings) and get these ASTs back without re-doing the pretty printer for candid types.