### PR TITLE
Fix broken link?

### DIFF
--- a/docs/modules/candid-guide/pages/candid-concepts.adoc
+++ b/docs/modules/candid-guide/pages/candid-concepts.adoc
@@ -293,4 +293,4 @@ Therefore, if you write a program for a service in Rust or C, you need to write 
 For examples of how to write Candid service descriptions for Rust programs, see the link:https://github.com/dfinity/cdk-rs/tree/next/examples[Rust CDK examples] and the link:../rust-guide/rust-intro{outfilesuffix}[Rust tutorials].
 
 Regardless of the host language you use, it is important to know the mapping between host language types and Candid types.
-In the link:../candid-types{outfilesuffix}[Supported types] reference section, you'll find Candid type mapping described for Motoko, Rust, and JavaScript.
+In the link:candid-types{outfilesuffix}[Supported types] reference section, you'll find Candid type mapping described for Motoko, Rust, and JavaScript.


### PR DESCRIPTION
https://sdk.dfinity.org/docs/candid-guide/candid-concepts.html has a broken link to
 [Supported types](https://sdk.dfinity.org/docs/candid-types.html)

which should be  [Supported types](https://sdk.dfinity.org/docs/candid-guide/candid-types.html)

I hope this fixes it.