### PR TITLE
Tests: Test width subtyping for binary and textual form separately

### DIFF
--- a/test/construct.test.did
+++ b/test/construct.test.did
@@ -64,7 +64,8 @@ assert blob "DIDL\02\6d\01\6c\00\01\00\05"                                  : (v
 assert blob "DIDL\01\6c\00\01\00" == "(record {})"                                : (record {}) "record: empty";
 assert blob "DIDL\01\6c\00\03\00\00\00" == "(record {}, record {}, record {})"    : (record {}, record {}, record {}) "record: multiple records";
 assert blob "DIDL\01\6c\01\01\7c\01\00\2a" == "(record { 1 = 42 })"               : (record {1:int}) "record";
-assert blob "DIDL\01\6c\01\01\7c\01\00\2a" == "(record { whatever = 0 })"         : (record {}) "record: ignore fields";
+assert blob "DIDL\01\6c\01\01\7c\01\00\2a" == "(record {})"                       : (record {}) "record: ignore fields";
+assert "(record { whatever = 0 })"  == "(record {})"                              : (record {}) "record: ignore fields (textual)";
 assert blob "DIDL\01\6c\01\01\7c\01\00\2a"                                       !: (record {2:int}) "record: missing field";
 assert blob "DIDL\01\6c\02\00\7c\01\7e\01\00\2a\01" == "(record {42; true})"      : (record {int; bool}) "record: tuple";
 assert blob "DIDL\01\6c\02\00\7c\01\7e\01\00\2a\01" == "(record {1 = true})"      : (record {1:bool}) "record: ignore fields";


### PR DESCRIPTION
this increases the signal, and helps Motoko, which can only process test
cases where the textual representation does not use subtyping.