### PR TITLE
fix: disallow sharing of memo table in IDLBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "candid"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "arbitrary",
  "byteorder",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.6.18"
+version = "0.6.19"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -19,6 +19,10 @@ pub struct IDLBuilder {
 
 impl IDLBuilder {
     pub fn new() -> Self {
+        // We cannot share the memo table across different Builder. Because the same Rust
+        // type can map to a different but equivalent candid type for different builder,
+        // due to memo match happening in different time/order.
+        types::internal::env_clear();
         IDLBuilder {
             type_ser: TypeSerialize::new(),
             value_ser: ValueSerializer::new(),

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -374,6 +374,9 @@ pub(crate) fn show_env() {
 pub(crate) fn env_add(id: TypeId, t: Type) {
     ENV.with(|e| drop(e.borrow_mut().insert(id, t)));
 }
+pub(crate) fn env_clear() {
+    ENV.with(|e| e.borrow_mut().clear());
+}
 
 pub(crate) fn env_id(id: TypeId, t: Type) {
     // prefer shorter type names

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -222,6 +222,39 @@ fn test_struct() {
 }
 
 #[test]
+fn test_equivalent_types() {
+    #[derive(PartialEq, Debug, Deserialize, CandidType)]
+    struct RootType {
+        typeas: Vec<TypeA>,
+    }
+    #[derive(PartialEq, Debug, Deserialize, CandidType)]
+    struct TypeA {
+        typeb: Box<Option<TypeB>>,
+    }
+    #[derive(PartialEq, Debug, Deserialize, CandidType)]
+    struct TypeB {
+        typea: Option<TypeA>,
+    }
+    // Encode to the following types leads to equivalent but different representations of TypeA
+    all_check(
+        RootType { typeas: Vec::new() },
+        "4449444c066c01acd4dbb905016d026c01e8e0add601036e046c01e7e0add601056e02010000",
+    );
+    all_check(
+        TypeB { typea: None },
+        "4449444c046c01e7e0add601016e026c01e8e0add601036e00010000",
+    );
+    Encode!(
+        &RootType { typeas: Vec::new() },
+        &TypeB { typea: None },
+        &TypeA {
+            typeb: Box::new(None)
+        }
+    )
+    .unwrap();
+}
+
+#[test]
 fn test_extra_fields() {
     #[derive(PartialEq, Debug, Deserialize, CandidType)]
     struct A1 {


### PR DESCRIPTION
We use a global memo table to map Rust type to Candid type. The same Rust type can map to a different but equivalent Candid type in different runs, due to memo match happen in different time/order. Unless we implement equivalence checking for candid types, we failed to identify these equivalent types in the type table. 

The fix is easy: disallow sharing of memo tables across different encoding calls.