### PR TITLE
fix typescript binding for references

### DIFF
--- a/rust/candid/tests/assets/ok/actor.d.ts
+++ b/rust/candid/tests/assets/ok/actor.d.ts
@@ -4,10 +4,10 @@ export type f = (
     arg_0: number,
   ) => Promise<number>;
 export type g = f;
-export type h = (arg_0: f) => Promise<f>;
+export type h = (arg_0: [Principal, string]) => Promise<[Principal, string]>;
 export type o = [] | [o];
 export default interface _SERVICE {
-  'f' : (arg_0: BigNumber) => Promise<h>,
+  'f' : (arg_0: BigNumber) => Promise<[Principal, string]>,
   'g' : f,
   'h' : g,
   'o' : (arg_0: o) => Promise<o>,

--- a/rust/candid/tests/assets/ok/example.d.ts
+++ b/rust/candid/tests/assets/ok/example.d.ts
@@ -3,15 +3,10 @@ import type BigNumber from 'bignumber.js';
 export type List = [] | [
   { 'head' : BigNumber, 'tail' : List }
 ];
-export interface broker {
-  'find' : (arg_0: string) => Promise<
-      { 'current' : () => Promise<number>, 'up' : () => Promise<undefined> }
-    >,
-};
-export type f = (
-    arg_0: List,
-    arg_1: (arg_0: number) => Promise<BigNumber>,
-  ) => Promise<[] | [List]>;
+export interface broker { 'find' : (arg_0: string) => Promise<Principal> };
+export type f = (arg_0: List, arg_1: [Principal, string]) => Promise<
+    [] | [List]
+  >;
 export type my_type = Principal;
 export interface nested {
   _0_ : BigNumber,
@@ -32,7 +27,7 @@ export default interface _SERVICE {
       arg_1: List,
       arg_2: [] | [List],
       arg_3: nested,
-    ) => Promise<[BigNumber, broker]>,
+    ) => Promise<[BigNumber, Principal]>,
   'h' : (
       arg_0: Array<[] | [string]>,
       arg_1: { 'A' : BigNumber } |

--- a/rust/candid/tests/assets/ok/recursion.d.ts
+++ b/rust/candid/tests/assets/ok/recursion.d.ts
@@ -9,9 +9,9 @@ export interface s {
   'g' : (arg_0: list) => Promise<[B, tree, stream]>,
 };
 export type stream = [] | [
-  { 'head' : BigNumber, 'next' : () => Promise<stream> }
+  { 'head' : BigNumber, 'next' : [Principal, string] }
 ];
-export type t = (arg_0: s) => Promise<undefined>;
+export type t = (arg_0: Principal) => Promise<undefined>;
 export type tree = {
     'branch' : { 'val' : BigNumber, 'left' : tree, 'right' : tree }
   } |

--- a/rust/candid/tests/assets/ok/recursive_class.d.ts
+++ b/rust/candid/tests/assets/ok/recursive_class.d.ts
@@ -1,6 +1,6 @@
 import type { Principal } from '@dfinity/agent';
 import type BigNumber from 'bignumber.js';
 export interface s {
-  'next' : () => Promise<s>,
+  'next' : () => Promise<Principal>,
 };
 export default s;


### PR DESCRIPTION
Function/service types has two forms: 1) as a value, it's a principal id; 2) as a type signature, it's a function/service interface. 

In typescript binding, we need to distinguish the two cases: Only show type signatures for the top-level service/function definitions. The input/output arguments are always of principal type.