### PR TITLE
Improving the documentation.

### DIFF
--- a/docs/modules/candid-guide/index.adoc
+++ b/docs/modules/candid-guide/index.adoc
@@ -51,7 +51,7 @@ The features that make Candid particularly well-suited for developing dapps for 
 
 * Candid defines rules for how services and their interface can be upgraded in a sound and compositional way.
 
-* Candid is inherently a higher order language. With Candid, you can pass more than plain data, including references to services and methods. Candid support for safe upgrades takes such higher-order use into account.
+* Candid is inherently a higher-order language. With Candid, you can pass more than plain data, including references to services and methods. Candid support for safe upgrades takes such higher-order use into account.
 
 * Candid has built-in support for specific Internet Computer features, such as the `+query+` annotation.
 

--- a/docs/modules/candid-guide/index.adoc
+++ b/docs/modules/candid-guide/index.adoc
@@ -1,20 +1,20 @@
 = Candid
 
-Welcome to the Candid documentation for application developers. 
+Welcome to the Candid documentation for developers.
 
-This _Candid Guide_ explains what Candid is and how you can use it when developing programs to run on the {IC}.
+This _Candid Guide_ explains what Candid is and how you can use it when developing dapps to run on the {IC}.
 The information here is intended primarily for back-end and front-end developers who want to deploy canisters on the {IC}.
 If you want to _implement_ support for a new language or _extend_ existing Candid features, you should refer to the formal
 link:https://github.com/dfinity/candid/blob/master/spec/Candid.md[Candid implementation specification] for background information and details about the internal structure of the language.
 
-* The link:candid-concepts{outfilesuffix}[What is Candid?] section introduces the purpose and key features of the Candid interface description language. 
-It includes an overview of how Candid works and some simple examples to give you a working knowledge of how you can apply Candid to your use case. 
-* The link:candid-howto{outfilesuffix}[How to] section explains how to perform typical tasks. 
+* The link:candid-concepts{outfilesuffix}[What is Candid?] section introduces the purpose and key features of the Candid interface description language.
+It includes an overview of how Candid works and some simple examples to give you a working knowledge of how you can apply Candid to your use case.
+* The link:candid-howto{outfilesuffix}[How to] section explains how to perform typical tasks.
 * The link:candid-ref{outfilesuffix}[Reference] section provides links to Candid tools and libraries and detailed reference information about Candid supported types.
 
 == What is Candid?
 
-Candid is an _interface description language_. Its primary purpose is to describe the public interface of a **service**, usually in the form of a program deployed as a **canister** that runs on the Internet Computer. 
+Candid is an _interface description language_. Its primary purpose is to describe the public interface of a **service**, usually in the form of a program deployed as a **canister smart contract** that runs on the Internet Computer.
 One of the key benefits of Candid is that it is language-agnostic, and allows inter-operation between services and front-ends written in different programming languages, including Motoko, Rust, and JavaScript.
 
 A typical interface description in Candid might look like this:
@@ -27,31 +27,31 @@ service counter : {
 }
 ....
 
-In this example, the described service—`+counter+`—consists of the following public methods. 
+In this example, the described service—`+counter+`—consists of the following public methods.
 - The `+add+` and `+subtract+` methods change the value of a counter.
 - The `+get+` method reads the current value of a counter.
 - The `+subscribe+` method can be used to invoke another function, for example, to invoke a notification callback method each time the counter value changes.
 
-As this example illustrates, every method has a sequence of argument and result types. 
+As this example illustrates, every method has a sequence of argument and result types.
 A method can also include annotations—like the `+query+` notation shown in this example—that are specific to the Internet Computer.
 
-Given this simple interface description, it is possible for you to interact with this `+counter+` service directly from the command line or through a web-based front-end or programmatically from a Rust program or using through another programming or scripting language. 
+Given this simple interface description, it is possible for you to interact with this `+counter+` service directly from the command line or through a web-based front-end or programmatically from a Rust program or through another programming or scripting language.
 
 In addition to interoperability, Candid supports the evolution of service interfaces by precisely specifying the changes that can be made without breaking existing clients. For example, you can safely add new optional parameters to a service without losing compatibility for existing clients.
 
 == Why create a new IDL?
 
-At first glance, you might think that other technologies, such as JSON, XML, or Protobuf, would suffice. 
+At first glance, you might think that other technologies, such as JSON, XML, or Protobuf, would suffice.
 However, Candid provides a unique combination of features that are not found in these other technologies.
-The features that make Candid particularly well-suited for developing applications for the Internet Computer include the following:
+The features that make Candid particularly well-suited for developing dapps for the Internet Computer include the following:
 
 * Many languages like JSON, XML, and Protobuf only describe how to map individual values to bytes or characters. These data description languages do not describe services as a whole. These languages focus on the data types you want to transfer instead of the methods that make use of those data types.
 
-* Candid implementations map the Candid value directly to types and values of the host language. With Candid, programmers do not construct or deconstruct some abstract `+Candid+` value.
+* Candid implementations map the Candid value directly to types and values of the host language. With Candid, developers do not construct or deconstruct some abstract `+Candid+` value.
 
 * Candid defines rules for how services and their interface can be upgraded in a sound and compositional way.
 
-* Candid is inherently a higher order languages. With Candid, you can pass more than plain data, including references to services and methods. Candid support for safe upgrades takes such higher-order use into account.
+* Candid is inherently a higher order language. With Candid, you can pass more than plain data, including references to services and methods. Candid support for safe upgrades takes such higher-order use into account.
 
 * Candid has built-in support for specific Internet Computer features, such as the `+query+` annotation.
 
@@ -94,12 +94,12 @@ service : {
 }
 ....
 
-This example describes a service that supports a single public method called `+ping+`. 
+This example describes a service that supports a single public method called `+ping+`.
 Method names can be arbitrary strings, and you can quote them (`"method with spaces"`) if they are not plain identifiers.
 
-Methods declare a _sequence_ of arguments and result types. In the case of this `+ping+` method, no arguments are passed and no results are returned, so the empty sequence `+()+ ` is used for both arguments and results. 
+Methods declare a _sequence_ of arguments and result types. In the case of this `+ping+` method, no arguments are passed and no results are returned, so the empty sequence `+()+ ` is used for both arguments and results.
 
-Now that you've seen the simplest case, let's consider a slightly more complex service description. 
+Now that you've seen the simplest case, let's consider a slightly more complex service description.
 This service consists of two methods—`+reverse+` and `+divMod+`—and each method include a sequence of argument and result types:
 
 ....
@@ -115,9 +115,9 @@ The method `+divMod+` expects and returns two values, all of type `+nat+`.
 
 == Naming arguments and results
 
-In the previous example, the signature for the `+divMod+` method includes names for the argument and result values. 
+In the previous example, the signature for the `+divMod+` method includes names for the argument and result values.
 Naming the arguments or results for a method is purely for documentation purposes.
-The name you use does not change the method’s type or the values being passed. 
+The name you use does not change the method’s type or the values being passed.
 Instead, arguments and results are identified by their _position_, independent of the name.
 
 In particular, Candid does not prevent you from changing the type to
@@ -149,7 +149,7 @@ These type definitions merely abbreviate an _existing_ type, they do not define 
 
 == Specifying a query method
 
-In the last example, you might have noticed the use of the `+query+` annotation for the `+get_address+` method. 
+In the last example, you might have noticed the use of the `+query+` annotation for the `+get_address+` method.
 For example:
 ....
 service address_book : {
@@ -159,14 +159,14 @@ service address_book : {
 ....
 
 This annotation indicates that the `+get_address+` method can be invoked as an {IC} *query call*.
-As discussed in link:developers-guide:concepts/canisters-code{outfilesuffix}#query-update[Query and update methods], a query provides an efficient way to retrieve information from a canister without going through consensus, so being able to identify a method as a query one of the key benefits of using Candid to interact with the {IC}.
+As discussed in link:developers-guide:concepts/canisters-code{outfilesuffix}#query-update[Query and update methods], a query provides an efficient way to retrieve information from a canister smart contract without going through consensus, so being able to identify a method as a query is one of the key benefits of using Candid to interact with the {IC}.
 
 == Encoding and decoding
 
 The point of Candid is to allow seamless invocation of service methods, passing arguments encoded to a binary format and transferred by an underlying transportation method (such as messages into or within the Internet Computer), and decoded on the other side.
 
-As a Candid user, you do not have to worry about the details of this binary format. 
-If you plan to _implement_ Candid yourself (for example, to support a new host language), you can consult the link:https://github.com/dfinity/candid[Candid specification] for details. 
+As a Candid user, you do not have to worry about the details of this binary format.
+If you plan to _implement_ Candid yourself (for example, to support a new host language), you can consult the link:https://github.com/dfinity/candid[Candid specification] for details.
 However, some aspects of the format are worth knowing:
 
 * The Candid binary format starts with `+DIDL…+` (or, in hex, `+4449444c…+`). If you see this in some low-level log output, you are very likely observing a Candid-encoded value.
@@ -175,14 +175,14 @@ However, some aspects of the format are worth knowing:
 
 * The binary format is quite compact. A `+(vec nat64)+` with 125 000 entries takes 1 000 007 bytes.
 
-* The binary is self-describing, and includes a (condensed) description of type of the values therein. This allows the receiving side to detect if a message was sent at a different, incompatible type.
+* The binary is self-describing, and includes a (condensed) type description of the values therein. This allows the receiving side to detect if a message was sent as a different, incompatible type.
 
-* As long as the sender serializes the arguments at the same type that the receiving side expects them, deserialization will succeed.
+* As long as the sender serializes the arguments as the type that the receiving side expects, deserialization will succeed.
 
 [#upgrades]
 == Service upgrades
 
-Services evolve over time: They gain new methods, existing methods return more data, or expect additional arguments. Usually, service authors want to do that without breaking existing clients.
+Services evolve over time: They gain new methods, existing methods return more data, or expect additional arguments. Usually, developers want to do that without breaking existing clients.
 
 Candid supports such evolution by defining precise rules that indicate when the new service type will still be able to communicate with all other parties that are using the previous interface description. The underlying formalism is that of _subtyping_.
 
@@ -191,7 +191,7 @@ Services can safely evolve in the following ways:
  * New methods can be added.
  * Existing methods can return additional values, that is, the sequence of result types can be extended. Old clients will simply ignore additional values.
  * Existing methods can shorten their parameter list. Old clients may still send the extra arguments, but they will be ignored.
- * Existing methods can extend their parameter list with optional arguments (type `+opt …+`). When reading messages from old clients, who do not pass that argument, a `+null+` values is assumed.
+ * Existing methods can extend their parameter list with optional arguments (type `+opt …+`). When reading messages from old clients, who do not pass that argument, a `+null+` value is assumed.
  * Existing parameter types may be _changed_, but only to a _supertype_ of the previous type.
  * Existing result types may be _changed_, but only to a _subtype_ of the previous type.
 
@@ -226,14 +226,14 @@ service counter : {
 == Candid textual values
 
 The main purpose of Candid is to connect programs written in some host language—Motoko, Rust, or JavaScript, for example—with the {IC}.
-In most cases, therefore, you do not have to deal with your program data as Candid values. 
-Instead, you work with a host language like JavaScript using familiar JavaScript values then rely on Candid to transparently transport those values to a canister written in Rust or Motoko.
-The canister receive the values treats them as native Rust or Motoko values.
+In most cases, therefore, you do not have to deal with your program data as Candid values.
+Instead, you work with a host language like JavaScript using familiar JavaScript values then rely on Candid to transparently transport those values to a canister smart contract written in Rust or Motoko.
+The canister receiving the values treats them as native Rust or Motoko values.
 
-However, there are some cases—for example, when logging, debugging, or interacting with a service on the command-line—where it is useful to see the Candid values directly in a human-readable form. 
+However, there are some cases—for example, when logging, debugging, or interacting with a service on the command-line—where it is useful to see the Candid values directly in a human-readable form.
 In these scenarios, you can use the _textual presentation_ for Candid values.
 
-The syntax is similar to that for candid types. 
+The syntax is similar to that for candid types.
 For example, a typical textual presentation for a Candid value might look like this:
 
 ....
@@ -259,7 +259,7 @@ The Candid _binary_ format does not include the actual field names, merely numer
 
 In the <<candid-service-descriptions,section above>>, you learned how to write a Candid service description from scratch. But often, that is not even needed! Depending on the language you use to implement your service, you can get the Candid service description generated from your code.
 
-For example, in Motoko, you can write a canister like this:
+For example, in Motoko, you can write a canister smart contract like this:
 
 ....
 actor {
@@ -302,7 +302,7 @@ If you are writing a service from scratch in Motoko, then you need to take no sp
 
 For example, in a multi-canister project, dfx will ensure that any clients of your Motoko service will import the generated Candid description of that service.
 
-If you want to implement a _specific_ interface, for example because you want to interact with a service that expects your canister to have that interface, you can consult the 
+If you want to implement a _specific_ interface, for example because you want to interact with a service that expects your canister to have that interface, you can consult the
 reference below to figure which Motoko types to use to achieve this effect. In the future, this will be simplified.
 
 === How do I use Candid as Rust canister developer?
@@ -353,10 +353,10 @@ For each type, the reference includes the following information:
 Subtypes are the types you can change your method _results_ to.
 Supertypes are the types that you can change your method _arguments_ to.
 
-You should note that this reference only lists the specific subtypes and supertypes that are relevant for each type. 
-It does not repeat common information about subtypes and supertypes that can apply to any type. 
+You should note that this reference only lists the specific subtypes and supertypes that are relevant for each type.
+It does not repeat common information about subtypes and supertypes that can apply to any type.
 For example, the reference does not list `+empty+` as a subtype because it can be a subtype of any other type.
-Similarly, the types `+reserved+` and `+opt t+` are not listed as supertypes of specific types because they are supertypes of any type. 
+Similarly, the types `+reserved+` and `+opt t+` are not listed as supertypes of specific types because they are supertypes of any type.
 For details about the subtyping rules for the `+empty+`, `+reserved+`, and `+opt t+` types, see the <<type-empty,`+empty+` type>>, the <<type-reserved,`+reserved+` type>>, and the <<type-opt,`+opt t+` type>> sections.
 
 [#type-text]

--- a/docs/modules/candid-guide/pages/candid-howto.adoc
+++ b/docs/modules/candid-guide/pages/candid-howto.adoc
@@ -1,8 +1,8 @@
 = How to
 :!page-repl:
 
-As discussed in link:candid-concepts{outfilesuffix}[What is Candid?], Candid provides a language-agnostic way to interact with canisters.
-By using Candid, you can specify input argument values and display return values from canister methods regardless of whether you interact with the {IC} from a terminal using the `+dfx+` command-line interface, through a web browser, or from a program written in JavaScript, {proglang}, Rust, or other language.
+As discussed in link:candid-concepts{outfilesuffix}[What is Candid?], Candid provides a language-agnostic way to interact with canister smart contracts.
+By using Candid, you can specify input argument values and display return values from canister methods regardless of whether you interact with the {IC} from a terminal using the `+dfx+` command-line interface, through a web browser, or from a program written in JavaScript, {proglang}, Rust, or any other language.
 Now that you are familiar with what Candid is and how it works, this section provides instructions for how to use it in some common scenarios.
 
 As a concrete example, let's assume there is a `counter` canister already deployed on the network with the following Candid interface:
@@ -19,9 +19,9 @@ Now, let's explore how to interact with this canister in different scenarios wit
 [[idl-syntax]]
 == Interact with a service in a terminal
 
-One of the most common ways you interact with canisters and the {IC} is by using the {company-id} Canister SDK `+dfx+` command-line interface.
+One of the most common ways you interact with canister smart contracts and the {IC} is by using the {company-id} Canister SDK `+dfx+` command-line interface.
 
-The `+dfx+` tool provides the `+dfx canister call+` command to call a specific deployed canister—essentially a service that runs on the {IC}—and, if applicable, a method for that service.
+The `+dfx+` tool provides the `+dfx canister call+` command to call a specific deployed canister—essentially a smart contract that runs on the {IC}—and, if applicable, a method of the service provided by the smart contract.
 
 When you run the `+dfx canister call+` command, you can pass arguments to a method by specifying them as link:candid-concepts{outfilesuffix}#textual-values[Candid textual values].
 
@@ -52,8 +52,8 @@ For more information about using `+dfx+` and the `+dfx canister call+` command, 
 [[candid-ui]]
 == Interact with a service from a browser
 
-The Candid interface description language provides a common language for specifying the signature of a canister service.
-Based on the type signature of that service, Candid provides a web interface—the Candid UI—that allows you to call canister functions for testing and debugging from a web browser without writing any front-end code.
+The Candid interface description language provides a common language for specifying the signature of a canister smart contract.
+Based on the type signature of the service offered by the smart contract, Candid provides a web interface—the Candid UI—that allows you to call canister functions for testing and debugging from a web browser without writing any front-end code.
 
 To use the Candid web interface to test the `counter `canister:
 
@@ -69,7 +69,7 @@ The command displays the canister identifier for the Candid UI with output simil
 ....
 r7inp-6aaaa-aaaaa-aaabq-cai
 ....
-. Start the {IC} locally by running the following command:
+. Start the canister execution environment locally by running the following command:
 +
 [source,bash]
 ----
@@ -77,7 +77,7 @@ dfx start --background
 ----
 . Open a browser and navigate to the address and port number specified in the `+dfx.json+` configuration file.
 +
-By default, the `+local+` network binds to the `+127.0.0.1:8000+` address and port number.
+By default, the `+local+` canister execution environment binds to the `+127.0.0.1:8000+` address and port number.
 . Add the required `canisterId` parameter and the Candid UI canister identifier returned by the `+dfx canister id+` command.
 +
 For example, the full URL should look similar to the following but with the `+CANDID-UI-CANISTER-IDENTIFIER+` that was returned by the `+dfx canister id+` command:
@@ -91,7 +91,7 @@ The browser displays a form for you to specify a canister identifier or choose a
 
 image:candid-ui-select-id.png[]
 +
-If you aren't sure which canister identifier to use, you can run the `+dfx canister id+` command to look up the identifier for a specific canister name. 
+If you aren't sure which canister identifier to use, you can run the `+dfx canister id+` command to look up the identifier for a specific canister name.
 +
 For example, if you want to view the functions for the `+counter+` service description, you could look up the canister identifier by running the following command:
 +
@@ -106,7 +106,7 @@ For more information about the tool that creates a Web interface from the Candid
 
 == Interact with a service from a Motoko canister
 
-If you are writing a service in Motoko, the Motoko compiler automatically translates the signature of your canister’s top-level `actor` or `actor class` into a Candid description, and the `+dfx build+` command ensures that the service description is properly referenced where it needs to be.
+If you are writing a canister smart contract in Motoko, the Motoko compiler automatically translates the signature of your canister’s top-level `actor` or `actor class` into a Candid description, and the `+dfx build+` command ensures that the service description is properly referenced where it needs to be.
 
 For example, if you want to write a `hello` canister that calls the `counter` canister in {proglang}:
 
@@ -122,7 +122,7 @@ actor {
 }
 ....
 
-In this example, when the import dependency on the `counter` canister— the `import Counter "canister:Counter"` declaration—is processed by the `+dfx build+` command, the `+dfx build+` command ensures that the `counter` canister identifier and the Candid description are passed to the {proglang} compiler correctly .
+In this example, when the import dependency on the `counter` canister— the `import Counter "canister:Counter"` declaration—is processed by the `+dfx build+` command, the `+dfx build+` command ensures that the `counter` canister identifier and the Candid description are passed to the {proglang} compiler correctly.
 The {proglang} compiler then translates the Candid type into the appropriate native Motoko type. This translation enables you to call the `inc` method natively—as if it were a Motoko function—even if the `counter` canister is implemented in a different language and even if you do not have the source code for the imported canister.
 For additional information on the type mapping
 between Candid and {proglang}, you can consult the link:candid-types{outfilesuffix}[Supported types] reference section.
@@ -152,12 +152,12 @@ async fn greet() -> String {
 ....
 
 When the import macro on the `counter` canister— the `#[import(canister = "counter")]` declaration—is processed by the `+dfx build+` command, the `+dfx build+` command ensures that the `counter` canister identifier and the Candid description are passed to the Rust CDK correctly.
-The Rust CDK then translates the Candid type into the appropriate native Rust type. 
+The Rust CDK then translates the Candid type into the appropriate native Rust type.
 This translation enables you to call the `inc` method natively—as if it were a Rust function—even if the `counter` canister is implemented in a different language and even if you do not have the source code for the imported canister.
 For additional information on the type mapping
 between Candid and Rust, you can consult the link:candid-types{outfilesuffix}[Supported types] reference section.
 
-For other canisters and tools to interact with the `hello` canister, you need to manually create a `.did` file:
+For other canister smart contracts and tools to interact with the `hello` canister, you need to manually create a `.did` file:
 
 [source, candid]
 ....
@@ -166,7 +166,7 @@ service : {
 }
 ....
 
-There is also an experimental feature to generate Candid service description automatically, see this https://github.com/dfinity/candid/blob/master/rust/candid/tests/types.rs#L99[test case] as an example.
+There is also an experimental feature to generate a Candid service description automatically, see this https://github.com/dfinity/candid/blob/master/rust/candid/tests/types.rs#L99[test case] as an example.
 
 For additional information and libraries to help you create Candid services or canisters in Rust, see the documentation for the https://docs.rs/candid/[Candid crate], link:https://github.com/dfinity/cdk-rs/tree/next/examples[Rust CDK examples] and the link:../rust-guide/rust-intro{outfilesuffix}[Rust tutorials].
 
@@ -187,7 +187,7 @@ import BigNumber from 'bignumber.js';
 })();
 ....
 
-When the import dependency of counter canister is processed by the `+dfx build+` command and the `webpack` configuration, this processing ensures that the canister identifer and the Candid description are passed to the JavaScript program correctly. Behind the scenes, the Candid service description is
+When the import dependency of counter canister is processed by the `+dfx build+` command and the `webpack` configuration, this processing ensures that the canister identifier and the Candid description are passed to the JavaScript program correctly. Behind the scenes, the Candid service description is
 translated into a JavaScript module, located at `.dfx/local/canister/counter/counter.did.js`, by `+dfx build+`. The `dfinity/agent` package then translates the Candid type into
 native JavaScript values and enables you to call the `inc` method natively—as if it were a JavaScript function—even if the `counter` canister is implemented in a
 different language and even if you do not have the source code for the imported canister. For additional information on the type mapping


### PR DESCRIPTION
This PR contains several minor fixes.
In particular, the text now stresses that we run `canister smart contracts` and developers build `dapps` (as opposed to applications).
