### PR TITLE
chore: update to use new `ic-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,9 +763,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ic-types"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80baa984981300b80bc45a589ebb49ed09738be532db025f9a94fc6f88bf77d"
+checksum = "08f0b1f1517d697f67a8b5ad558ef6b9372ed1fc5ab669a519d7fa1837e8f88a"
 dependencies = [
  "base32",
  "crc32fast",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "1.4.3"
 candid_derive = { path = "../candid_derive", version = "=0.4.4" }
 codespan-reporting = "0.11"
 hex = "0.4.2"
-ic-types = "0.1.3"
+ic-types = "0.2.0"
 lalrpop-util = "0.19.0"
 leb128 = "0.2.4"
 logos = "0.12"

--- a/rust/candid/src/bindings/analysis.rs
+++ b/rust/candid/src/bindings/analysis.rs
@@ -58,7 +58,7 @@ pub fn chase_types<'a>(env: &'a TypeEnv, tys: &'a [Type]) -> crate::Result<Vec<&
     let mut seen = BTreeSet::new();
     let mut res = Vec::new();
     for t in tys.iter() {
-        chase_type(&mut seen, &mut res, env, &t)?;
+        chase_type(&mut seen, &mut res, env, t)?;
     }
     Ok(res)
 }
@@ -111,7 +111,7 @@ pub fn infer_rec<'a>(
     }
     for var in def_list.iter() {
         let t = env.0.get(*var).unwrap();
-        go(&mut seen, &mut res, env, &t)?;
+        go(&mut seen, &mut res, env, t)?;
         seen.insert(var);
     }
     Ok(res)

--- a/rust/candid/src/bindings/candid.rs
+++ b/rust/candid/src/bindings/candid.rs
@@ -107,7 +107,7 @@ pub fn pp_ty(ty: &Type) -> RcDoc {
         Func(ref func) => kwd("func").append(pp_function(func)),
         Service(ref serv) => kwd("service").append(pp_service(serv)),
         Class(ref args, ref t) => {
-            let doc = pp_args(&args).append(" ->").append(RcDoc::space());
+            let doc = pp_args(args).append(" ->").append(RcDoc::space());
             match t.as_ref() {
                 Service(ref serv) => doc.append(pp_service(serv)),
                 Var(ref s) => doc.append(s),

--- a/rust/candid/src/bindings/javascript.rs
+++ b/rust/candid/src/bindings/javascript.rs
@@ -252,10 +252,10 @@ pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {
             let body = defs.append(actor);
             let doc = str("export default ({ IDL }) => ").append(enclose_space("{", body, "};"));
             // export init args
-            let init_defs = chase_types(env, &init).unwrap();
+            let init_defs = chase_types(env, init).unwrap();
             let init_recs = infer_rec(env, &init_defs).unwrap();
             let init_defs_doc = pp_defs(env, &init_defs, &init_recs);
-            let init_doc = kwd("return").append(pp_args(&init)).append(";");
+            let init_doc = kwd("return").append(pp_args(init)).append(";");
             let init_doc = init_defs_doc.append(init_doc);
             let init_doc =
                 str("export const init = ({ IDL }) => ").append(enclose_space("{", init_doc, "};"));
@@ -333,7 +333,7 @@ pub mod value {
                     let tuple = concat(fields.iter().map(|f| pp_value(&f.val)), ",");
                     enclose_space("[", tuple, "]")
                 } else {
-                    enclose_space("{", pp_fields(&fields), "}")
+                    enclose_space("{", pp_fields(fields), "}")
                 }
             }
             Variant(v) => enclose_space("{", pp_field(&v.0), "}"),
@@ -359,16 +359,16 @@ pub mod test {
             .append("', 'hex')")
     }
     fn pp_encode<'a>(args: &'a crate::IDLArgs, tys: &'a [crate::types::Type]) -> RcDoc<'a> {
-        let vals = value::pp_args(&args);
-        let tys = super::pp_args(&tys);
+        let vals = value::pp_args(args);
+        let tys = super::pp_args(tys);
         let items = [tys, vals];
         let params = concat(items.iter().cloned(), ",");
         str("IDL.encode").append(enclose("(", params, ")"))
     }
 
     fn pp_decode<'a>(bytes: &'a [u8], tys: &'a [crate::types::Type]) -> RcDoc<'a> {
-        let hex = pp_hex(&bytes);
-        let tys = super::pp_args(&tys);
+        let hex = pp_hex(bytes);
+        let tys = super::pp_args(tys);
         let items = [tys, hex];
         let params = concat(items.iter().cloned(), ",");
         str("IDL.decode").append(enclose("(", params, ")"))
@@ -403,11 +403,11 @@ import { Principal } from './principal';
                 use HostAssert::*;
                 let test_func = match cmd {
                     Encode(args, tys, _, _) | NotEncode(args, tys) => {
-                        let items = [super::pp_args(&tys), pp_encode(&args, &tys)];
+                        let items = [super::pp_args(tys), pp_encode(args, tys)];
                         let params = concat(items.iter().cloned(), ",");
                         str("IDL.decode").append(enclose("(", params, ")"))
                     }
-                    Decode(bytes, tys, _, _) | NotDecode(bytes, tys) => pp_decode(&bytes, &tys),
+                    Decode(bytes, tys, _, _) | NotDecode(bytes, tys) => pp_decode(bytes, tys),
                 };
                 let (test_func, predicate) = match cmd {
                     Encode(_, _, true, _) | Decode(_, _, true, _) => (test_func, str(".toEqual")),
@@ -419,8 +419,8 @@ import { Principal } from './principal';
                     }
                 };
                 let expected = match cmd {
-                    Encode(_, tys, _, bytes) => pp_decode(&bytes, &tys),
-                    Decode(_, _, _, vals) => value::pp_args(&vals),
+                    Encode(_, tys, _, bytes) => pp_decode(bytes, tys),
+                    Decode(_, _, _, vals) => value::pp_args(vals),
                     NotEncode(_, _) | NotDecode(_, _) => RcDoc::nil(),
                 };
                 let expect = enclose("expect(", test_func, ")")

--- a/rust/candid/src/bindings/motoko.rs
+++ b/rust/candid/src/bindings/motoko.rs
@@ -125,7 +125,7 @@ fn pp_ty(ty: &Type) -> RcDoc {
         Func(ref func) => pp_function(func),
         Service(ref serv) => pp_service(serv),
         Class(ref args, ref t) => {
-            let doc = pp_args(&args).append(" -> async ");
+            let doc = pp_args(args).append(" -> async ");
             match t.as_ref() {
                 Service(ref serv) => doc.append(pp_service(serv)),
                 Var(ref s) => doc.append(s),

--- a/rust/candid/src/codegen/rust.rs
+++ b/rust/candid/src/codegen/rust.rs
@@ -33,7 +33,7 @@ pub fn candid_id_to_rust(id: &str) -> String {
     if id.starts_with(|c: char| !c.is_ascii_alphabetic() && c != '_')
         || id.chars().any(|c| !c.is_ascii_alphanumeric() && c != '_')
     {
-        format!("_{}_", idl_hash(&id))
+        format!("_{}_", idl_hash(id))
     } else if is_keyword(id) {
         format!("r#{}", id)
     } else {
@@ -270,16 +270,16 @@ impl<'a> LanguageBinding for RustLanguageBinding<'a> {
 
     fn declare(&self, id: &str, ty: &IDLType) -> Result<String> {
         match ty {
-            IDLType::PrimT(prim) => self.declare_prim(&id, prim),
-            IDLType::VarT(var) => self.declare_var(&id, var),
-            IDLType::FuncT(func) => self.declare_func(&id, func),
-            IDLType::OptT(sub_t) => self.declare_opt(&id, sub_t.as_ref()),
-            IDLType::VecT(item_t) => self.declare_vec(&id, item_t.as_ref()),
-            IDLType::RecordT(fields) => self.declare_record(&id, fields),
-            IDLType::VariantT(fields) => self.declare_variant(&id, fields),
-            IDLType::ServT(serv_t) => self.declare_service(&id, serv_t),
+            IDLType::PrimT(prim) => self.declare_prim(id, prim),
+            IDLType::VarT(var) => self.declare_var(id, var),
+            IDLType::FuncT(func) => self.declare_func(id, func),
+            IDLType::OptT(sub_t) => self.declare_opt(id, sub_t.as_ref()),
+            IDLType::VecT(item_t) => self.declare_vec(id, item_t.as_ref()),
+            IDLType::RecordT(fields) => self.declare_record(id, fields),
+            IDLType::VariantT(fields) => self.declare_variant(id, fields),
+            IDLType::ServT(serv_t) => self.declare_service(id, serv_t),
             IDLType::ClassT(_, _) => unreachable!(),
-            IDLType::PrincipalT => self.declare_var(&id, "principal"),
+            IDLType::PrincipalT => self.declare_var(id, "principal"),
         }
     }
     fn declare_prim(&self, id: &str, ty: &PrimType) -> Result<String> {
@@ -356,7 +356,7 @@ impl<'a> LanguageBinding for RustLanguageBinding<'a> {
                         .enumerate()
                         .map(|(i, ty)| {
                             let arg_name = format!("arg{}", i);
-                            let ty = self.usage(&ty)?;
+                            let ty = self.usage(ty)?;
 
                             Ok((arg_name, ty))
                         })
@@ -379,10 +379,7 @@ impl<'a> LanguageBinding for RustLanguageBinding<'a> {
 
 /// Takes an IDL string and returns a Rust string, unformatted.
 pub fn idl_to_rust(prog: &IDLProg, config: &Config) -> Result<String> {
-    let binding = RustLanguageBinding {
-        config,
-        prog: &prog,
-    };
+    let binding = RustLanguageBinding { config, prog };
 
-    generate_code(&prog, binding)
+    generate_code(prog, binding)
 }

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -670,7 +670,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 let wire = w[index].clone();
                 let expect = e
                     .iter()
-                    .find(|ref f| f.id == wire.id)
+                    .find(|f| f.id == wire.id)
                     .ok_or_else(|| Error::msg(format!("Unknown variant field {}", wire.id)))?
                     .clone();
                 visitor.visit_enum(Compound::new(&mut self, Style::Enum { expect, wire }))

--- a/rust/candid/src/error.rs
+++ b/rust/candid/src/error.rs
@@ -40,11 +40,11 @@ impl Error {
                         Label::primary((), *location..location + 1).with_message("Invalid token")
                     }
                     UnrecognizedEOF { location, expected } => {
-                        diag = diag.with_notes(report_expected(&expected));
+                        diag = diag.with_notes(report_expected(expected));
                         Label::primary((), *location..location + 1).with_message("Unexpected EOF")
                     }
                     UnrecognizedToken { token, expected } => {
-                        diag = diag.with_notes(report_expected(&expected));
+                        diag = diag.with_notes(report_expected(expected));
                         Label::primary((), token.0..token.2).with_message("Unexpected token")
                     }
                     ExtraToken { token } => {

--- a/rust/candid/src/parser/pretty.rs
+++ b/rust/candid/src/parser/pretty.rs
@@ -11,7 +11,7 @@ const MAX_ELEMENTS_FOR_PRETTY_PRINT: usize = 10;
 
 impl fmt::Display for IDLArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", pp_args(&self).pretty(80))
+        write!(f, "{}", pp_args(self).pretty(80))
     }
 }
 
@@ -20,7 +20,7 @@ impl fmt::Display for IDLValue {
         write!(
             f,
             "{}",
-            pp_value(MAX_ELEMENTS_FOR_PRETTY_PRINT, &self).pretty(80)
+            pp_value(MAX_ELEMENTS_FOR_PRETTY_PRINT, self).pretty(80)
         )
     }
 }
@@ -219,7 +219,7 @@ pub fn pp_value(depth: usize, v: &IDLValue) -> RcDoc {
                 let tuple = concat(fields.iter().map(|f| pp_value(depth - 1, &f.val)), ";");
                 kwd("record").append(enclose_space("{", tuple, "}"))
             } else {
-                kwd("record").append(pp_fields(depth, &fields))
+                kwd("record").append(pp_fields(depth, fields))
             }
         }
         Variant(v) => kwd("variant").append(enclose_space("{", pp_field(depth, &v.0, true), "}")),

--- a/rust/candid/src/parser/test.rs
+++ b/rust/candid/src/parser/test.rs
@@ -57,7 +57,7 @@ impl Input {
     fn check_round_trip(&self, v: &IDLArgs, env: &TypeEnv, types: &[Type]) -> Result<bool> {
         match self {
             Input::Blob(ref blob) => {
-                let bytes = v.to_bytes_with_types(&env, &types)?;
+                let bytes = v.to_bytes_with_types(env, types)?;
                 Ok(*blob == bytes)
             }
             Input::Text(_) => Ok(true), //Ok(*s == v.to_string()),

--- a/rust/candid/src/parser/typing.rs
+++ b/rust/candid/src/parser/typing.rs
@@ -62,7 +62,7 @@ impl TypeEnv {
         match t {
             Type::Service(s) => Ok(s),
             Type::Var(id) => self.as_service(self.find_type(id)?),
-            Type::Class(_, ty) => self.as_service(&ty),
+            Type::Class(_, ty) => self.as_service(ty),
             _ => Err(Error::msg(format!("not a service type: {}", t))),
         }
     }
@@ -325,7 +325,7 @@ fn check_actor(env: &Env, actor: &Option<IDLType>) -> Result<Option<Type>> {
             Ok(Some(Type::Class(args, Box::new(serv))))
         }
         Some(typ) => {
-            let t = check_type(env, &typ)?;
+            let t = check_type(env, typ)?;
             env.te.as_service(&t)?;
             Ok(Some(t))
         }

--- a/rust/candid/src/parser/value.rs
+++ b/rust/candid/src/parser/value.rs
@@ -67,7 +67,7 @@ impl IDLArgs {
     pub fn annotate_types(self, from_parser: bool, env: &TypeEnv, types: &[Type]) -> Result<Self> {
         let mut args = Vec::new();
         for (v, ty) in self.args.iter().zip(types.iter()) {
-            let v = v.annotate_type(from_parser, env, &ty)?;
+            let v = v.annotate_type(from_parser, env, ty)?;
             args.push(v);
         }
         for ty in types[self.args.len()..].iter() {
@@ -253,7 +253,7 @@ impl IDLValue {
                 }
                 return Err(Error::msg(format!("variant field {} not found", v.0.id)));
             }
-            (IDLValue::Principal(id), Type::Principal) => IDLValue::Principal(id.clone()),
+            (IDLValue::Principal(id), Type::Principal) => IDLValue::Principal(*id),
             (IDLValue::Service(_), Type::Service(_)) => self.clone(),
             (IDLValue::Func(_, _), Type::Func(_)) => self.clone(),
             (IDLValue::Number(str), t) if from_parser => match t {

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -344,7 +344,7 @@ impl TypeSerialize {
     fn encode(&self, buf: &mut Vec<u8>, t: &Type) -> Result<()> {
         if let Type::Var(id) = t {
             let actual_type = self.env.rec_find_type(id)?;
-            if types::internal::is_primitive(&actual_type) {
+            if types::internal::is_primitive(actual_type) {
                 return self.encode(buf, actual_type);
             }
         }
@@ -379,14 +379,14 @@ impl TypeSerialize {
             Type::Var(_) => {
                 let idx = self
                     .type_map
-                    .get(&t)
+                    .get(t)
                     .ok_or_else(|| Error::msg(format!("var type {} not found", t)))?;
                 sleb128_encode(buf, i64::from(*idx))
             }
             _ => {
                 let idx = self
                     .type_map
-                    .get(&t)
+                    .get(t)
                     .ok_or_else(|| Error::msg(format!("type {} not found", t)))?;
                 sleb128_encode(buf, i64::from(*idx))
             }

--- a/rust/candid/src/types/impls.rs
+++ b/rust/candid/src/types/impls.rs
@@ -148,7 +148,7 @@ impl CandidType for serde_bytes::ByteBuf {
     where
         S: Serializer,
     {
-        serializer.serialize_blob(&self.as_slice())
+        serializer.serialize_blob(self.as_slice())
     }
 }
 impl CandidType for serde_bytes::Bytes {
@@ -159,7 +159,7 @@ impl CandidType for serde_bytes::Bytes {
     where
         S: Serializer,
     {
-        serializer.serialize_blob(&self)
+        serializer.serialize_blob(self)
     }
 }
 

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -24,7 +24,7 @@ impl TypeId {
 }
 impl std::fmt::Display for TypeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name = NAME.with(|n| n.borrow_mut().get(&self));
+        let name = NAME.with(|n| n.borrow_mut().get(self));
         write!(f, "{}", name)
     }
 }
@@ -208,7 +208,7 @@ impl Type {
 }
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", crate::bindings::candid::pp_ty(&self).pretty(80))
+        write!(f, "{}", crate::bindings::candid::pp_ty(self).pretty(80))
     }
 }
 
@@ -269,7 +269,7 @@ impl fmt::Display for Function {
         write!(
             f,
             "{}",
-            crate::bindings::candid::pp_function(&self).pretty(80)
+            crate::bindings::candid::pp_function(self).pretty(80)
         )
     }
 }

--- a/rust/candid/src/types/mod.rs
+++ b/rust/candid/src/types/mod.rs
@@ -4,6 +4,7 @@
 //!    We do not use Serde's `Serialize` trait because Candid requires serializing types along with the values.
 //!    This is difficult to achieve in `Serialize`, especially for enum types.
 
+pub use ic_types;
 use serde::ser::Error;
 
 mod impls;

--- a/rust/candid/src/types/principal.rs
+++ b/rust/candid/src/types/principal.rs
@@ -1,6 +1,6 @@
 use super::{CandidType, Serializer, Type, TypeId};
 
-pub type Principal = ic_types::Principal;
+pub use ic_types::Principal;
 
 impl CandidType for Principal {
     fn id() -> TypeId {

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -138,10 +138,10 @@ fn test_reserved() {
 fn test_reference() {
     use candid::{Func, Principal, Service};
     let principal = Principal::from_text("w7x7r-cok77-xa").unwrap();
-    all_check(principal.clone(), "4449444c0001680103caffee");
+    all_check(principal, "4449444c0001680103caffee");
     all_check(
         Service {
-            principal: principal.clone(),
+            principal,
         },
         "4449444c01690001000103caffee",
     );

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -139,12 +139,7 @@ fn test_reference() {
     use candid::{Func, Principal, Service};
     let principal = Principal::from_text("w7x7r-cok77-xa").unwrap();
     all_check(principal, "4449444c0001680103caffee");
-    all_check(
-        Service {
-            principal,
-        },
-        "4449444c01690001000103caffee",
-    );
+    all_check(Service { principal }, "4449444c01690001000103caffee");
     all_check(
         Func {
             principal,


### PR DESCRIPTION
Also re-export `ic_types`.
Also clippy fixes.