### PR TITLE
bugfix: Use escape_debug when printing text value

### DIFF
--- a/rust/candid/src/parser/pretty.rs
+++ b/rust/candid/src/parser/pretty.rs
@@ -199,7 +199,7 @@ pub fn pp_value(depth: usize, v: &IDLValue) -> RcDoc {
         return RcDoc::as_string(format!("{:?}", v));
     }
     match v {
-        Text(ref s) => RcDoc::as_string(format!("\"{}\"", s)),
+        Text(ref s) => RcDoc::as_string(format!("\"{}\"", s.escape_debug())),
         Opt(v) if has_type_annotation(v) => {
             kwd("opt").append(enclose("(", pp_value(depth - 1, v), ")"))
         }


### PR DESCRIPTION
Problem: when pretty printing candid values of text type to stdout, the output is not escaped and prevents a parser from reading it back properly.

Solution: apply escape_debug on the string to be printed.