### PR TITLE
chore: removes default exports from types

### DIFF
--- a/rust/candid/src/bindings/javascript.rs
+++ b/rust/candid/src/bindings/javascript.rs
@@ -250,7 +250,8 @@ pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {
             };
             let actor = kwd("return").append(pp_actor(actor, &recs)).append(";");
             let body = defs.append(actor);
-            let doc = str("export const idlFactory = ({ IDL }) => ").append(enclose_space("{", body, "};"));
+            let doc = str("export const idlFactory = ({ IDL }) => ")
+                .append(enclose_space("{", body, "};"));
             // export init args
             let init_defs = chase_types(env, init).unwrap();
             let init_recs = infer_rec(env, &init_defs).unwrap();

--- a/rust/candid/src/bindings/javascript.rs
+++ b/rust/candid/src/bindings/javascript.rs
@@ -250,7 +250,7 @@ pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {
             };
             let actor = kwd("return").append(pp_actor(actor, &recs)).append(";");
             let body = defs.append(actor);
-            let doc = str("export default ({ IDL }) => ").append(enclose_space("{", body, "};"));
+            let doc = str("export const idlFactory = ({ IDL }) => ").append(enclose_space("{", body, "};"));
             // export init args
             let init_defs = chase_types(env, init).unwrap();
             let init_recs = infer_rec(env, &init_defs).unwrap();

--- a/rust/candid/src/bindings/typescript.rs
+++ b/rust/candid/src/bindings/typescript.rs
@@ -137,7 +137,7 @@ fn pp_defs<'a>(env: &'a TypeEnv, def_list: &'a [&'a str]) -> RcDoc<'a> {
                 .append(pp_ty(ty))
                 .append(";"),
         };
-        export.append("")
+        export
     }))
 }
 

--- a/rust/candid/src/bindings/typescript.rs
+++ b/rust/candid/src/bindings/typescript.rs
@@ -143,10 +143,10 @@ fn pp_defs<'a>(env: &'a TypeEnv, def_list: &'a [&'a str]) -> RcDoc<'a> {
 
 fn pp_actor<'a>(env: &'a TypeEnv, ty: &'a Type) -> RcDoc<'a> {
     match ty {
-        Type::Service(ref serv) => {
-            kwd("export interface _SERVICE").append(pp_service(env, serv))
-        }
-        Type::Var(id) => kwd("export interface _SERVICE extends").append(str(id)).append(str(" {}")),
+        Type::Service(ref serv) => kwd("export interface _SERVICE").append(pp_service(env, serv)),
+        Type::Var(id) => kwd("export interface _SERVICE extends")
+            .append(str(id))
+            .append(str(" {}")),
         Type::Class(_, t) => pp_actor(env, t),
         _ => unreachable!(),
     }

--- a/rust/candid/src/bindings/typescript.rs
+++ b/rust/candid/src/bindings/typescript.rs
@@ -129,13 +129,15 @@ fn pp_defs<'a>(env: &'a TypeEnv, def_list: &'a [&'a str]) -> RcDoc<'a> {
             Type::Func(ref func) => kwd("export type")
                 .append(ident(id))
                 .append(" = ")
-                .append(pp_function(env, func)),
+                .append(pp_function(env, func))
+                .append(";"),
             _ => kwd("export type")
                 .append(ident(id))
                 .append(" = ")
-                .append(pp_ty(ty)),
+                .append(pp_ty(ty))
+                .append(";"),
         };
-        export.append(";")
+        export.append("")
     }))
 }
 
@@ -156,7 +158,7 @@ pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {
     let defs = pp_defs(env, &def_list);
     let actor = match actor {
         None => RcDoc::nil(),
-        Some(actor) => pp_actor(env, actor).append(";"),
+        Some(actor) => pp_actor(env, actor),
     };
     let doc = RcDoc::text(header)
         .append(RcDoc::line())

--- a/rust/candid/src/bindings/typescript.rs
+++ b/rust/candid/src/bindings/typescript.rs
@@ -142,9 +142,9 @@ fn pp_defs<'a>(env: &'a TypeEnv, def_list: &'a [&'a str]) -> RcDoc<'a> {
 fn pp_actor<'a>(env: &'a TypeEnv, ty: &'a Type) -> RcDoc<'a> {
     match ty {
         Type::Service(ref serv) => {
-            kwd("export default interface _SERVICE").append(pp_service(env, serv))
+            kwd("export interface _SERVICE").append(pp_service(env, serv))
         }
-        Type::Var(id) => kwd("export default").append(str(id)),
+        Type::Var(id) => kwd("export").append(str(id)),
         Type::Class(_, t) => pp_actor(env, t),
         _ => unreachable!(),
     }

--- a/rust/candid/src/bindings/typescript.rs
+++ b/rust/candid/src/bindings/typescript.rs
@@ -146,7 +146,7 @@ fn pp_actor<'a>(env: &'a TypeEnv, ty: &'a Type) -> RcDoc<'a> {
         Type::Service(ref serv) => {
             kwd("export interface _SERVICE").append(pp_service(env, serv))
         }
-        Type::Var(id) => kwd("export").append(str(id)),
+        Type::Var(id) => kwd("export interface _SERVICE extends").append(str(id)).append(str(" {}")),
         Type::Class(_, t) => pp_actor(env, t),
         _ => unreachable!(),
     }

--- a/rust/candid/tests/assets/ok/actor.d.ts
+++ b/rust/candid/tests/assets/ok/actor.d.ts
@@ -3,9 +3,9 @@ export type f = (arg_0: number) => Promise<number>;
 export type g = f;
 export type h = (arg_0: [Principal, string]) => Promise<[Principal, string]>;
 export type o = [] | [o];
-export default interface _SERVICE {
+export interface _SERVICE {
   'f' : (arg_0: bigint) => Promise<[Principal, string]>,
   'g' : f,
   'h' : g,
   'o' : (arg_0: o) => Promise<o>,
-};
+}

--- a/rust/candid/tests/assets/ok/actor.js
+++ b/rust/candid/tests/assets/ok/actor.js
@@ -1,4 +1,4 @@
-export default ({ IDL }) => {
+export const idlFactory = ({ IDL }) => {
   const o = IDL.Rec();
   const f = IDL.Func([IDL.Int8], [IDL.Int8], []);
   const h = IDL.Func([f], [f], []);

--- a/rust/candid/tests/assets/ok/class.d.ts
+++ b/rust/candid/tests/assets/ok/class.d.ts
@@ -1,6 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 export type List = [] | [[bigint, List]];
-export default interface _SERVICE {
+export interface _SERVICE {
   'get' : () => Promise<List>,
   'set' : (arg_0: List) => Promise<List>,
-};
+}

--- a/rust/candid/tests/assets/ok/class.js
+++ b/rust/candid/tests/assets/ok/class.js
@@ -1,4 +1,4 @@
-export default ({ IDL }) => {
+export const idlFactory = ({ IDL }) => {
   const List = IDL.Rec();
   List.fill(IDL.Opt(IDL.Tuple(IDL.Int, List)));
   return IDL.Service({

--- a/rust/candid/tests/assets/ok/cyclic.d.ts
+++ b/rust/candid/tests/assets/ok/cyclic.d.ts
@@ -5,8 +5,8 @@ export type C = A;
 export type X = Y;
 export type Y = Z;
 export type Z = A;
-export default interface _SERVICE {
+export interface _SERVICE {
   'f' : (arg_0: A, arg_1: B, arg_2: C, arg_3: X, arg_4: Y, arg_5: Z) => Promise<
       undefined
     >,
-};
+}

--- a/rust/candid/tests/assets/ok/cyclic.js
+++ b/rust/candid/tests/assets/ok/cyclic.js
@@ -1,4 +1,4 @@
-export default ({ IDL }) => {
+export const idlFactory = ({ IDL }) => {
   const A = IDL.Rec();
   const C = A;
   const B = IDL.Opt(C);

--- a/rust/candid/tests/assets/ok/escape.d.ts
+++ b/rust/candid/tests/assets/ok/escape.d.ts
@@ -4,7 +4,7 @@ export interface t {
   '\'' : bigint,
   '\"\'' : bigint,
   '\\\n\'\"' : bigint,
-};
-export default interface _SERVICE {
+}
+export interface _SERVICE {
   '\n\'\"\'\'\"\"\r\t' : (arg_0: t) => Promise<undefined>,
-};
+}

--- a/rust/candid/tests/assets/ok/escape.js
+++ b/rust/candid/tests/assets/ok/escape.js
@@ -1,4 +1,4 @@
-export default ({ IDL }) => {
+export const idlFactory = ({ IDL }) => {
   const t = IDL.Record({
     '\"' : IDL.Nat,
     '\'' : IDL.Nat,

--- a/rust/candid/tests/assets/ok/example.d.ts
+++ b/rust/candid/tests/assets/ok/example.d.ts
@@ -1,6 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 export type List = [] | [{ 'head' : bigint, 'tail' : List }];
-export interface broker { 'find' : (arg_0: string) => Promise<Principal> };
+export interface broker { 'find' : (arg_0: string) => Promise<Principal> }
 export type f = (arg_0: List, arg_1: [Principal, string]) => Promise<
     [] | [List]
   >;
@@ -16,8 +16,8 @@ export interface nested {
     { 'B' : null } |
     { 'C' : null },
   _42_ : bigint,
-};
-export default interface _SERVICE {
+}
+export interface _SERVICE {
   'f' : (arg_0: Array<number>, arg_1: [] | [boolean]) => Promise<undefined>,
   'g' : (
       arg_0: my_type,
@@ -32,4 +32,4 @@ export default interface _SERVICE {
       arg_2: [] | [List],
     ) => Promise<{ _42_ : {}, 'id' : bigint }>,
   'i' : f,
-};
+}

--- a/rust/candid/tests/assets/ok/example.js
+++ b/rust/candid/tests/assets/ok/example.js
@@ -1,4 +1,4 @@
-export default ({ IDL }) => {
+export const idlFactory = ({ IDL }) => {
   const List = IDL.Rec();
   const my_type = IDL.Principal;
   List.fill(IDL.Opt(IDL.Record({ 'head' : IDL.Int, 'tail' : List })));

--- a/rust/candid/tests/assets/ok/fieldnat.d.ts
+++ b/rust/candid/tests/assets/ok/fieldnat.d.ts
@@ -1,7 +1,7 @@
 import type { Principal } from '@dfinity/principal';
-export interface non_tuple { _1_ : string, _2_ : string };
+export interface non_tuple { _1_ : string, _2_ : string }
 export type tuple = [string, string];
-export default interface _SERVICE {
+export interface _SERVICE {
   'bab' : (arg_0: bigint, arg_1: bigint) => Promise<undefined>,
   'bar' : (arg_0: { '2' : bigint }) => Promise<undefined>,
   'bas' : (arg_0: [bigint, bigint]) => Promise<[string, bigint]>,
@@ -9,4 +9,4 @@ export default interface _SERVICE {
   'bba' : (arg_0: tuple) => Promise<non_tuple>,
   'bib' : (arg_0: [bigint]) => Promise<{ _0_ : bigint }>,
   'foo' : (arg_0: { _2_ : bigint }) => Promise<{ _2_ : bigint, '_2' : bigint }>,
-};
+}

--- a/rust/candid/tests/assets/ok/fieldnat.js
+++ b/rust/candid/tests/assets/ok/fieldnat.js
@@ -1,4 +1,4 @@
-export default ({ IDL }) => {
+export const idlFactory = ({ IDL }) => {
   const tuple = IDL.Tuple(IDL.Text, IDL.Text);
   const non_tuple = IDL.Record({ _1_ : IDL.Text, _2_ : IDL.Text });
   return IDL.Service({

--- a/rust/candid/tests/assets/ok/keyword.d.ts
+++ b/rust/candid/tests/assets/ok/keyword.d.ts
@@ -4,15 +4,15 @@ export type if_ = {
   } |
   { 'leaf' : bigint };
 export type list = [] | [node];
-export interface node { 'head' : bigint, 'tail' : list };
+export interface node { 'head' : bigint, 'tail' : list }
 export type o = [] | [o];
 export interface return_ {
   'f' : t,
   'g' : (arg_0: list) => Promise<[if_, stream]>,
-};
+}
 export type stream = [] | [{ 'head' : bigint, 'next' : [Principal, string] }];
 export type t = (arg_0: Principal) => Promise<undefined>;
-export default interface _SERVICE {
+export interface _SERVICE {
   'Oneway' : () => Promise<undefined>,
   'f_' : (arg_0: o) => Promise<o>,
   'field' : (arg_0: { 'test' : number, _1291438163_ : number }) => Promise<{}>,
@@ -31,4 +31,4 @@ export default interface _SERVICE {
         { 'C' : null } |
         { 'D' : number },
     ) => Promise<undefined>,
-};
+}

--- a/rust/candid/tests/assets/ok/keyword.js
+++ b/rust/candid/tests/assets/ok/keyword.js
@@ -1,4 +1,4 @@
-export default ({ IDL }) => {
+export const idlFactory = ({ IDL }) => {
   const if_ = IDL.Rec();
   const list = IDL.Rec();
   const o = IDL.Rec();

--- a/rust/candid/tests/assets/ok/recursion.d.ts
+++ b/rust/candid/tests/assets/ok/recursion.d.ts
@@ -2,15 +2,14 @@ import type { Principal } from '@dfinity/principal';
 export type A = B;
 export type B = [] | [A];
 export type list = [] | [node];
-export interface node { 'head' : bigint, 'tail' : list };
+export interface node { 'head' : bigint, 'tail' : list }
 export interface s {
   'f' : t,
   'g' : (arg_0: list) => Promise<[B, tree, stream]>,
-};
+}
 export type stream = [] | [{ 'head' : bigint, 'next' : [Principal, string] }];
 export type t = (arg_0: Principal) => Promise<undefined>;
 export type tree = {
     'branch' : { 'val' : bigint, 'left' : tree, 'right' : tree }
   } |
   { 'leaf' : bigint };
-export default s;

--- a/rust/candid/tests/assets/ok/recursion.d.ts
+++ b/rust/candid/tests/assets/ok/recursion.d.ts
@@ -13,3 +13,4 @@ export type tree = {
     'branch' : { 'val' : bigint, 'left' : tree, 'right' : tree }
   } |
   { 'leaf' : bigint };
+export interface _SERVICE extends s {}

--- a/rust/candid/tests/assets/ok/recursion.js
+++ b/rust/candid/tests/assets/ok/recursion.js
@@ -1,4 +1,4 @@
-export default ({ IDL }) => {
+export const idlFactory = ({ IDL }) => {
   const B = IDL.Rec();
   const list = IDL.Rec();
   const s = IDL.Rec();

--- a/rust/candid/tests/assets/ok/recursive_class.d.ts
+++ b/rust/candid/tests/assets/ok/recursive_class.d.ts
@@ -1,2 +1,3 @@
 import type { Principal } from '@dfinity/principal';
 export interface s { 'next' : () => Promise<Principal> }
+export interface _SERVICE extends s {}

--- a/rust/candid/tests/assets/ok/recursive_class.d.ts
+++ b/rust/candid/tests/assets/ok/recursive_class.d.ts
@@ -1,3 +1,2 @@
 import type { Principal } from '@dfinity/principal';
-export interface s { 'next' : () => Promise<Principal> };
-export default s;
+export interface s { 'next' : () => Promise<Principal> }

--- a/rust/candid/tests/assets/ok/recursive_class.js
+++ b/rust/candid/tests/assets/ok/recursive_class.js
@@ -1,4 +1,4 @@
-export default ({ IDL }) => {
+export const idlFactory = ({ IDL }) => {
   const s = IDL.Rec();
   s.fill(IDL.Service({ 'next' : IDL.Func([], [s], []) }));
   return s.getType();

--- a/rust/candid/tests/assets/ok/unicode.d.ts
+++ b/rust/candid/tests/assets/ok/unicode.d.ts
@@ -4,14 +4,14 @@ export interface A {
   '📦🍦' : bigint,
   '字段名' : bigint,
   '字 段 名2' : bigint,
-};
+}
 export type B = { '' : null } |
   { '空的' : null } |
   { '  空的  ' : null } |
   { '1⃣️2⃣️3⃣️' : null };
-export default interface _SERVICE {
+export interface _SERVICE {
   '' : (arg_0: bigint) => Promise<bigint>,
   '✈️  🚗 ⛱️ ' : () => Promise<undefined>,
   '函数名' : (arg_0: A) => Promise<B>,
   '👀' : (arg_0: bigint) => Promise<bigint>,
-};
+}

--- a/rust/candid/tests/assets/ok/unicode.js
+++ b/rust/candid/tests/assets/ok/unicode.js
@@ -1,4 +1,4 @@
-export default ({ IDL }) => {
+export const idlFactory = ({ IDL }) => {
   const A = IDL.Record({
     '\u{e000}' : IDL.Nat,
     '📦🍦' : IDL.Nat,

--- a/tools/didc/README.md
+++ b/tools/didc/README.md
@@ -46,9 +46,9 @@ record { edit { 1 put { 5 } }; edit { 2 put { 9 } }; }
 skip
 
 $ didc bind hello.did -t js
-export default ({ IDL }) => {
+export const idlFactory = ({ IDL }) => {
   return IDL.Service({ 'greet' : IDL.Func([IDL.Text], [IDL.Text], []) });
-};
+}
 
 $ didc random -t '(int, text)'
 (-72_594_379_354_493_140_610_202_928_640_651_761_468, "_J`:t7^>")


### PR DESCRIPTION
**Overview**
Why do we need this feature? What are we trying to accomplish?
This will support automatic type inference in `dfx` projects

**Changes**

- typescript bindings will no longer use default exports, instead favoring named _SERVICE export
- javascript exports named `idlFactory` instead of default export
- typescript interface no longer appends semicolon

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?

Some existing TypeScript projects may require updates after updating `dfx`