### PR TITLE
Add parser fuzzer

### DIFF
--- a/rust/candid/fuzz/.gitignore
+++ b/rust/candid/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/rust/candid/fuzz/Cargo.toml
+++ b/rust/candid/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "candid-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.candid]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "parser"
+path = "fuzz_targets/parser.rs"
+test = false
+doc = false

--- a/rust/candid/fuzz/fuzz_targets/parser.rs
+++ b/rust/candid/fuzz/fuzz_targets/parser.rs
@@ -1,0 +1,20 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use std::slice;
+use candid::parser::{
+    types::IDLProg,
+    typing::{check_prog, TypeEnv},
+    value::{IDLArgs, IDLField, IDLValue},
+};
+use candid::types::Label;
+use candid::{decode_args, decode_one, Decode};
+
+fuzz_target!(|data: &[u8]| {
+    let decoded = match IDLArgs::from_bytes(&data) {
+        Ok(_v) => _v,
+        Err(e) => return,
+    };
+    decoded.get_types();
+    decoded.to_bytes();
+    decoded.to_string();
+});


### PR DESCRIPTION
**Overview**
> Why do we need this feature? What are we trying to accomplish?

For finding bugs and vulnerabilities in candid.

**Requirements**
> What requirements are necessary to consider this problem solved?

This cargo fuzz-compatible fuzzing harness is required to fuzz candid.

**Considered Solutions**
> What solutions were considered?

**Recommended Solution**
> What solution are you recommending? Why?

This fuzzer integration was requested by Dfinity.

**Considerations**
> What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?

Maintenance: the fuzzer must constitute a valid program, and if changes to the candid API are made, it must be ensured that the fuzzer still compiles, and if not, the fuzzer code must be adapted to the new API.
