### PR TITLE
Add benchmark for Rust library

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,5 +22,6 @@ jobs:
         key: ${{ runner.os }}-bench-${{ hashFiles('**/Cargo.lock') }}
     - uses: jasonwilliams/criterion-compare-action@move_to_actions
       with:
-        cwd: "rust/candid"
+        cwd: rust/candid
+        benchName: benchmark
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,7 +20,7 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-bench-${{ hashFiles('**/Cargo.lock') }}
-    - uses: jasonwilliams/criterion-compare-action@master
+    - uses: boa-dev/criterion-compare-action@v2
       with:
         cwd: rust/candid
         benchName: benchmark

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,7 +5,9 @@ jobs:
     name: run benchmark
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 0
     - name: Install stable toolchain
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,7 +20,7 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-bench-${{ hashFiles('**/Cargo.lock') }}
-    - uses: jasonwilliams/criterion-compare-action@v2
+    - uses: jasonwilliams/criterion-compare-action@master
       with:
         cwd: rust/candid
         benchName: benchmark

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,7 +20,7 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-bench-${{ hashFiles('**/Cargo.lock') }}
-    - uses: boa-dev/criterion-compare-action@v2
+    - uses: boa-dev/criterion-compare-action@master
       with:
         cwd: rust/candid
         benchName: benchmark

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -25,5 +25,5 @@ jobs:
     - uses: boa-dev/criterion-compare-action@master
       with:
         cwd: rust/candid
-        benchName: benchmark
+        benchName: benchmark  # needed to address https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,7 +20,7 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-bench-${{ hashFiles('**/Cargo.lock') }}
-    - uses: jasonwilliams/criterion-compare-action@move_to_actions
+    - uses: jasonwilliams/criterion-compare-action@v2
       with:
         cwd: rust/candid
         benchName: benchmark

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,26 @@
+name: Rust Bench
+on: [pull_request]
+jobs:
+  runBenchMark:
+    name: run benchmark
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install stable toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Cache cargo build
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-bench-${{ hashFiles('**/Cargo.lock') }}
+    - uses: jasonwilliams/criterion-compare-action@move_to_actions
+      with:
+        cwd: "rust/candid"
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -235,6 +236,7 @@ dependencies = [
  "byteorder",
  "candid_derive",
  "codespan-reporting",
+ "criterion",
  "fake",
  "goldenfile",
  "hex",
@@ -278,6 +280,15 @@ dependencies = [
  "predicates",
  "pretty 0.10.0",
  "structopt",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -355,6 +366,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools 0.10.0",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+dependencies = [
+ "cast",
+ "itertools 0.9.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +451,28 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "derivative"
@@ -1015,6 +1118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "memoffset"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,6 +1272,12 @@ name = "once_cell"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -1349,6 +1467,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
+name = "plotters"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1682,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,10 +1815,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1658,6 +1847,12 @@ dependencies = [
  "lazy_static",
  "winapi",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
@@ -1681,6 +1876,21 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1975,6 +2185,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,6 +2404,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,16 +367,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+checksum = "63f696897c88b57f4ffe3c69d8e1a0613c7d0e6c4833363c8560fbde9c47b966"
 dependencies = [
  "atty",
  "cast",
  "clap",
  "criterion-plot",
  "csv",
- "itertools 0.10.0",
+ "itertools 0.9.0",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -384,7 +384,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -1468,30 +1467,14 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
-version = "0.3.0"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+checksum = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
 dependencies = [
+ "js-sys",
  "num-traits",
- "plotters-backend",
- "plotters-svg",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
-dependencies = [
- "plotters-backend",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -482,7 +482,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -519,7 +519,7 @@ dependencies = [
  "itertools 0.9.0",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -592,9 +592,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elsa"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0daf12e2857c9485cb2386b18a9ecd5a17c7cee2fd10afb87d436b10ced678e7"
+checksum = "848344296205756adc00ab3bec02658da0f72eaa1461474aa2d51d64311876a5"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -956,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "log"
@@ -1095,7 +1095,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "regex-syntax",
- "syn 1.0.60",
+ "syn 1.0.62",
  "utf8-ranges",
 ]
 
@@ -1207,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
+checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1264,7 +1264,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -1366,7 +1366,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -1389,7 +1389,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -1445,7 +1445,7 @@ checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -1578,7 +1578,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
  "version_check",
 ]
 
@@ -1856,9 +1856,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfd318104249865096c8da1dfabf09ddbb6d0330ea176812a62ec75e40c4166"
+checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1894,9 +1894,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
@@ -1922,13 +1922,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -2066,7 +2066,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "123a78a3596b24fee53a6464ce52d8ecbf62241e6294c7e7fe12086cd161f512"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -2163,7 +2163,7 @@ checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -2462,7 +2462,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
  "wasm-bindgen-shared",
 ]
 
@@ -2496,7 +2496,7 @@ checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.62",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -45,7 +45,7 @@ rand = { version = "0.8", optional = true }
 goldenfile = "1.1.0"
 test-generator = "0.3.0"
 rand = "0.8"
-iai = { git = "https://github.com/bheisler/iai.git", branch = "main" }
+criterion = "0.3"
 
 [[bench]]
 name = "benchmark"

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -45,6 +45,11 @@ rand = { version = "0.8", optional = true }
 goldenfile = "1.1.0"
 test-generator = "0.3.0"
 rand = "0.8"
+iai = { git = "https://github.com/bheisler/iai.git", branch = "main" }
+
+[[bench]]
+name = "benchmark"
+harness = false
 
 [features]
 cdk = ["candid_derive/cdk"]

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -45,7 +45,7 @@ rand = { version = "0.8", optional = true }
 goldenfile = "1.1.0"
 test-generator = "0.3.0"
 rand = "0.8"
-criterion = "0.3"
+criterion = "=0.3.2"
 
 [[bench]]
 name = "benchmark"

--- a/rust/candid/benches/benchmark.rs
+++ b/rust/candid/benches/benchmark.rs
@@ -1,15 +1,98 @@
-use iai::{main};
-use candid::{CandidType, Deserialize, Encode, Decode, Result};
+use candid::{CandidType, Decode, Deserialize, Encode, Principal};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 
-fn test_str() -> Result<()> {
-    #[derive(CandidType, Deserialize)]
-    struct A {
-        inner: Vec<u8>
-    }
-    let vec: Vec<u8> = vec![0; 1024];
-    let bytes = Encode!(&A{inner: vec})?;
-    let _ = Decode!(&bytes, A)?;
-    Ok(())
+fn bench_blob(c: &mut Criterion) {
+    use serde_bytes::{ByteBuf, Bytes};
+    let vec: Vec<u8> = vec![0x61; 524288];
+    let mut group = c.benchmark_group("Blob");
+    /*group.bench_function("Vector", |b| {
+        b.iter_batched(
+            || vec.clone(),
+            |vec| {
+                let bytes = Encode!(&vec).unwrap();
+                Decode!(&bytes, Vec<u8>).unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });*/
+    group.bench_function("ByteBuf", |b| {
+        b.iter_batched(
+            || vec.clone(),
+            |vec| {
+                let bytes = Encode!(&ByteBuf::from(vec)).unwrap();
+                Decode!(&bytes, ByteBuf).unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("Bytes", |b| {
+        b.iter_batched_ref(
+            || vec.clone(),
+            |vec| {
+                let bytes = Encode!(&Bytes::new(vec)).unwrap();
+                Decode!(&bytes, &Bytes).unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    let text = String::from_utf8(vec).unwrap();
+    group.bench_function("String", |b| {
+        b.iter_batched(
+            || text.clone(),
+            |text| {
+                let bytes = Encode!(&text).unwrap();
+                Decode!(&bytes, String).unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("&str", |b| {
+        b.iter_batched_ref(
+            || text.clone(),
+            |text| {
+                let bytes = Encode!(text).unwrap();
+                Decode!(&bytes, &str).unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
 }
 
-main!(test_str);
+fn bench_profile(c: &mut Criterion) {
+    #[derive(CandidType, Deserialize, Clone)]
+    struct Profile {
+        id: Principal,
+        imgUrl: String,
+        title: String,
+        education: String,
+        experience: String,
+        company: String,
+        lastName: String,
+        firstName: String,
+    }
+    let profile = Profile {
+        id: Principal::from_text("27u75-h7div-y6axr-knc2i-3bsij-dr5wo-jdb5t-ndd2n-mh22v-ooz2s-iqe").unwrap(),
+        firstName: "Dominic".to_string(),
+        lastName: "Williams".to_string(),
+        title: "Founder & Chief Scientist".to_string(),
+        company: "DFINITY".to_string(),
+        experience: "**President & Chief Scientist**, DFINITY  \nJan 2015 – Present  \nPalo Alto, CA\n\n**President & CTO**, String Labs, Inc  \nJun 2015 – Feb 2018  \nPalo Alto, CA".to_string(),
+        education: "**King's College London**  \nBA, Computer Science".to_string(),
+        imgUrl: "https://media-exp1.licdn.com/dms/image/C5603AQHdxGV6zMbg-A/profile-displayphoto-shrink_200_200/0?e=1592438400&v=beta&t=NlR0J9mgJXd3SO6K3YJ6xBC_wCip20u5THPNKu6ImYQ".to_string(),
+    };
+    let profiles: Vec<_> = std::iter::repeat(profile).take(500).collect();
+    c.bench_with_input(
+        BenchmarkId::new("profiles", profiles.len()),
+        &profiles,
+        |b, vec| {
+            b.iter(|| {
+                let bytes = Encode!(vec).unwrap();
+                Decode!(&bytes, Vec<Profile>).unwrap()
+            })
+        },
+    );
+}
+
+criterion_group!(benches, bench_blob, bench_profile);
+criterion_main!(benches);

--- a/rust/candid/benches/benchmark.rs
+++ b/rust/candid/benches/benchmark.rs
@@ -82,7 +82,7 @@ fn bench_profile(c: &mut Criterion) {
         education: "**King's College London**  \nBA, Computer Science".to_string(),
         imgUrl: "https://media-exp1.licdn.com/dms/image/C5603AQHdxGV6zMbg-A/profile-displayphoto-shrink_200_200/0?e=1592438400&v=beta&t=NlR0J9mgJXd3SO6K3YJ6xBC_wCip20u5THPNKu6ImYQ".to_string(),
     };
-    let profiles: Vec<_> = std::iter::repeat(profile).take(500).collect();
+    let profiles: Vec<_> = std::iter::repeat(profile).take(200).collect();
     c.bench_with_input(
         BenchmarkId::new("profiles", profiles.len()),
         &profiles,

--- a/rust/candid/benches/benchmark.rs
+++ b/rust/candid/benches/benchmark.rs
@@ -1,0 +1,15 @@
+use iai::{main};
+use candid::{CandidType, Deserialize, Encode, Decode, Result};
+
+fn test_str() -> Result<()> {
+    #[derive(CandidType, Deserialize)]
+    struct A {
+        inner: Vec<u8>
+    }
+    let vec: Vec<u8> = vec![0; 1024];
+    let bytes = Encode!(&A{inner: vec})?;
+    let _ = Decode!(&bytes, A)?;
+    Ok(())
+}
+
+main!(test_str);

--- a/rust/candid/benches/benchmark.rs
+++ b/rust/candid/benches/benchmark.rs
@@ -61,6 +61,7 @@ fn bench_blob(c: &mut Criterion) {
 
 fn bench_profile(c: &mut Criterion) {
     #[derive(CandidType, Deserialize, Clone)]
+    #[allow(non_snake_case)]
     struct Profile {
         id: Principal,
         imgUrl: String,

--- a/rust/candid/src/types/impls.rs
+++ b/rust/candid/src/types/impls.rs
@@ -317,6 +317,23 @@ where
         (**self).idl_serialize(serializer)
     }
 }
+impl<'a, T> CandidType for &'a mut T
+where
+    T: ?Sized + CandidType,
+{
+    fn id() -> TypeId {
+        TypeId::of::<&T>()
+    } // ignore lifetime
+    fn _ty() -> Type {
+        T::ty()
+    }
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: Serializer,
+    {
+        (**self).idl_serialize(serializer)
+    }
+}
 
 impl<'a, T> CandidType for std::borrow::Cow<'a, T>
 where


### PR DESCRIPTION
Add `cargo bench` for performance testing. This will be useful to access the performance implications for adding subtyping check during decoding.

Two benchmarks for now: 1) large blob; 2) vector of profiles.

Since `criterion` and `bench` measures wall time, it is not very robust to put this in the CI. Instrumenting the Wasm is another option, but it will instrument the whole binary, instead of just the encoding/decoding code?