### PR TITLE
chore: upgrade ic-types to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,9 +741,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ic-types"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f0b1f1517d697f67a8b5ad558ef6b9372ed1fc5ab669a519d7fa1837e8f88a"
+checksum = "471541b20b3d2bb26dd81ac0c44c66eabeaa2ba3641e96606b6c66f86a035a27"
 dependencies = [
  "base32",
  "crc32fast",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "1.4.3"
 candid_derive = { path = "../candid_derive", version = "=0.4.5" }
 codespan-reporting = "0.11"
 hex = "0.4.2"
-ic-types = "0.2.0"
+ic-types = "0.2.1"
 lalrpop-util = "0.19.0"
 leb128 = "0.2.4"
 logos = "0.12"


### PR DESCRIPTION
In https://github.com/dfinity/agent-rs/pull/232 which already upgrade `ic-types` to 0.2.1, the `ic-ref` tests failed because `candid` haven't been upgraded to use the latest `ic-types`.

And since https://github.com/dfinity/candid/pull/260 has been merged, this dependency upgrade should not break `candid` anymore.