### PR TITLE
Change the version label from master to latest

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,2 +1,2 @@
 name: docs
-version: 'master'
+version: 'latest'


### PR DESCRIPTION
**Overview**
To be more PC and "accurate" changing the label for the docs bucket from "master" to "latest"

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
