### PR TITLE
feat: move CandidType cache to CandidTypeCache trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "arbitrary",
  "binread",
  "byteorder",
+ "candid_common",
  "candid_derive",
  "codespan-reporting",
  "criterion",
@@ -277,9 +278,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "candid_common"
+version = "1.0.0"
+
+[[package]]
 name = "candid_derive"
 version = "0.4.4"
 dependencies = [
+ "candid_common",
  "lazy_static",
  "proc-macro2 1.0.27",
  "quote 1.0.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "rust/candid",
+    "rust/candid_common",
     "rust/candid_derive",
     "tools/candiff",
     "tools/didc",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -20,6 +20,7 @@ lalrpop = "0.19.0"
 
 [dependencies]
 byteorder = "1.4.3"
+candid_common = { path = "../candid_common", version = "1.0" }
 candid_derive = { path = "../candid_derive", version = "=0.4.4" }
 codespan-reporting = "0.11"
 hex = "0.4.2"

--- a/rust/candid/src/bindings/analysis.rs
+++ b/rust/candid/src/bindings/analysis.rs
@@ -58,7 +58,7 @@ pub fn chase_types<'a>(env: &'a TypeEnv, tys: &'a [Type]) -> crate::Result<Vec<&
     let mut seen = BTreeSet::new();
     let mut res = Vec::new();
     for t in tys.iter() {
-        chase_type(&mut seen, &mut res, env, &t)?;
+        chase_type(&mut seen, &mut res, env, t)?;
     }
     Ok(res)
 }
@@ -111,7 +111,7 @@ pub fn infer_rec<'a>(
     }
     for var in def_list.iter() {
         let t = env.0.get(*var).unwrap();
-        go(&mut seen, &mut res, env, &t)?;
+        go(&mut seen, &mut res, env, t)?;
         seen.insert(var);
     }
     Ok(res)

--- a/rust/candid/src/bindings/candid.rs
+++ b/rust/candid/src/bindings/candid.rs
@@ -107,7 +107,7 @@ pub fn pp_ty(ty: &Type) -> RcDoc {
         Func(ref func) => kwd("func").append(pp_function(func)),
         Service(ref serv) => kwd("service").append(pp_service(serv)),
         Class(ref args, ref t) => {
-            let doc = pp_args(&args).append(" ->").append(RcDoc::space());
+            let doc = pp_args(args).append(" ->").append(RcDoc::space());
             match t.as_ref() {
                 Service(ref serv) => doc.append(pp_service(serv)),
                 Var(ref s) => doc.append(s),

--- a/rust/candid/src/bindings/javascript.rs
+++ b/rust/candid/src/bindings/javascript.rs
@@ -252,10 +252,10 @@ pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {
             let body = defs.append(actor);
             let doc = str("export default ({ IDL }) => ").append(enclose_space("{", body, "};"));
             // export init args
-            let init_defs = chase_types(env, &init).unwrap();
+            let init_defs = chase_types(env, init).unwrap();
             let init_recs = infer_rec(env, &init_defs).unwrap();
             let init_defs_doc = pp_defs(env, &init_defs, &init_recs);
-            let init_doc = kwd("return").append(pp_args(&init)).append(";");
+            let init_doc = kwd("return").append(pp_args(init)).append(";");
             let init_doc = init_defs_doc.append(init_doc);
             let init_doc =
                 str("export const init = ({ IDL }) => ").append(enclose_space("{", init_doc, "};"));
@@ -333,7 +333,7 @@ pub mod value {
                     let tuple = concat(fields.iter().map(|f| pp_value(&f.val)), ",");
                     enclose_space("[", tuple, "]")
                 } else {
-                    enclose_space("{", pp_fields(&fields), "}")
+                    enclose_space("{", pp_fields(fields), "}")
                 }
             }
             Variant(v) => enclose_space("{", pp_field(&v.0), "}"),
@@ -359,16 +359,16 @@ pub mod test {
             .append("', 'hex')")
     }
     fn pp_encode<'a>(args: &'a crate::IDLArgs, tys: &'a [crate::types::Type]) -> RcDoc<'a> {
-        let vals = value::pp_args(&args);
-        let tys = super::pp_args(&tys);
+        let vals = value::pp_args(args);
+        let tys = super::pp_args(tys);
         let items = [tys, vals];
         let params = concat(items.iter().cloned(), ",");
         str("IDL.encode").append(enclose("(", params, ")"))
     }
 
     fn pp_decode<'a>(bytes: &'a [u8], tys: &'a [crate::types::Type]) -> RcDoc<'a> {
-        let hex = pp_hex(&bytes);
-        let tys = super::pp_args(&tys);
+        let hex = pp_hex(bytes);
+        let tys = super::pp_args(tys);
         let items = [tys, hex];
         let params = concat(items.iter().cloned(), ",");
         str("IDL.decode").append(enclose("(", params, ")"))
@@ -403,11 +403,11 @@ import { Principal } from './principal';
                 use HostAssert::*;
                 let test_func = match cmd {
                     Encode(args, tys, _, _) | NotEncode(args, tys) => {
-                        let items = [super::pp_args(&tys), pp_encode(&args, &tys)];
+                        let items = [super::pp_args(tys), pp_encode(args, tys)];
                         let params = concat(items.iter().cloned(), ",");
                         str("IDL.decode").append(enclose("(", params, ")"))
                     }
-                    Decode(bytes, tys, _, _) | NotDecode(bytes, tys) => pp_decode(&bytes, &tys),
+                    Decode(bytes, tys, _, _) | NotDecode(bytes, tys) => pp_decode(bytes, tys),
                 };
                 let (test_func, predicate) = match cmd {
                     Encode(_, _, true, _) | Decode(_, _, true, _) => (test_func, str(".toEqual")),
@@ -419,8 +419,8 @@ import { Principal } from './principal';
                     }
                 };
                 let expected = match cmd {
-                    Encode(_, tys, _, bytes) => pp_decode(&bytes, &tys),
-                    Decode(_, _, _, vals) => value::pp_args(&vals),
+                    Encode(_, tys, _, bytes) => pp_decode(bytes, tys),
+                    Decode(_, _, _, vals) => value::pp_args(vals),
                     NotEncode(_, _) | NotDecode(_, _) => RcDoc::nil(),
                 };
                 let expect = enclose("expect(", test_func, ")")

--- a/rust/candid/src/bindings/motoko.rs
+++ b/rust/candid/src/bindings/motoko.rs
@@ -125,7 +125,7 @@ fn pp_ty(ty: &Type) -> RcDoc {
         Func(ref func) => pp_function(func),
         Service(ref serv) => pp_service(serv),
         Class(ref args, ref t) => {
-            let doc = pp_args(&args).append(" -> async ");
+            let doc = pp_args(args).append(" -> async ");
             match t.as_ref() {
                 Service(ref serv) => doc.append(pp_service(serv)),
                 Var(ref s) => doc.append(s),

--- a/rust/candid/src/codegen/rust.rs
+++ b/rust/candid/src/codegen/rust.rs
@@ -379,10 +379,7 @@ impl<'a> LanguageBinding for RustLanguageBinding<'a> {
 
 /// Takes an IDL string and returns a Rust string, unformatted.
 pub fn idl_to_rust(prog: &IDLProg, config: &Config) -> Result<String> {
-    let binding = RustLanguageBinding {
-        config,
-        prog,
-    };
+    let binding = RustLanguageBinding { config, prog };
 
     generate_code(prog, binding)
 }

--- a/rust/candid/src/codegen/rust.rs
+++ b/rust/candid/src/codegen/rust.rs
@@ -33,7 +33,7 @@ pub fn candid_id_to_rust(id: &str) -> String {
     if id.starts_with(|c: char| !c.is_ascii_alphabetic() && c != '_')
         || id.chars().any(|c| !c.is_ascii_alphanumeric() && c != '_')
     {
-        format!("_{}_", idl_hash(&id))
+        format!("_{}_", idl_hash(id))
     } else if is_keyword(id) {
         format!("r#{}", id)
     } else {
@@ -270,16 +270,16 @@ impl<'a> LanguageBinding for RustLanguageBinding<'a> {
 
     fn declare(&self, id: &str, ty: &IDLType) -> Result<String> {
         match ty {
-            IDLType::PrimT(prim) => self.declare_prim(&id, prim),
-            IDLType::VarT(var) => self.declare_var(&id, var),
-            IDLType::FuncT(func) => self.declare_func(&id, func),
-            IDLType::OptT(sub_t) => self.declare_opt(&id, sub_t.as_ref()),
-            IDLType::VecT(item_t) => self.declare_vec(&id, item_t.as_ref()),
-            IDLType::RecordT(fields) => self.declare_record(&id, fields),
-            IDLType::VariantT(fields) => self.declare_variant(&id, fields),
-            IDLType::ServT(serv_t) => self.declare_service(&id, serv_t),
+            IDLType::PrimT(prim) => self.declare_prim(id, prim),
+            IDLType::VarT(var) => self.declare_var(id, var),
+            IDLType::FuncT(func) => self.declare_func(id, func),
+            IDLType::OptT(sub_t) => self.declare_opt(id, sub_t.as_ref()),
+            IDLType::VecT(item_t) => self.declare_vec(id, item_t.as_ref()),
+            IDLType::RecordT(fields) => self.declare_record(id, fields),
+            IDLType::VariantT(fields) => self.declare_variant(id, fields),
+            IDLType::ServT(serv_t) => self.declare_service(id, serv_t),
             IDLType::ClassT(_, _) => unreachable!(),
-            IDLType::PrincipalT => self.declare_var(&id, "principal"),
+            IDLType::PrincipalT => self.declare_var(id, "principal"),
         }
     }
     fn declare_prim(&self, id: &str, ty: &PrimType) -> Result<String> {
@@ -356,7 +356,7 @@ impl<'a> LanguageBinding for RustLanguageBinding<'a> {
                         .enumerate()
                         .map(|(i, ty)| {
                             let arg_name = format!("arg{}", i);
-                            let ty = self.usage(&ty)?;
+                            let ty = self.usage(ty)?;
 
                             Ok((arg_name, ty))
                         })
@@ -381,8 +381,8 @@ impl<'a> LanguageBinding for RustLanguageBinding<'a> {
 pub fn idl_to_rust(prog: &IDLProg, config: &Config) -> Result<String> {
     let binding = RustLanguageBinding {
         config,
-        prog: &prog,
+        prog,
     };
 
-    generate_code(&prog, binding)
+    generate_code(prog, binding)
 }

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -670,7 +670,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 let wire = w[index].clone();
                 let expect = e
                     .iter()
-                    .find(|ref f| f.id == wire.id)
+                    .find(|f| f.id == wire.id)
                     .ok_or_else(|| Error::msg(format!("Unknown variant field {}", wire.id)))?
                     .clone();
                 visitor.visit_enum(Compound::new(&mut self, Style::Enum { expect, wire }))

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -3,8 +3,8 @@
 use super::error::{Error, Result};
 use super::{
     parser::typing::TypeEnv,
-    types::{Field, Label, Type},
-    CandidType, Int, Nat,
+    types::{CandidTyping, Field, Label, Type},
+    Int, Nat,
 };
 use crate::binary_parser::{BoolValue, Header, Len, PrincipalBytes};
 use crate::types::subtype::{subtype, Gamma};
@@ -29,7 +29,7 @@ impl<'de> IDLDeserialize<'de> {
     /// Deserialize one value from deserializer.
     pub fn get_value<T>(&mut self) -> Result<T>
     where
-        T: de::Deserialize<'de> + CandidType,
+        T: de::Deserialize<'de> + CandidTyping,
     {
         self.de.is_untyped = false;
         self.deserialize_with_type(T::ty())
@@ -45,7 +45,7 @@ impl<'de> IDLDeserialize<'de> {
     }
     fn deserialize_with_type<T>(&mut self, expected_type: Type) -> Result<T>
     where
-        T: de::Deserialize<'de> + CandidType,
+        T: de::Deserialize<'de>,
     {
         let expected_type = self.de.table.trace_type(&expected_type)?;
         if self.de.types.is_empty() {

--- a/rust/candid/src/error.rs
+++ b/rust/candid/src/error.rs
@@ -40,11 +40,11 @@ impl Error {
                         Label::primary((), *location..location + 1).with_message("Invalid token")
                     }
                     UnrecognizedEOF { location, expected } => {
-                        diag = diag.with_notes(report_expected(&expected));
+                        diag = diag.with_notes(report_expected(expected));
                         Label::primary((), *location..location + 1).with_message("Unexpected EOF")
                     }
                     UnrecognizedToken { token, expected } => {
-                        diag = diag.with_notes(report_expected(&expected));
+                        diag = diag.with_notes(report_expected(expected));
                         Label::primary((), token.0..token.2).with_message("Unexpected token")
                     }
                     ExtraToken { token } => {

--- a/rust/candid/src/lib.rs
+++ b/rust/candid/src/lib.rs
@@ -330,13 +330,5 @@ pub mod pretty;
 // Candid hash function comes from
 // https://caml.inria.fr/pub/papers/garrigue-polymorphic_variants-ml98.pdf
 // Not public API. Only used by tests.
-// Remember to update the same function in candid_derive if you change this function.
 #[doc(hidden)]
-#[inline]
-pub fn idl_hash(id: &str) -> u32 {
-    let mut s: u32 = 0;
-    for c in id.as_bytes().iter() {
-        s = s.wrapping_mul(223).wrapping_add(*c as u32);
-    }
-    s
-}
+pub use candid_common::idl_hash;

--- a/rust/candid/src/parser/pretty.rs
+++ b/rust/candid/src/parser/pretty.rs
@@ -11,7 +11,7 @@ const MAX_ELEMENTS_FOR_PRETTY_PRINT: usize = 10;
 
 impl fmt::Display for IDLArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", pp_args(&self).pretty(80))
+        write!(f, "{}", pp_args(self).pretty(80))
     }
 }
 
@@ -20,7 +20,7 @@ impl fmt::Display for IDLValue {
         write!(
             f,
             "{}",
-            pp_value(MAX_ELEMENTS_FOR_PRETTY_PRINT, &self).pretty(80)
+            pp_value(MAX_ELEMENTS_FOR_PRETTY_PRINT, self).pretty(80)
         )
     }
 }
@@ -219,7 +219,7 @@ pub fn pp_value(depth: usize, v: &IDLValue) -> RcDoc {
                 let tuple = concat(fields.iter().map(|f| pp_value(depth - 1, &f.val)), ";");
                 kwd("record").append(enclose_space("{", tuple, "}"))
             } else {
-                kwd("record").append(pp_fields(depth, &fields))
+                kwd("record").append(pp_fields(depth, fields))
             }
         }
         Variant(v) => kwd("variant").append(enclose_space("{", pp_field(depth, &v.0, true), "}")),

--- a/rust/candid/src/parser/test.rs
+++ b/rust/candid/src/parser/test.rs
@@ -57,7 +57,7 @@ impl Input {
     fn check_round_trip(&self, v: &IDLArgs, env: &TypeEnv, types: &[Type]) -> Result<bool> {
         match self {
             Input::Blob(ref blob) => {
-                let bytes = v.to_bytes_with_types(&env, &types)?;
+                let bytes = v.to_bytes_with_types(env, types)?;
                 Ok(*blob == bytes)
             }
             Input::Text(_) => Ok(true), //Ok(*s == v.to_string()),

--- a/rust/candid/src/parser/typing.rs
+++ b/rust/candid/src/parser/typing.rs
@@ -62,7 +62,7 @@ impl TypeEnv {
         match t {
             Type::Service(s) => Ok(s),
             Type::Var(id) => self.as_service(self.find_type(id)?),
-            Type::Class(_, ty) => self.as_service(&ty),
+            Type::Class(_, ty) => self.as_service(ty),
             _ => Err(Error::msg(format!("not a service type: {}", t))),
         }
     }
@@ -325,7 +325,7 @@ fn check_actor(env: &Env, actor: &Option<IDLType>) -> Result<Option<Type>> {
             Ok(Some(Type::Class(args, Box::new(serv))))
         }
         Some(typ) => {
-            let t = check_type(env, &typ)?;
+            let t = check_type(env, typ)?;
             env.te.as_service(&t)?;
             Ok(Some(t))
         }

--- a/rust/candid/src/parser/value.rs
+++ b/rust/candid/src/parser/value.rs
@@ -346,9 +346,8 @@ impl IDLValue {
     }
 }
 
-
-impl crate::types::CandidTyping for IDLValue {
-    fn ty() -> Type {
+impl<C> crate::types::CandidTyping<C> for IDLValue {
+    fn ty_from_cache(_c: &mut C) -> Type {
         Type::Unknown
     }
 }

--- a/rust/candid/src/parser/value.rs
+++ b/rust/candid/src/parser/value.rs
@@ -67,7 +67,7 @@ impl IDLArgs {
     pub fn annotate_types(self, from_parser: bool, env: &TypeEnv, types: &[Type]) -> Result<Self> {
         let mut args = Vec::new();
         for (v, ty) in self.args.iter().zip(types.iter()) {
-            let v = v.annotate_type(from_parser, env, &ty)?;
+            let v = v.annotate_type(from_parser, env, ty)?;
             args.push(v);
         }
         for ty in types[self.args.len()..].iter() {

--- a/rust/candid/src/parser/value.rs
+++ b/rust/candid/src/parser/value.rs
@@ -346,16 +346,14 @@ impl IDLValue {
     }
 }
 
-impl crate::CandidType for IDLValue {
+
+impl crate::types::CandidTyping for IDLValue {
     fn ty() -> Type {
         Type::Unknown
     }
-    fn id() -> crate::types::TypeId {
-        unreachable!();
-    }
-    fn _ty() -> Type {
-        Type::Unknown
-    }
+}
+
+impl crate::types::IdlSerialize for IDLValue {
     fn idl_serialize<S>(&self, serializer: S) -> std::result::Result<(), S::Error>
     where
         S: crate::types::Serializer,

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -341,7 +341,7 @@ impl TypeSerialize {
     fn encode(&self, buf: &mut Vec<u8>, t: &Type) -> Result<()> {
         if let Type::Var(id) = t {
             let actual_type = self.env.rec_find_type(id)?;
-            if types::internal::is_primitive(&actual_type) {
+            if types::internal::is_primitive(actual_type) {
                 return self.encode(buf, actual_type);
             }
         }
@@ -376,14 +376,14 @@ impl TypeSerialize {
             Type::Var(_) => {
                 let idx = self
                     .type_map
-                    .get(&t)
+                    .get(t)
                     .ok_or_else(|| Error::msg(format!("var type {} not found", t)))?;
                 sleb128_encode(buf, i64::from(*idx))
             }
             _ => {
                 let idx = self
                     .type_map
-                    .get(&t)
+                    .get(t)
                     .ok_or_else(|| Error::msg(format!("type {} not found", t)))?;
                 sleb128_encode(buf, i64::from(*idx))
             }

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -2,7 +2,7 @@
 
 use super::error::{Error, Result};
 use super::parser::{typing::TypeEnv, value::IDLValue};
-use super::types::{self, CandidTyping, IdlSerialize, internal::Opcode, Field, Type};
+use super::types::{self, internal::Opcode, CandidTyping, Field, IdlSerialize, Type};
 use byteorder::{LittleEndian, WriteBytesExt};
 use leb128::write::{signed as sleb128_encode, unsigned as leb128_encode};
 use std::collections::HashMap;
@@ -27,7 +27,7 @@ impl IDLBuilder {
             value_ser: ValueSerializer::new(),
         }
     }
-    pub fn arg<'a, T: ?Sized+CandidTyping>(&'a mut self, value: &T) -> Result<&'a mut Self> {
+    pub fn arg<'a, T: ?Sized + CandidTyping>(&'a mut self, value: &T) -> Result<&'a mut Self> {
         self.type_ser.push_type(&T::ty())?;
         value.idl_serialize(&mut self.value_ser)?;
         Ok(self)

--- a/rust/candid/src/types/impls.rs
+++ b/rust/candid/src/types/impls.rs
@@ -1,177 +1,136 @@
 use super::internal::*;
-use super::{CandidType, Compound, Serializer};
+use super::{CandidType, CandidTyping, Compound, IdlSerialize, Serializer};
+
+macro_rules! serialize_impl {
+    (
+        <
+            $($l:lifetime),*
+            $(,)?
+            $($p:ident $(: ($($b:tt)+) )?),*
+            $(,)?
+            $(;)?
+            $(const $c:ident: $ct:ty),*
+        > for $t:ty,
+        ($self:ident, $serializer:ident) => $cast:expr
+    ) => {
+        impl<
+            $($l,)*
+            $($p$(:$($b)+)?,)*
+            $(const $c: $ct),*
+        > IdlSerialize for $t {
+            fn idl_serialize<S: Serializer>(&$self, $serializer: S) -> Result<(), S::Error> {
+                $cast
+            }
+        }
+    };
+
+    ($($t:ident)::+ $(<
+        $($l:lifetime),*
+        $(,)?
+        $($p:ident $(:$b:tt)?),*
+        $(,)?
+        $(;)?
+        $(const $c:ident: $ct:ty),*
+    >)?, ($self:ident, $serializer:ident) => $cast:expr) => {
+        serialize_impl!{
+            <$(
+                $($l,)*
+                $($p$(:$b)?,)*
+                $(const $c: $ct),*
+            )?> for $($t)::+$(<$($l,)*$($p,)*$(const $c: $ct),*>)?,
+            ($self, $serializer) => $cast
+        }
+    };
+
+    ($t:ty, $method:ident($self:ident => $cast:expr)) => {
+        serialize_impl!{
+            <> for $t,
+            ($self, serializer) => serializer.$method($cast)
+        }
+    };
+    ($t:ty, $method:ident as $cast:ty) => {
+        serialize_impl!{$t, $method(self => *self as $cast)}
+    };
+    ($t:ty, $method:ident) => {
+        serialize_impl!{$t, $method(self => *self)}
+    };
+    ($t:ty, ($self:ident, $serializer:ident) => $cast:expr) => {
+        serialize_impl!{<> for $t, ($self, $serializer) => $cast}
+    };
+}
+macro_rules! candid_impl {
+    (
+        <
+            $($l:lifetime),*
+            $(,)?
+            $($p:ident $(: ($($b:tt)+) )?),*
+            $(,)?
+            $(;)?
+            $(const $c:ident: $ct:ty),*
+        > for $t:ty,
+        $_ty:expr
+    ) => {
+        impl<
+            $($l,)*
+            $($p$(:$($b)+)?,)*
+            $(const $c: $ct),*
+        > CandidType for $t {
+            fn _ty() -> Type { $_ty }
+        }
+    };
+    
+    (
+        $($t:ident)::+ $(<
+            $($l:lifetime),*
+            $(,)?
+            $($p:ident $(:$b:tt)?),*
+            $(,)?
+            $(;)?
+            $(const $c:ident: $ct:ty),*
+        >)?,
+        $_ty:expr
+    ) => {
+        candid_impl!{
+            <$(
+                $($l,)*
+                $($p$(:$b)?,)*
+                $(const $c: $ct),*
+            )?> for $($t)::+$(<$($l,)*$($p,)*$(const $c: $ct),*>)?,
+            $_ty
+        }
+    };
+
+    ($t:ty, $_ty:expr) => {
+        candid_impl!{<> for $t, $_ty}
+    };
+}
 
 macro_rules! primitive_impl {
-    ($t:ty, $id:tt, $method:ident $($cast:tt)*) => {
-        impl CandidType for $t {
-            fn _ty() -> Type { Type::$id }
-            fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error> where S: Serializer {
-                serializer.$method(*self $($cast)*)
+    ($t:ty, $id:tt, $($serialize:tt)+) => {
+        serialize_impl!{$t, $($serialize)+}
+        candid_impl!{$t, Type::$id}
+    };
+}
+
+macro_rules! iter_serialize_impl {
+    ($($t:tt)+) => {
+        serialize_impl!{
+            $($t)+,
+            (self, serializer) => {
+                let mut ser = serializer.serialize_vec(self.len())?;
+                for e in self.iter() {
+                    Compound::serialize_element(&mut ser, &e)?;
+                }
+                Ok(())
             }
         }
     };
 }
-
-primitive_impl!((), Null, serialize_null);
-primitive_impl!(bool, Bool, serialize_bool);
-
-primitive_impl!(i8, Int8, serialize_int8);
-primitive_impl!(i16, Int16, serialize_int16);
-primitive_impl!(i32, Int32, serialize_int32);
-primitive_impl!(i64, Int64, serialize_int64);
-
-primitive_impl!(u8, Nat8, serialize_nat8);
-primitive_impl!(u16, Nat16, serialize_nat16);
-primitive_impl!(u32, Nat32, serialize_nat32);
-primitive_impl!(u64, Nat64, serialize_nat64);
-
-primitive_impl!(f32, Float32, serialize_float32);
-primitive_impl!(f64, Float64, serialize_float64);
-
-// isize, usize always encode to 64bit to ensure the same behavior
-// on different platforms. This is consistent with serde's convention
-primitive_impl!(isize, Int64, serialize_int64 as i64);
-primitive_impl!(usize, Nat64, serialize_nat64 as u64);
-
-impl CandidType for i128 {
-    fn _ty() -> Type {
-        Type::Int
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_int(&crate::Int::from(*self))
-    }
-}
-impl CandidType for u128 {
-    fn _ty() -> Type {
-        Type::Nat
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_nat(&crate::Nat::from(*self))
-    }
-}
-
-impl CandidType for String {
-    fn _ty() -> Type {
-        Type::Text
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_text(self)
-    }
-}
-impl CandidType for str {
-    fn _ty() -> Type {
-        Type::Text
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_text(self)
-    }
-}
-
-impl CandidType for std::path::Path {
-    fn _ty() -> Type {
-        Type::Text
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::Error;
-        match self.to_str() {
-            Some(s) => s.idl_serialize(serializer),
-            None => Err(S::Error::custom("path contains invalid UTF-8 characters")),
-        }
-    }
-}
-
-impl CandidType for std::path::PathBuf {
-    fn _ty() -> Type {
-        Type::Text
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        self.as_path().idl_serialize(serializer)
-    }
-}
-
-impl<T: Sized> CandidType for Option<T>
-where
-    T: CandidType,
-{
-    fn _ty() -> Type {
-        Type::Opt(Box::new(T::ty()))
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_option(self.as_ref())
-    }
-}
-
-impl<T> CandidType for [T]
-where
-    T: CandidType,
-{
-    fn _ty() -> Type {
-        Type::Vec(Box::new(T::ty()))
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        let mut ser = serializer.serialize_vec(self.len())?;
-        for e in self.iter() {
-            Compound::serialize_element(&mut ser, &e)?;
-        }
-        Ok(())
-    }
-}
-impl CandidType for serde_bytes::ByteBuf {
-    fn _ty() -> Type {
-        Type::Vec(Box::new(Type::Nat8))
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_blob(&self.as_slice())
-    }
-}
-impl CandidType for serde_bytes::Bytes {
-    fn _ty() -> Type {
-        Type::Vec(Box::new(Type::Nat8))
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_blob(&self)
-    }
-}
-
-macro_rules! map_impl {
-    ($ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V $(, $typaram:ident : $bound:ident)* >) => {
-        impl<K, V $(, $typaram)*> CandidType for $ty<K, V $(, $typaram)*>
-        where
-            K: CandidType $(+ $kbound1 $(+ $kbound2)*)*,
-            V: CandidType,
-            $($typaram: $bound,)*
-        {
-            fn _ty() -> Type {
+macro_rules! map_candid_impl {
+    ($($t:tt)+) => {
+        candid_impl!{
+            $($t)+,
+            {
                 let tuple = Type::Record(vec![
                     Field {
                         id: Label::Id(0),
@@ -184,104 +143,102 @@ macro_rules! map_impl {
                 ]);
                 Type::Vec(Box::new(tuple))
             }
-            fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-            where
-                S: Serializer,
-            {
-                let mut ser = serializer.serialize_vec(self.len())?;
-                for e in self.iter() {
-                    Compound::serialize_element(&mut ser, &e)?;
-                }
-                Ok(())
-            }
         }
-    }
+    };
 }
-macro_rules! seq_impl {
-    ($ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)* $(, $typaram:ident : $bound:ident)* >) => {
-        impl<K $(, $typaram)*> CandidType for $ty<K $(, $typaram)*>
-        where
-            K: CandidType $(+ $kbound1 $(+ $kbound2)*)*,
-            $($typaram: $bound,)*
-        {
-            fn _ty() -> Type {
-                Type::Vec(Box::new(K::ty()))
-            }
-            fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-            where
-                S: Serializer,
-            {
-                let mut ser = serializer.serialize_vec(self.len())?;
-                for e in self.iter() {
-                    Compound::serialize_element(&mut ser, &e)?;
-                }
-                Ok(())
-            }
-        }
-    }
+macro_rules! seq_candid_impl {
+    ($($t:tt)+) => {
+        candid_impl!{$($t)+, Type::Vec(Box::new(K::ty()))}
+    };
 }
+
+primitive_impl!((), Null, serialize_null);
+primitive_impl!(bool, Bool, serialize_bool);
+
+primitive_impl!(i8, Int8, serialize_int8);
+primitive_impl!(i16, Int16, serialize_int16);
+primitive_impl!(i32, Int32, serialize_int32);
+primitive_impl!(i64, Int64, serialize_int64);
+primitive_impl!(i128, Int, serialize_int(self => &crate::Int::from(*self)));
+
+primitive_impl!(u8, Nat8, serialize_nat8);
+primitive_impl!(u16, Nat16, serialize_nat16);
+primitive_impl!(u32, Nat32, serialize_nat32);
+primitive_impl!(u64, Nat64, serialize_nat64);
+primitive_impl!(u128, Nat, serialize_nat(self => &crate::Nat::from(*self)));
+
+primitive_impl!(f32, Float32, serialize_float32);
+primitive_impl!(f64, Float64, serialize_float64);
+
+// isize, usize always encode to 64bit to ensure the same behavior
+// on different platforms. This is consistent with serde's convention
+primitive_impl!(isize, Int64, serialize_int64 as i64);
+primitive_impl!(usize, Nat64, serialize_nat64 as u64);
+
+primitive_impl!(String, Text, serialize_text(self => &*self));
+primitive_impl!(str, Text, serialize_text(self => self));
+primitive_impl!(std::path::Path, Text, serialize_text(self => {
+    use serde::ser::Error;
+    match self.to_str() {
+        Some(s) => s,
+        None => return Err(S::Error::custom("path contains invalid UTF-8 characters")),
+    }
+}));
+primitive_impl!(std::path::PathBuf, Text, (self, serializer) => {
+    self.as_path().idl_serialize(serializer)
+});
+
+// Option
+serialize_impl!{
+    Option<T: (IdlSerialize)>, 
+    (self, serializer) => serializer.serialize_option(self.as_ref())
+}
+candid_impl!{Option<T: (CandidType)>, Type::Opt(Box::new(T::ty()))}
+
+// [T]
+iter_serialize_impl!{<T: (IdlSerialize)> for [T]}
+candid_impl!{<T: (CandidType)> for [T], Type::Vec(Box::new(T::ty()))}
+
+serialize_impl!{
+    serde_bytes::ByteBuf,
+    (self, serializer) => serializer.serialize_blob(self.as_slice())
+}
+candid_impl!{serde_bytes::ByteBuf, Type::Vec(Box::new(Type::Nat8))}
+
+serialize_impl!{
+    serde_bytes::Bytes,
+    (self, serializer) => serializer.serialize_blob(self.as_ref())
+}
+candid_impl!{serde_bytes::Bytes, Type::Vec(Box::new(Type::Nat8))}
+
+
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 use std::hash::{BuildHasher, Hash};
-map_impl!(BTreeMap<K: Ord, V>);
-map_impl!(HashMap<K: Eq + Hash, V, H: BuildHasher>);
+iter_serialize_impl!{BTreeMap<K: (Ord+IdlSerialize), V: (IdlSerialize)>}
+map_candid_impl!{BTreeMap<K: (Ord+CandidType), V: (CandidType)>}
 
-seq_impl!(Vec<K>);
-seq_impl!(VecDeque<K>);
-seq_impl!(LinkedList<K>);
-seq_impl!(BinaryHeap<K: Ord>);
-seq_impl!(BTreeSet<K: Ord>);
-seq_impl!(HashSet<K: Eq + Hash, H: BuildHasher>);
+iter_serialize_impl!{HashMap<K: (Eq+Hash+IdlSerialize), V: (IdlSerialize), H: (BuildHasher)>}
+map_candid_impl!{HashMap<K: (Eq+Hash+CandidType), V: (CandidType), H: (BuildHasher)>}
 
-macro_rules! array_impls {
-    ($($len:tt)+) => {
-        $(
-            impl<T> CandidType for [T; $len]
-            where T: CandidType,
-            {
-                fn _ty() -> Type { Type::Vec(Box::new(T::ty())) }
-                fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-                where S: Serializer,
-                {
-                    let mut ser = serializer.serialize_vec($len)?;
-                    for e in self.iter() {
-                        Compound::serialize_element(&mut ser, &e)?;
-                    };
-                    Ok(())
-                }
-            }
-        )+
-    }
-}
+iter_serialize_impl!{Vec<K: (IdlSerialize)>}
+seq_candid_impl!{Vec<K: (CandidType)>}
+iter_serialize_impl!{VecDeque<K: (IdlSerialize)>}
+seq_candid_impl!{VecDeque<K: (CandidType)>}
+iter_serialize_impl!{LinkedList<K: (IdlSerialize)>}
+seq_candid_impl!{LinkedList<K: (CandidType)>}
+iter_serialize_impl!{BinaryHeap<K: (Ord+IdlSerialize)>}
+seq_candid_impl!{BinaryHeap<K: (Ord+CandidType)>}
+iter_serialize_impl!{BTreeSet<K: (Ord+IdlSerialize)>}
+seq_candid_impl!{BTreeSet<K: (Ord+CandidType)>}
+iter_serialize_impl!{HashSet<K: (Eq+Hash+IdlSerialize), H: (BuildHasher)>}
+seq_candid_impl!{HashSet<K: (Eq+Hash+CandidType), H: (BuildHasher)>}
 
-array_impls! {
-     1  2  3  4  5  6  7  8  9 10
-    11 12 13 14 15 16 17 18 19 20
-    21 22 23 24 25 26 27 28 29 30
-    31 32 00
-}
+iter_serialize_impl!{<T: (IdlSerialize); const N: usize> for [T; N]}
+candid_impl!{<T: (CandidType); const N: usize> for [T; N], Type::Vec(Box::new(T::ty()))}
 
-impl<T, E> CandidType for Result<T, E>
-where
-    T: CandidType,
-    E: CandidType,
-{
-    fn _ty() -> Type {
-        Type::Variant(vec![
-            // Make sure the field id is sorted by idl_hash
-            Field {
-                id: Label::Named("Ok".to_owned()),
-                ty: T::ty(),
-            },
-            Field {
-                id: Label::Named("Err".to_owned()),
-                ty: E::ty(),
-            },
-        ])
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
+serialize_impl!{
+    Result<T: (IdlSerialize), E: (IdlSerialize)>, 
+    (self, serializer) => {
         match *self {
             Result::Ok(ref v) => {
                 let mut ser = serializer.serialize_variant(0)?;
@@ -294,98 +251,72 @@ where
         }
     }
 }
+candid_impl!{Result<T: (CandidType), E: (CandidType)>, Type::Variant(vec![
+    // Make sure the field id is sorted by idl_hash
+    Field {
+        id: Label::Named("Ok".to_owned()),
+        ty: T::ty(),
+    },
+    Field {
+        id: Label::Named("Err".to_owned()),
+        ty: E::ty(),
+    },
+])}
 
-impl<T> CandidType for Box<T>
-where
-    T: ?Sized + CandidType,
-{
-    fn _ty() -> Type {
-        T::ty()
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        (**self).idl_serialize(serializer)
-    }
+serialize_impl!{
+    Box<T: (?Sized + IdlSerialize)>,
+    (self, serializer) => (**self).idl_serialize(serializer)
 }
+candid_impl!{Box<T: (?Sized+CandidType)>, T::ty()}
 
+serialize_impl!{
+    <'a, T: (?Sized + IdlSerialize)> for &'a T,
+    (self, serializer) => (**self).idl_serialize(serializer)
+}
 impl<'a, T> CandidType for &'a T
 where
     T: ?Sized + CandidType,
 {
     fn id() -> TypeId {
-        TypeId::of::<&T>()
-    } // ignore lifetime
+        TypeId::of::<&T>() // ignore lifetime
+    }
     fn _ty() -> Type {
         T::ty()
     }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        (**self).idl_serialize(serializer)
-    }
+}
+
+serialize_impl!{
+    <'a, T: (?Sized + IdlSerialize)> for &'a mut T,
+    (self, serializer) => (**self).idl_serialize(serializer)
 }
 impl<'a, T> CandidType for &'a mut T
 where
     T: ?Sized + CandidType,
 {
     fn id() -> TypeId {
-        TypeId::of::<&T>()
-    } // ignore lifetime
+        TypeId::of::<&T>() // ignore lifetime
+    }
     fn _ty() -> Type {
         T::ty()
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        (**self).idl_serialize(serializer)
     }
 }
 
-impl<'a, T> CandidType for std::borrow::Cow<'a, T>
-where
-    T: ?Sized + CandidType + ToOwned,
-{
-    fn _ty() -> Type {
-        T::ty()
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        (**self).idl_serialize(serializer)
-    }
-}
 
-impl<T> CandidType for std::cell::Cell<T>
-where
-    T: CandidType + Copy,
-{
-    fn _ty() -> Type {
-        T::ty()
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        self.get().idl_serialize(serializer)
-    }
+serialize_impl!{
+    std::borrow::Cow<'a, T: (?Sized + IdlSerialize + ToOwned)>,
+    (self, serializer) => (**self).idl_serialize(serializer)
 }
+candid_impl!{std::borrow::Cow<'a, T: (?Sized + CandidType + ToOwned)>, T::ty()}
 
-impl<T> CandidType for std::cell::RefCell<T>
-where
-    T: CandidType,
-{
-    fn _ty() -> Type {
-        T::ty()
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
+serialize_impl!{
+    std::cell::Cell<T: (IdlSerialize + Copy)>,
+    (self, serializer) => self.get().idl_serialize(serializer)
+}
+candid_impl!{std::cell::Cell<T: (CandidType + Copy)>, T::ty()}
+
+serialize_impl!{
+    std::cell::RefCell<T: (IdlSerialize)>,
+    (self, serializer) => {
         use serde::ser::Error;
         match self.try_borrow() {
             Ok(v) => v.idl_serialize(serializer),
@@ -393,28 +324,27 @@ where
         }
     }
 }
+candid_impl!{std::cell::RefCell<T: (CandidType)>, T::ty()}
 
 macro_rules! tuple_impls {
     ($($len:expr => ($($n:tt $name:ident)+))+) => {
         $(
-            impl<$($name),+> CandidType for ($($name,)+)
-            where
-                $($name: CandidType,)+
-            {
-                fn _ty() -> Type {
-                    Type::Record(vec![
-                        $(Field{ id: Label::Id($n), ty: $name::ty() },)+
-                    ])
-                }
-                fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-                where S: Serializer,
-                {
+            serialize_impl!{
+                <$($name: (IdlSerialize)),+> for ($($name,)+),
+                (self, serializer) => {
                     let mut ser = serializer.serialize_struct()?;
                     $(
                         Compound::serialize_element(&mut ser, &self.$n)?;
                     )+
                     Ok(())
                 }
+            }
+
+            candid_impl!{
+                <$($name: (CandidType)),+> for ($($name,)+),
+                Type::Record(vec![
+                    $(Field{ id: Label::Id($n), ty: $name::ty() },)+
+                ])
             }
         )+
     }
@@ -439,23 +369,9 @@ tuple_impls! {
     16 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15)
 }
 
-impl CandidType for std::time::SystemTime {
-    fn _ty() -> Type {
-        Type::Record(vec![
-            Field {
-                id: Label::Named("nanos_since_epoch".to_owned()),
-                ty: u32::ty(),
-            },
-            Field {
-                id: Label::Named("secs_since_epoch".to_owned()),
-                ty: u64::ty(),
-            },
-        ])
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
+serialize_impl!{
+    std::time::SystemTime,
+    (self, serializer) => {
         use serde::ser::Error;
 
         let duration_since_epoch = self
@@ -472,7 +388,34 @@ impl CandidType for std::time::SystemTime {
         Ok(())
     }
 }
+impl CandidType for std::time::SystemTime {
+    fn _ty() -> Type {
+        Type::Record(vec![
+            Field {
+                id: Label::Named("nanos_since_epoch".to_owned()),
+                ty: u32::ty(),
+            },
+            Field {
+                id: Label::Named("secs_since_epoch".to_owned()),
+                ty: u64::ty(),
+            },
+        ])
+    }
+}
 
+serialize_impl!{
+    std::time::Duration,
+    (self, serializer) => {
+        let secs: u64 = self.as_secs();
+        let nanos: u32 = self.subsec_nanos();
+
+        let mut ser = serializer.serialize_struct()?;
+        ser.serialize_element(&secs)?;
+        ser.serialize_element(&nanos)?;
+
+        Ok(())
+    }
+}
 impl CandidType for std::time::Duration {
     fn _ty() -> Type {
         Type::Record(vec![
@@ -485,18 +428,5 @@ impl CandidType for std::time::Duration {
                 ty: u32::ty(),
             },
         ])
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        let secs: u64 = self.as_secs();
-        let nanos: u32 = self.subsec_nanos();
-
-        let mut ser = serializer.serialize_struct()?;
-        ser.serialize_element(&secs)?;
-        ser.serialize_element(&nanos)?;
-
-        Ok(())
-    }
+    }    
 }

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -24,7 +24,7 @@ impl TypeId {
 }
 impl std::fmt::Display for TypeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name = NAME.with(|n| n.borrow_mut().get(&self));
+        let name = NAME.with(|n| n.borrow_mut().get(self));
         write!(f, "{}", name)
     }
 }
@@ -208,7 +208,7 @@ impl Type {
 }
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", crate::bindings::candid::pp_ty(&self).pretty(80))
+        write!(f, "{}", crate::bindings::candid::pp_ty(self).pretty(80))
     }
 }
 
@@ -269,7 +269,7 @@ impl fmt::Display for Function {
         write!(
             f,
             "{}",
-            crate::bindings::candid::pp_function(&self).pretty(80)
+            crate::bindings::candid::pp_function(self).pretty(80)
         )
     }
 }

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -89,7 +89,7 @@ impl TypeContainer {
         }
     }
     pub fn add<T: CandidType>(&mut self) -> Type {
-        let t = T::ty();
+        let t = <T as CandidTyping>::ty();
         self.go(&t)
     }
     fn go(&mut self, t: &Type) -> Type {
@@ -395,5 +395,5 @@ pub fn get_type<T>(_v: &T) -> Type
 where
     T: CandidType,
 {
-    T::ty()
+    <T as CandidTyping>::ty()
 }

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -1,4 +1,4 @@
-use super::CandidType;
+use super::{CandidType, CandidTyping};
 use crate::idl_hash;
 use num_enum::TryFromPrimitive;
 use std::cell::RefCell;

--- a/rust/candid/src/types/number.rs
+++ b/rust/candid/src/types/number.rs
@@ -1,6 +1,6 @@
 //! Data structure for Candid type Int, Nat, supporting big integer with LEB128 encoding.
 
-use super::{CandidType, IdlSerialize, Serializer, Type, TypeId};
+use super::{CandidType, CandidTypeCache, IdlSerialize, Serializer, Type, TypeId};
 use crate::Error;
 use num_bigint::{BigInt, BigUint};
 use serde::de::{self, Deserialize, Visitor};
@@ -126,7 +126,7 @@ impl CandidType for Int {
     fn id() -> TypeId {
         TypeId::of::<Int>()
     }
-    fn _ty() -> Type {
+    fn _ty<C: CandidTypeCache>(_c: &mut C) -> Type {
         Type::Int
     }
 }
@@ -143,7 +143,7 @@ impl CandidType for Nat {
     fn id() -> TypeId {
         TypeId::of::<Nat>()
     }
-    fn _ty() -> Type {
+    fn _ty<C: CandidTypeCache>(_c: &mut C) -> Type {
         Type::Nat
     }
 }

--- a/rust/candid/src/types/number.rs
+++ b/rust/candid/src/types/number.rs
@@ -1,6 +1,6 @@
 //! Data structure for Candid type Int, Nat, supporting big integer with LEB128 encoding.
 
-use super::{CandidType, Serializer, Type, TypeId};
+use super::{CandidType, IdlSerialize, Serializer, Type, TypeId};
 use crate::Error;
 use num_bigint::{BigInt, BigUint};
 use serde::de::{self, Deserialize, Visitor};
@@ -113,13 +113,7 @@ impl fmt::Display for Nat {
     }
 }
 
-impl CandidType for Int {
-    fn id() -> TypeId {
-        TypeId::of::<Int>()
-    }
-    fn _ty() -> Type {
-        Type::Int
-    }
+impl IdlSerialize for Int {
     fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
     where
         S: Serializer,
@@ -128,18 +122,29 @@ impl CandidType for Int {
     }
 }
 
+impl CandidType for Int {
+    fn id() -> TypeId {
+        TypeId::of::<Int>()
+    }
+    fn _ty() -> Type {
+        Type::Int
+    }
+}
+
+impl IdlSerialize for Nat {
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_nat(self)
+    }
+}
 impl CandidType for Nat {
     fn id() -> TypeId {
         TypeId::of::<Nat>()
     }
     fn _ty() -> Type {
         Type::Nat
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_nat(self)
     }
 }
 

--- a/rust/candid/src/types/principal.rs
+++ b/rust/candid/src/types/principal.rs
@@ -1,6 +1,15 @@
-use super::{CandidType, Serializer, Type, TypeId};
+use super::{CandidType, IdlSerialize, Serializer, Type, TypeId};
 
-pub type Principal = ic_types::Principal;
+pub use ic_types::Principal;
+
+impl IdlSerialize for Principal {
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_principal(self.as_slice())
+    }
+}
 
 impl CandidType for Principal {
     fn id() -> TypeId {
@@ -8,11 +17,5 @@ impl CandidType for Principal {
     }
     fn _ty() -> Type {
         Type::Principal
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_principal(self.as_slice())
     }
 }

--- a/rust/candid/src/types/principal.rs
+++ b/rust/candid/src/types/principal.rs
@@ -1,4 +1,4 @@
-use super::{CandidType, IdlSerialize, Serializer, Type, TypeId};
+use super::{CandidType, CandidTypeCache, IdlSerialize, Serializer, Type, TypeId};
 
 pub use ic_types::Principal;
 
@@ -15,7 +15,7 @@ impl CandidType for Principal {
     fn id() -> TypeId {
         TypeId::of::<Principal>()
     }
-    fn _ty() -> Type {
+    fn _ty<C: CandidTypeCache>(_c: &mut C) -> Type {
         Type::Principal
     }
 }

--- a/rust/candid/src/types/reference.rs
+++ b/rust/candid/src/types/reference.rs
@@ -1,6 +1,6 @@
 //! Data structure for Candid value Func and Service
 
-use super::{CandidType, Function, IdlSerialize, Serializer, Type};
+use super::{CandidType, CandidTypeCache, Function, IdlSerialize, Serializer, Type};
 use ic_types::Principal;
 use serde::de::{self, Deserialize, Visitor};
 use std::convert::TryFrom;
@@ -25,7 +25,7 @@ impl IdlSerialize for Func {
     }
 }
 impl CandidType for Func {
-    fn _ty() -> Type {
+    fn _ty<C: CandidTypeCache>(_c: &mut C) -> Type {
         Type::Func(Function {
             modes: Vec::new(),
             args: Vec::new(),
@@ -42,7 +42,7 @@ impl IdlSerialize for Service {
     }
 }
 impl CandidType for Service {
-    fn _ty() -> Type {
+    fn _ty<C: CandidTypeCache>(_c: &mut C) -> Type {
         Type::Service(Vec::new())
     }
 }

--- a/rust/candid/src/types/reference.rs
+++ b/rust/candid/src/types/reference.rs
@@ -1,6 +1,6 @@
 //! Data structure for Candid value Func and Service
 
-use super::{CandidType, Function, Serializer, Type};
+use super::{CandidType, Function, IdlSerialize, Serializer, Type};
 use ic_types::Principal;
 use serde::de::{self, Deserialize, Visitor};
 use std::convert::TryFrom;
@@ -16,6 +16,14 @@ pub struct Service {
     pub principal: Principal,
 }
 
+impl IdlSerialize for Func {
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_function(self.principal.as_slice(), &self.method)
+    }
+}
 impl CandidType for Func {
     fn _ty() -> Type {
         Type::Func(Function {
@@ -24,22 +32,18 @@ impl CandidType for Func {
             rets: Vec::new(),
         })
     }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_function(self.principal.as_slice(), &self.method)
-    }
 }
-impl CandidType for Service {
-    fn _ty() -> Type {
-        Type::Service(Vec::new())
-    }
+impl IdlSerialize for Service {
     fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
     where
         S: Serializer,
     {
         serializer.serialize_principal(self.principal.as_slice())
+    }
+}
+impl CandidType for Service {
+    fn _ty() -> Type {
+        Type::Service(Vec::new())
     }
 }
 

--- a/rust/candid/src/types/reserved.rs
+++ b/rust/candid/src/types/reserved.rs
@@ -1,6 +1,6 @@
 //! Data structure for Candid type Reserved and Empty.
 
-use super::{CandidType, Serializer, Type, TypeId};
+use super::{CandidType, IdlSerialize, Serializer, Type, TypeId};
 use serde::de::{self, Deserialize, Deserializer, Visitor};
 use std::fmt;
 
@@ -9,13 +9,7 @@ pub struct Reserved;
 #[derive(PartialEq, Debug)]
 pub enum Empty {}
 
-impl CandidType for Reserved {
-    fn id() -> TypeId {
-        TypeId::of::<Reserved>()
-    }
-    fn _ty() -> Type {
-        Type::Reserved
-    }
+impl IdlSerialize for Reserved {
     fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
     where
         S: Serializer,
@@ -23,19 +17,29 @@ impl CandidType for Reserved {
         serializer.serialize_null(())
     }
 }
+impl CandidType for Reserved {
+    fn id() -> TypeId {
+        TypeId::of::<Reserved>()
+    }
+    fn _ty() -> Type {
+        Type::Reserved
+    }
+}
 
+impl IdlSerialize for Empty {
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_empty()
+    }
+}
 impl CandidType for Empty {
     fn id() -> TypeId {
         TypeId::of::<Empty>()
     }
     fn _ty() -> Type {
         Type::Empty
-    }
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_empty()
     }
 }
 

--- a/rust/candid/src/types/reserved.rs
+++ b/rust/candid/src/types/reserved.rs
@@ -1,6 +1,6 @@
 //! Data structure for Candid type Reserved and Empty.
 
-use super::{CandidType, IdlSerialize, Serializer, Type, TypeId};
+use super::{CandidType, CandidTypeCache, IdlSerialize, Serializer, Type, TypeId};
 use serde::de::{self, Deserialize, Deserializer, Visitor};
 use std::fmt;
 
@@ -21,7 +21,7 @@ impl CandidType for Reserved {
     fn id() -> TypeId {
         TypeId::of::<Reserved>()
     }
-    fn _ty() -> Type {
+    fn _ty<C: CandidTypeCache>(_c: &mut C) -> Type {
         Type::Reserved
     }
 }
@@ -38,7 +38,7 @@ impl CandidType for Empty {
     fn id() -> TypeId {
         TypeId::of::<Empty>()
     }
-    fn _ty() -> Type {
+    fn _ty<C: CandidTypeCache>(_c: &mut C) -> Type {
         Type::Empty
     }
 }

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -137,7 +137,7 @@ pub fn encode_args<Tuple: ArgumentEncoder>(arguments: Tuple) -> Result<Vec<u8>> 
 /// let (value) = Decode!(&buffer, String).unwrap();
 /// assert_eq!(golden, value);
 /// ```
-pub fn encode_one<T: ?Sized+CandidTyping>(argument: &T) -> Result<Vec<u8>> {
+pub fn encode_one<T: ?Sized + CandidTyping>(argument: &T) -> Result<Vec<u8>> {
     encode_args((argument,))
 }
 

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::unit_cmp)]
-use candid::{decode_one, encode_one, CandidType, Decode, Deserialize, Encode, Int, Nat};
+use candid::{decode_one, encode_one, CandidType, types::CandidTyping, Decode, Deserialize, Encode, Int, Nat};
 
 #[test]
 fn test_error() {
@@ -608,7 +608,7 @@ fn hex(bytes: &str) -> Vec<u8> {
 
 fn all_check<T>(value: T, bytes: &str)
 where
-    T: PartialEq + CandidType + serde::de::DeserializeOwned + std::fmt::Debug,
+    T: PartialEq + CandidTyping + serde::de::DeserializeOwned + std::fmt::Debug,
 {
     let bytes = hex(bytes);
     test_encode(&value, &bytes);
@@ -617,9 +617,9 @@ where
 
 fn test_encode<T>(value: &T, expected: &[u8])
 where
-    T: CandidType,
+    T: CandidTyping,
 {
-    let encoded = encode(&value);
+    let encoded = encode(value);
     assert_eq!(
         encoded, expected,
         "\nActual\n{:02x?}\nExpected\n{:02x?}\n",
@@ -629,7 +629,7 @@ where
 
 fn test_decode<'de, T>(bytes: &'de [u8], expected: &T)
 where
-    T: PartialEq + serde::de::Deserialize<'de> + std::fmt::Debug + CandidType,
+    T: PartialEq + serde::de::Deserialize<'de> + std::fmt::Debug + CandidTyping,
 {
     let decoded_one = decode_one::<T>(bytes).unwrap();
     let decoded_macro = Decode!(bytes, T).unwrap();
@@ -637,9 +637,9 @@ where
     assert_eq!(decoded_macro, *expected);
 }
 
-fn encode<T: CandidType>(value: &T) -> Vec<u8> {
+fn encode<T: CandidTyping>(value: &T) -> Vec<u8> {
     let encode_one = encode_one(value).unwrap();
-    let encode_macro = Encode!(&value).unwrap();
+    let encode_macro = Encode!(value).unwrap();
 
     assert_eq!(encode_one, encode_macro);
     encode_one

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::unit_cmp)]
-use candid::{decode_one, encode_one, CandidType, types::CandidTyping, Decode, Deserialize, Encode, Int, Nat};
+use candid::{
+    decode_one, encode_one, types::CandidTyping, CandidType, Decode, Deserialize, Encode, Int, Nat,
+};
 
 #[test]
 fn test_error() {

--- a/rust/candid/tests/types.rs
+++ b/rust/candid/tests/types.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use candid::types::{get_type, Label, Type};
-use candid::{candid_method, CandidType, types::CandidTyping, Int};
+use candid::{candid_method, types::CandidTyping, CandidType, Int};
 
 #[test]
 fn test_primitive() {
@@ -17,14 +17,14 @@ fn test_primitive() {
 fn test_struct() {
     #[derive(Debug, CandidType)]
     struct Newtype(Int);
-    assert_eq!(Newtype::ty(), Type::Int,);
+    assert_eq!(<Newtype as CandidTyping>::ty(), Type::Int,);
     #[derive(Debug, CandidType)]
     struct A {
         foo: Int,
         bar: bool,
     }
     assert_eq!(
-        A::ty(),
+        <A as CandidTyping>::ty(),
         Type::Record(vec![field("bar", Type::Bool), field("foo", Type::Int),])
     );
 
@@ -45,7 +45,7 @@ fn test_struct() {
         tail: Option<Box<List>>,
     }
     assert_eq!(
-        List::ty(),
+        <List as CandidTyping>::ty(),
         Type::Record(vec![
             field("head", Type::Int32),
             field(

--- a/rust/candid/tests/types.rs
+++ b/rust/candid/tests/types.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use candid::types::{get_type, Label, Type};
-use candid::{candid_method, CandidType, Int};
+use candid::{candid_method, CandidType, types::CandidTyping, Int};
 
 #[test]
 fn test_primitive() {

--- a/rust/candid_common/Cargo.toml
+++ b/rust/candid_common/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "candid_common"
+version = "1.0.0"
+edition = "2018"
+authors = ["DFINITY Team"]
+description = "Common elements Candid creates."
+homepage = "https://docs.rs/candid_common"
+documentation = "https://docs.rs/candid_common"
+repository = "https://github.com/dfinity/candid"
+license = "Apache-2.0"
+readme = "README.md"
+
+categories = ["encoding", "wasm"]
+keywords = ["internet-computer", "idl", "candid", "dfinity", "parser"]
+include = ["src", "README.md", "Cargo.toml", "LICENSE"]

--- a/rust/candid_common/LICENSE
+++ b/rust/candid_common/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 DFINITY LLC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rust/candid_common/README.md
+++ b/rust/candid_common/README.md
@@ -1,0 +1,3 @@
+# Candid Common
+
+This library contains common elements between the `candid` and `candid_derive` crates.

--- a/rust/candid_common/src/lib.rs
+++ b/rust/candid_common/src/lib.rs
@@ -1,0 +1,23 @@
+/// Hash function for [Symbolic Field Ids](https://github.com/dfinity/candid/blob/master/spec/Candid.md#shorthand-symbolic-field-ids)
+#[inline]
+pub fn idl_hash(id: &str) -> u32 {
+    let mut s: u32 = 0;
+    for c in id.as_bytes().iter() {
+        s = s.wrapping_mul(223).wrapping_add(*c as u32);
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+
+    fn test_record() {
+        assert_eq!(idl_hash("name"), 1224700491);
+        assert_eq!(idl_hash("street"), 288167939);
+        assert_eq!(idl_hash("num"), 5496390);
+        assert_eq!(idl_hash("city"), 1103114667);
+        assert_eq!(idl_hash("zip"), 6090465);
+    }
+}

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -19,6 +19,7 @@ name = "candid_derive"
 proc-macro = true
 
 [dependencies]
+candid_common = { path = "../candid_common", version = "1.0" }
 quote = "1.0.7"
 syn = { version = "1.0.38", features = ["visit", "full"] }
 proc-macro2 = "1.0.19"

--- a/rust/candid_derive/src/derive.rs
+++ b/rust/candid_derive/src/derive.rs
@@ -21,18 +21,19 @@ pub(crate) fn derive_idl_type(input: DeriveInput) -> TokenStream {
         Data::Union(_) => unimplemented!("doesn't derive union type"),
     };
     let gen = quote! {
-        impl #impl_generics #candid::types::CandidType for #name #ty_generics #where_clause {
-            fn _ty() -> #candid::types::Type {
-                #ty_body
-            }
-            fn id() -> #candid::types::TypeId { #candid::types::TypeId::of::<#name #ty_generics>() }
-
+        impl #impl_generics #candid::types::IdlSerialize for #name #ty_generics #where_clause {
             fn idl_serialize<__S>(&self, __serializer: __S) -> ::std::result::Result<(), __S::Error>
                 where
                 __S: #candid::types::Serializer,
                 {
                     #ser_body
                 }
+        }
+        impl #impl_generics #candid::types::CandidType for #name #ty_generics #where_clause {
+            fn _ty() -> #candid::types::Type {
+                #ty_body
+            }
+            fn id() -> #candid::types::TypeId { #candid::types::TypeId::of::<#name #ty_generics>() }
         }
     };
     //panic!(gen.to_string());
@@ -382,7 +383,7 @@ fn fields_from_ast(
 fn derive_type(t: &syn::Type) -> TokenStream {
     let candid = candid_path();
     quote! {
-        <#t as #candid::types::CandidType>::ty()
+        <#t as #candid::types::CandidTyping>::ty()
     }
 }
 

--- a/rust/candid_derive/src/derive.rs
+++ b/rust/candid_derive/src/derive.rs
@@ -30,7 +30,7 @@ pub(crate) fn derive_idl_type(input: DeriveInput) -> TokenStream {
                 }
         }
         impl #impl_generics #candid::types::CandidType for #name #ty_generics #where_clause {
-            fn _ty() -> #candid::types::Type {
+            fn _ty<C: #candid::types::CandidTypeCache>(_c: &mut C) -> #candid::types::Type {
                 #ty_body
             }
             fn id() -> #candid::types::TypeId { #candid::types::TypeId::of::<#name #ty_generics>() }
@@ -383,7 +383,7 @@ fn fields_from_ast(
 fn derive_type(t: &syn::Type) -> TokenStream {
     let candid = candid_path();
     quote! {
-        <#t as #candid::types::CandidTyping>::ty()
+        <#t as #candid::types::CandidTyping<C>>::ty_from_cache(_c)
     }
 }
 

--- a/rust/candid_derive/src/derive.rs
+++ b/rust/candid_derive/src/derive.rs
@@ -1,4 +1,5 @@
-use super::{candid_path, idl_hash};
+use super::candid_path;
+use candid_common::idl_hash;
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::collections::BTreeSet;

--- a/rust/candid_derive/src/lib.rs
+++ b/rust/candid_derive/src/lib.rs
@@ -22,15 +22,6 @@ pub fn export_service(_: TokenStream) -> TokenStream {
     func::export_service().into()
 }
 
-#[inline]
-pub(crate) fn idl_hash(id: &str) -> u32 {
-    let mut s: u32 = 0;
-    for c in id.as_bytes().iter() {
-        s = s.wrapping_mul(223).wrapping_add(*c as u32);
-    }
-    s
-}
-
 #[cfg(feature = "cdk")]
 pub(crate) fn candid_path() -> proc_macro2::TokenStream {
     quote::quote! { ::ic_cdk::export::candid }

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use candid::{
     check_prog,
+    idl_hash,
     parser::types::{IDLType, IDLTypes},
     pretty_parse,
     types::Type,
@@ -219,7 +220,7 @@ fn main() -> Result<()> {
             println!("{}", content);
         }
         Command::Hash { input } => {
-            println!("{}", candid::idl_hash(&input));
+            println!("{}", idl_hash(&input));
         }
         Command::Encode {
             args,

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -1,7 +1,6 @@
 use anyhow::{bail, Result};
 use candid::{
-    check_prog,
-    idl_hash,
+    check_prog, idl_hash,
     parser::types::{IDLType, IDLTypes},
     pretty_parse,
     types::Type,


### PR DESCRIPTION
**Overview**
This makes it possible to move away from a global thread local static type cache.

**Requirements**
Eventual deprecation and removal of `internal::env_id` would be the end goal of this feature.

**Considered Solutions**
Most solutions to this end up needing to refactor these traits.

**Recommended Solution**
This solution forces caching for all `CandidType`s, removes the need for `unreachable` impls of `CandidType`, while still allowing `IDLValue` to override default behavior, while only minimally altering the overall interface.

**Considerations**
There are no notable security or performance considerations, but this does change the interface in a way which could break some power users. Ordinary users who are just using `#[derive(CandidType)]` should not notice any difference. Additional traits does add additional complexity.