### PR TITLE
Generate a default Rust binding

### DIFF
--- a/rust/candid/src/bindings/analysis.rs
+++ b/rust/candid/src/bindings/analysis.rs
@@ -1,5 +1,6 @@
 use crate::parser::typing::TypeEnv;
 use crate::types::Type;
+use crate::Result;
 use std::collections::BTreeSet;
 
 /// Same as chase_actor, with seen set as part of the type. Used for chasing type names from type definitions.
@@ -8,7 +9,7 @@ pub fn chase_type<'a>(
     res: &mut Vec<&'a str>,
     env: &'a TypeEnv,
     t: &'a Type,
-) -> crate::Result<()> {
+) -> Result<()> {
     use Type::*;
     match t {
         Var(id) => {
@@ -47,14 +48,14 @@ pub fn chase_type<'a>(
 
 /// Gather type definitions mentioned in actor, return the non-recursive type names in topological order.
 /// Recursive types can appear in any order.
-pub fn chase_actor<'a>(env: &'a TypeEnv, actor: &'a Type) -> crate::Result<Vec<&'a str>> {
+pub fn chase_actor<'a>(env: &'a TypeEnv, actor: &'a Type) -> Result<Vec<&'a str>> {
     let mut seen = BTreeSet::new();
     let mut res = Vec::new();
     chase_type(&mut seen, &mut res, env, actor)?;
     Ok(res)
 }
 
-pub fn chase_types<'a>(env: &'a TypeEnv, tys: &'a [Type]) -> crate::Result<Vec<&'a str>> {
+pub fn chase_types<'a>(env: &'a TypeEnv, tys: &'a [Type]) -> Result<Vec<&'a str>> {
     let mut seen = BTreeSet::new();
     let mut res = Vec::new();
     for t in tys.iter() {
@@ -64,10 +65,7 @@ pub fn chase_types<'a>(env: &'a TypeEnv, tys: &'a [Type]) -> crate::Result<Vec<&
 }
 
 /// Given a `def_list` produced by the `chase_actor` function, infer which types are recursive
-pub fn infer_rec<'a>(
-    env: &'a TypeEnv,
-    def_list: &'a [&'a str],
-) -> crate::Result<BTreeSet<&'a str>> {
+pub fn infer_rec<'a>(env: &'a TypeEnv, def_list: &'a [&'a str]) -> Result<BTreeSet<&'a str>> {
     let mut seen = BTreeSet::new();
     let mut res = BTreeSet::new();
     fn go<'a>(
@@ -75,7 +73,7 @@ pub fn infer_rec<'a>(
         res: &mut BTreeSet<&'a str>,
         env: &'a TypeEnv,
         t: &'a Type,
-    ) -> crate::Result<()> {
+    ) -> Result<()> {
         use Type::*;
         match t {
             Var(id) => {

--- a/rust/candid/src/bindings/mod.rs
+++ b/rust/candid/src/bindings/mod.rs
@@ -5,4 +5,5 @@ pub mod analysis;
 pub mod candid;
 pub mod javascript;
 pub mod motoko;
+pub mod rust;
 pub mod typescript;

--- a/rust/candid/src/bindings/rust.rs
+++ b/rust/candid/src/bindings/rust.rs
@@ -1,0 +1,287 @@
+use super::analysis::{chase_actor, chase_types, infer_rec};
+use crate::parser::typing::TypeEnv;
+use crate::pretty::*;
+use crate::types::{Field, Function, Label, Type};
+use pretty::RcDoc;
+
+// The definition of tuple is language specific.
+pub(crate) fn is_tuple(fs: &[Field]) -> bool {
+    if fs.is_empty() {
+        return false;
+    }
+    for (i, field) in fs.iter().enumerate() {
+        if field.id.get_id() != (i as u32) {
+            return false;
+        }
+    }
+    true
+}
+static KEYWORDS: [&str; 51] = [
+    "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",
+    "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return",
+    "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe", "use", "where",
+    "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro",
+    "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
+];
+pub fn ident(id: &str) -> RcDoc {
+    if id.is_empty()
+        || id.starts_with(|c: char| !c.is_ascii_alphabetic() && c != '_')
+        || id.chars().any(|c| !c.is_ascii_alphanumeric() && c != '_')
+    {
+        RcDoc::as_string(format!("_{}_", crate::idl_hash(id)))
+    } else if ["crate", "self", "super", "Self"].contains(&id) {
+        str(id).append("_")
+    } else if KEYWORDS.contains(&id) {
+        str("r#").append(id)
+    } else {
+        str(id)
+    }
+}
+
+fn pp_ty(ty: &Type) -> RcDoc {
+    use Type::*;
+    match *ty {
+        Null => str("()"),
+        Bool => str("bool"),
+        Nat => str("candid::Nat"),
+        Int => str("candid::Int"),
+        Nat8 => str("u8"),
+        Nat16 => str("u16"),
+        Nat32 => str("u32"),
+        Nat64 => str("u64"),
+        Int8 => str("i8"),
+        Int16 => str("i16"),
+        Int32 => str("i32"),
+        Int64 => str("i64"),
+        Float32 => str("f32"),
+        Float64 => str("f64"),
+        Text => str("String"),
+        Reserved => str("candid::Reserved"),
+        Empty => str("candid::Empty"),
+        Var(ref s) => ident(s),
+        Principal => str("candid::Principal"),
+        Opt(ref t) => str("Option").append(enclose("<", pp_ty(t), ">")),
+        Vec(ref t) => str("Vec").append(enclose("<", pp_ty(t), ">")),
+        Record(ref fs) => pp_record_fields(fs),
+        Variant(_) => unreachable!(),
+        Func(_) => str("candid::Func"),
+        Service(_) => str("candid::Service"),
+        Class(_, _) => unreachable!(),
+        Knot(_) | Unknown => unreachable!(),
+    }
+}
+
+fn pp_label(id: &Label) -> RcDoc {
+    match id {
+        Label::Named(str) => ident(str),
+        Label::Id(n) | Label::Unnamed(n) => str("_").append(RcDoc::as_string(n)).append("_"),
+    }
+}
+
+fn pp_record_field(field: &Field) -> RcDoc {
+    pp_label(&field.id)
+        .append(kwd(":"))
+        .append(pp_ty(&field.ty))
+}
+
+fn pp_record_fields(fs: &[Field]) -> RcDoc {
+    if is_tuple(fs) {
+        let tuple = RcDoc::concat(fs.iter().map(|f| pp_ty(&f.ty).append(",")));
+        enclose("(", tuple, ")")
+    } else {
+        let fields = concat(fs.iter().map(pp_record_field), ",");
+        enclose_space("{", fields, "}")
+    }
+}
+
+fn pp_variant_field(field: &Field) -> RcDoc {
+    match &field.ty {
+        Type::Null => pp_label(&field.id),
+        Type::Record(fs) => pp_label(&field.id).append(pp_record_fields(fs)),
+        _ => pp_label(&field.id).append(enclose("(", pp_ty(&field.ty), ")")),
+    }
+}
+
+fn pp_variant_fields(fs: &[Field]) -> RcDoc {
+    let fields = concat(fs.iter().map(pp_variant_field), ",");
+    enclose_space("{", fields, "}")
+}
+
+fn pp_defs(env: &TypeEnv) -> RcDoc {
+    let derive = "#[derive(CandidType, Deserialize)]";
+    lines(env.0.iter().map(|(id, ty)| {
+        let id = ident(id).append(" ");
+        match ty {
+            Type::Record(fs) => str(derive)
+                .append(RcDoc::line())
+                .append("struct ")
+                .append(id)
+                .append(pp_record_fields(fs)),
+            Type::Variant(fs) => str(derive)
+                .append(RcDoc::line())
+                .append("enum ")
+                .append(id)
+                .append(pp_variant_fields(fs)),
+            _ => kwd("type").append(id).append("= ").append(pp_ty(ty)),
+        }
+    }))
+}
+
+pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {
+    let header = r#"// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+"#;
+    let (env, actor) = nominalize_all(env, actor);
+    let defs = pp_defs(&env);
+    let doc = RcDoc::text(header).append(RcDoc::line()).append(defs);
+    doc.pretty(LINE_WIDTH).to_string()
+}
+
+pub enum TypePath {
+    Id(String),
+    Opt,
+    Vec,
+    RecordField(String),
+    VariantField(String),
+    Func(String),
+    Init,
+}
+fn path_to_var(path: &[TypePath]) -> String {
+    let name: Vec<&str> = path
+        .iter()
+        .map(|node| match node {
+            TypePath::Id(id) => id.as_str(),
+            TypePath::RecordField(f) | TypePath::VariantField(f) => f.as_str(),
+            TypePath::Opt => "inner",
+            TypePath::Vec => "item",
+            TypePath::Func(id) => id.as_str(),
+            TypePath::Init => "init",
+        })
+        .collect();
+    name.join("_")
+}
+// Convert structural typing to nominal typing to fit Rust's type system
+fn nominalize(env: &mut TypeEnv, path: &mut Vec<TypePath>, t: Type) -> Type {
+    match t {
+        Type::Opt(ty) => {
+            path.push(TypePath::Opt);
+            let ty = nominalize(env, path, *ty);
+            path.pop();
+            Type::Opt(Box::new(ty))
+        }
+        Type::Vec(ty) => {
+            path.push(TypePath::Opt);
+            let ty = nominalize(env, path, *ty);
+            path.pop();
+            Type::Vec(Box::new(ty))
+        }
+        Type::Record(fs) => {
+            if matches!(
+                path.last(),
+                None | Some(TypePath::VariantField(_)) | Some(TypePath::Id(_))
+            ) || is_tuple(&fs)
+            {
+                let fs: Vec<_> = fs
+                    .into_iter()
+                    .map(|Field { id, ty }| {
+                        path.push(TypePath::RecordField(id.to_string()));
+                        let ty = nominalize(env, path, ty);
+                        path.pop();
+                        Field { id, ty }
+                    })
+                    .collect();
+                Type::Record(fs)
+            } else {
+                let new_var = path_to_var(path);
+                let ty = nominalize(
+                    env,
+                    &mut vec![TypePath::Id(new_var.clone())],
+                    Type::Record(fs),
+                );
+                env.0.insert(new_var.clone(), ty);
+                Type::Var(new_var)
+            }
+        }
+        Type::Variant(fs) => match path.last() {
+            None | Some(TypePath::Id(_)) => {
+                let fs: Vec<_> = fs
+                    .into_iter()
+                    .map(|Field { id, ty }| {
+                        path.push(TypePath::VariantField(id.to_string()));
+                        let ty = nominalize(env, path, ty);
+                        path.pop();
+                        Field { id, ty }
+                    })
+                    .collect();
+                Type::Variant(fs)
+            }
+            Some(_) => {
+                let new_var = path_to_var(path);
+                let ty = nominalize(
+                    env,
+                    &mut vec![TypePath::Id(new_var.clone())],
+                    Type::Variant(fs),
+                );
+                env.0.insert(new_var.clone(), ty);
+                Type::Var(new_var)
+            }
+        },
+        Type::Func(func) => Type::Func(Function {
+            modes: func.modes,
+            args: func
+                .args
+                .into_iter()
+                .enumerate()
+                .map(|(i, ty)| {
+                    path.push(TypePath::Func(format!("arg{}", i)));
+                    let ty = nominalize(env, path, ty);
+                    path.pop();
+                    ty
+                })
+                .collect(),
+            rets: func
+                .rets
+                .into_iter()
+                .enumerate()
+                .map(|(i, ty)| {
+                    path.push(TypePath::Func(format!("ret{}", i)));
+                    let ty = nominalize(env, path, ty);
+                    path.pop();
+                    ty
+                })
+                .collect(),
+        }),
+        Type::Service(serv) => Type::Service(
+            serv.into_iter()
+                .map(|(meth, ty)| {
+                    path.push(TypePath::Id(meth.to_string()));
+                    let ty = nominalize(env, path, ty);
+                    path.pop();
+                    (meth, ty)
+                })
+                .collect(),
+        ),
+        Type::Class(args, ty) => Type::Class(
+            args.into_iter()
+                .map(|ty| {
+                    path.push(TypePath::Init);
+                    let ty = nominalize(env, path, ty);
+                    path.pop();
+                    ty
+                })
+                .collect(),
+            Box::new(nominalize(env, path, *ty)),
+        ),
+        _ => t,
+    }
+}
+
+fn nominalize_all(env: &TypeEnv, actor: &Option<Type>) -> (TypeEnv, Option<Type>) {
+    let mut res = TypeEnv(Default::default());
+    for (id, ty) in env.0.iter() {
+        let ty = nominalize(&mut res, &mut vec![TypePath::Id(id.clone())], ty.clone());
+        res.0.insert(id.to_string(), ty);
+    }
+    let actor = actor.as_ref().map(|ty| nominalize(&mut res, &mut vec![], ty.clone()));
+    (res, actor)
+}

--- a/rust/candid/src/bindings/rust.rs
+++ b/rust/candid/src/bindings/rust.rs
@@ -123,14 +123,12 @@ fn pp_defs<'a>(env: &'a TypeEnv, recs: &'a RecPoints) -> RcDoc<'a> {
                 .append("struct ")
                 .append(name)
                 .append(pp_record_fields(fs, recs))
-                .append(";")
                 .append(RcDoc::hardline()),
             Type::Variant(fs) => str(derive)
                 .append(RcDoc::line())
                 .append("enum ")
                 .append(name)
                 .append(pp_variant_fields(fs, recs))
-                .append(";")
                 .append(RcDoc::hardline()),
             _ => {
                 if recs.contains(id.as_str()) {
@@ -139,14 +137,12 @@ fn pp_defs<'a>(env: &'a TypeEnv, recs: &'a RecPoints) -> RcDoc<'a> {
                         .append("struct ")
                         .append(ident(id))
                         .append(enclose("(", pp_ty(ty, recs), ")"))
-                        .append(";")
                         .append(RcDoc::hardline())
                 } else {
-                    let empty = BTreeSet::new();
                     kwd("type")
                         .append(name)
                         .append("= ")
-                        .append(pp_ty(ty, &empty))
+                        .append(pp_ty(ty, recs))
                         .append(";")
                 }
             }

--- a/rust/candid/src/bindings/rust.rs
+++ b/rust/candid/src/bindings/rust.rs
@@ -11,12 +11,9 @@ pub(crate) fn is_tuple(fs: &[Field]) -> bool {
     if fs.is_empty() {
         return false;
     }
-    for (i, field) in fs.iter().enumerate() {
-        if field.id.get_id() != (i as u32) {
-            return false;
-        }
-    }
-    true
+    !fs.iter()
+        .enumerate()
+        .any(|(i, field)| field.id.get_id() != (i as u32))
 }
 static KEYWORDS: [&str; 51] = [
     "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",

--- a/rust/candid/src/bindings/rust.rs
+++ b/rust/candid/src/bindings/rust.rs
@@ -137,6 +137,7 @@ fn pp_defs<'a>(env: &'a TypeEnv, recs: &'a RecPoints) -> RcDoc<'a> {
                         .append("struct ")
                         .append(ident(id))
                         .append(enclose("(", pp_ty(ty, recs), ")"))
+                        .append(";")
                         .append(RcDoc::hardline())
                 } else {
                     kwd("type")

--- a/rust/candid/tests/assets/ok/actor.rs
+++ b/rust/candid/tests/assets/ok/actor.rs
@@ -5,7 +5,7 @@ type f = candid::Func;
 type g = f;
 type h = candid::Func;
 #[derive(CandidType, Deserialize)]
-struct o(Option<Box<o>>);
+struct o(Option<Box<o>>)
 
 pub trait SERVICE {
   pub fn f(arg0: candid::Nat) -> (h);

--- a/rust/candid/tests/assets/ok/actor.rs
+++ b/rust/candid/tests/assets/ok/actor.rs
@@ -1,0 +1,8 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+type f = candid::Func
+type g = f
+type h = candid::Func
+type o = Option<o>
+

--- a/rust/candid/tests/assets/ok/actor.rs
+++ b/rust/candid/tests/assets/ok/actor.rs
@@ -5,4 +5,9 @@ type f = candid::Func
 type g = f
 type h = candid::Func
 type o = Option<o>
-
+pub trait SERVICE {
+  pub fn f(arg0: candid::Nat) -> (h);
+  pub fn g(arg0: i8) -> (i8);
+  pub fn h(arg0: i8) -> (i8);
+  pub fn o(arg0: o) -> (o);
+}

--- a/rust/candid/tests/assets/ok/actor.rs
+++ b/rust/candid/tests/assets/ok/actor.rs
@@ -5,7 +5,7 @@ type f = candid::Func;
 type g = f;
 type h = candid::Func;
 #[derive(CandidType, Deserialize)]
-struct o(Option<Box<o>>)
+struct o(Option<Box<o>>);
 
 pub trait SERVICE {
   pub fn f(arg0: candid::Nat) -> (h);

--- a/rust/candid/tests/assets/ok/actor.rs
+++ b/rust/candid/tests/assets/ok/actor.rs
@@ -1,5 +1,7 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 type f = candid::Func;
 type h = candid::Func;
@@ -9,16 +11,16 @@ struct o(Option<Box<o>>);
 
 struct SERVICE(candid::Principal);
 impl SERVICE{
-  pub async fn f(&self, arg0: candid::Nat) -> (h) {
-    ic_cdk::call(self.0, "f", (arg0,)).await.unwrap()
+  pub async fn f(&self, arg0: candid::Nat) -> CallResult<(h,)> {
+    ic_cdk::call(self.0, "f", (arg0,)).await
   }
-  pub async fn g(&self, arg0: i8) -> (i8) {
-    ic_cdk::call(self.0, "g", (arg0,)).await.unwrap()
+  pub async fn g(&self, arg0: i8) -> CallResult<(i8,)> {
+    ic_cdk::call(self.0, "g", (arg0,)).await
   }
-  pub async fn h(&self, arg0: i8) -> (i8) {
-    ic_cdk::call(self.0, "h", (arg0,)).await.unwrap()
+  pub async fn h(&self, arg0: i8) -> CallResult<(i8,)> {
+    ic_cdk::call(self.0, "h", (arg0,)).await
   }
-  pub async fn o(&self, arg0: o) -> (o) {
-    ic_cdk::call(self.0, "o", (arg0,)).await.unwrap()
+  pub async fn o(&self, arg0: o) -> CallResult<(o,)> {
+    ic_cdk::call(self.0, "o", (arg0,)).await
   }
 }

--- a/rust/candid/tests/assets/ok/actor.rs
+++ b/rust/candid/tests/assets/ok/actor.rs
@@ -7,9 +7,18 @@ type h = candid::Func;
 #[derive(CandidType, Deserialize)]
 struct o(Option<Box<o>>);
 
-pub trait SERVICE {
-  pub fn f(arg0: candid::Nat) -> (h);
-  pub fn g(arg0: i8) -> (i8);
-  pub fn h(arg0: i8) -> (i8);
-  pub fn o(arg0: o) -> (o);
+struct SERVICE(candid::Principal);
+impl SERVICE{
+  pub async fn f(&self, arg0: candid::Nat) -> (h) {
+    ic_cdk::call(self.0, "f", (arg0,)).await.unwrap()
+  }
+  pub async fn g(&self, arg0: i8) -> (i8) {
+    ic_cdk::call(self.0, "g", (arg0,)).await.unwrap()
+  }
+  pub async fn h(&self, arg0: i8) -> (i8) {
+    ic_cdk::call(self.0, "h", (arg0,)).await.unwrap()
+  }
+  pub async fn o(&self, arg0: o) -> (o) {
+    ic_cdk::call(self.0, "o", (arg0,)).await.unwrap()
+  }
 }

--- a/rust/candid/tests/assets/ok/actor.rs
+++ b/rust/candid/tests/assets/ok/actor.rs
@@ -2,8 +2,8 @@
 // You may want to manually adjust some of the types.
 
 type f = candid::Func;
-type g = f;
 type h = candid::Func;
+type g = f;
 #[derive(CandidType, Deserialize)]
 struct o(Option<Box<o>>);
 

--- a/rust/candid/tests/assets/ok/actor.rs
+++ b/rust/candid/tests/assets/ok/actor.rs
@@ -1,10 +1,12 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type f = candid::Func
-type g = f
-type h = candid::Func
-type o = Option<o>
+type f = candid::Func;
+type g = f;
+type h = candid::Func;
+#[derive(CandidType, Deserialize)]
+struct o(Option<o>);
+
 pub trait SERVICE {
   pub fn f(arg0: candid::Nat) -> (h);
   pub fn g(arg0: i8) -> (i8);

--- a/rust/candid/tests/assets/ok/actor.rs
+++ b/rust/candid/tests/assets/ok/actor.rs
@@ -5,7 +5,7 @@ type f = candid::Func;
 type g = f;
 type h = candid::Func;
 #[derive(CandidType, Deserialize)]
-struct o(Option<o>);
+struct o(Option<Box<o>>);
 
 pub trait SERVICE {
   pub fn f(arg0: candid::Nat) -> (h);

--- a/rust/candid/tests/assets/ok/class.rs
+++ b/rust/candid/tests/assets/ok/class.rs
@@ -2,4 +2,7 @@
 // You may want to manually adjust some of the types.
 
 type List = Option<(candid::Int,List,)>
-
+pub trait SERVICE {
+  pub fn get() -> (List);
+  pub fn set(arg0: List) -> (List);
+}

--- a/rust/candid/tests/assets/ok/class.rs
+++ b/rust/candid/tests/assets/ok/class.rs
@@ -1,0 +1,5 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+type List = Option<(candid::Int,List,)>
+

--- a/rust/candid/tests/assets/ok/class.rs
+++ b/rust/candid/tests/assets/ok/class.rs
@@ -1,15 +1,17 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize)]
 struct List(Option<(candid::Int,Box<List>,)>);
 
 struct SERVICE(candid::Principal);
 impl SERVICE{
-  pub async fn get(&self) -> (List) {
-    ic_cdk::call(self.0, "get", ()).await.unwrap()
+  pub async fn get(&self) -> CallResult<(List,)> {
+    ic_cdk::call(self.0, "get", ()).await
   }
-  pub async fn set(&self, arg0: List) -> (List) {
-    ic_cdk::call(self.0, "set", (arg0,)).await.unwrap()
+  pub async fn set(&self, arg0: List) -> CallResult<(List,)> {
+    ic_cdk::call(self.0, "set", (arg0,)).await
   }
 }

--- a/rust/candid/tests/assets/ok/class.rs
+++ b/rust/candid/tests/assets/ok/class.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 
 #[derive(CandidType, Deserialize)]
-struct List(Option<(candid::Int,Box<List>,)>)
+struct List(Option<(candid::Int,Box<List>,)>);
 
 pub trait SERVICE {
   pub fn get() -> (List);

--- a/rust/candid/tests/assets/ok/class.rs
+++ b/rust/candid/tests/assets/ok/class.rs
@@ -1,7 +1,9 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type List = Option<(candid::Int,List,)>
+#[derive(CandidType, Deserialize)]
+struct List(Option<(candid::Int,List,)>);
+
 pub trait SERVICE {
   pub fn get() -> (List);
   pub fn set(arg0: List) -> (List);

--- a/rust/candid/tests/assets/ok/class.rs
+++ b/rust/candid/tests/assets/ok/class.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 
 #[derive(CandidType, Deserialize)]
-struct List(Option<(candid::Int,List,)>);
+struct List(Option<(candid::Int,Box<List>,)>);
 
 pub trait SERVICE {
   pub fn get() -> (List);

--- a/rust/candid/tests/assets/ok/class.rs
+++ b/rust/candid/tests/assets/ok/class.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 
 #[derive(CandidType, Deserialize)]
-struct List(Option<(candid::Int,Box<List>,)>);
+struct List(Option<(candid::Int,Box<List>,)>)
 
 pub trait SERVICE {
   pub fn get() -> (List);

--- a/rust/candid/tests/assets/ok/class.rs
+++ b/rust/candid/tests/assets/ok/class.rs
@@ -4,7 +4,12 @@
 #[derive(CandidType, Deserialize)]
 struct List(Option<(candid::Int,Box<List>,)>);
 
-pub trait SERVICE {
-  pub fn get() -> (List);
-  pub fn set(arg0: List) -> (List);
+struct SERVICE(candid::Principal);
+impl SERVICE{
+  pub async fn get(&self) -> (List) {
+    ic_cdk::call(self.0, "get", ()).await.unwrap()
+  }
+  pub async fn set(&self, arg0: List) -> (List) {
+    ic_cdk::call(self.0, "set", (arg0,)).await.unwrap()
+  }
 }

--- a/rust/candid/tests/assets/ok/comment.rs
+++ b/rust/candid/tests/assets/ok/comment.rs
@@ -1,0 +1,5 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+type id = u8
+

--- a/rust/candid/tests/assets/ok/comment.rs
+++ b/rust/candid/tests/assets/ok/comment.rs
@@ -1,5 +1,7 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 type id = u8;
 

--- a/rust/candid/tests/assets/ok/comment.rs
+++ b/rust/candid/tests/assets/ok/comment.rs
@@ -1,5 +1,5 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type id = u8
+type id = u8;
 

--- a/rust/candid/tests/assets/ok/cyclic.rs
+++ b/rust/candid/tests/assets/ok/cyclic.rs
@@ -1,19 +1,19 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type A = Option<B>;
+type A = Option<Box<B>>;
 #[derive(CandidType, Deserialize)]
-struct B(Option<Box<C>>);
+struct B(Option<Box<C>>)
 
 #[derive(CandidType, Deserialize)]
-struct C(A);
+struct C(A)
 
-type X = Y;
+type X = Box<Y>;
 #[derive(CandidType, Deserialize)]
-struct Y(Box<Z>);
+struct Y(Box<Z>)
 
 #[derive(CandidType, Deserialize)]
-struct Z(A);
+struct Z(A)
 
 pub trait SERVICE {
   pub fn f(arg0: A, arg1: B, arg2: C, arg3: X, arg4: Y, arg5: Z) -> ();

--- a/rust/candid/tests/assets/ok/cyclic.rs
+++ b/rust/candid/tests/assets/ok/cyclic.rs
@@ -7,4 +7,6 @@ type C = A
 type X = Y
 type Y = Z
 type Z = A
-
+pub trait SERVICE {
+  pub fn f(arg0: A, arg1: B, arg2: C, arg3: X, arg4: Y, arg5: Z) -> ();
+}

--- a/rust/candid/tests/assets/ok/cyclic.rs
+++ b/rust/candid/tests/assets/ok/cyclic.rs
@@ -1,12 +1,20 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type A = Option<B>
-type B = Option<C>
-type C = A
-type X = Y
-type Y = Z
-type Z = A
+type A = Option<B>;
+#[derive(CandidType, Deserialize)]
+struct B(Option<C>);
+
+#[derive(CandidType, Deserialize)]
+struct C(A);
+
+type X = Y;
+#[derive(CandidType, Deserialize)]
+struct Y(Z);
+
+#[derive(CandidType, Deserialize)]
+struct Z(A);
+
 pub trait SERVICE {
   pub fn f(arg0: A, arg1: B, arg2: C, arg3: X, arg4: Y, arg5: Z) -> ();
 }

--- a/rust/candid/tests/assets/ok/cyclic.rs
+++ b/rust/candid/tests/assets/ok/cyclic.rs
@@ -1,0 +1,10 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+type A = Option<B>
+type B = Option<C>
+type C = A
+type X = Y
+type Y = Z
+type Z = A
+

--- a/rust/candid/tests/assets/ok/cyclic.rs
+++ b/rust/candid/tests/assets/ok/cyclic.rs
@@ -3,17 +3,17 @@
 
 type A = Option<Box<B>>;
 #[derive(CandidType, Deserialize)]
-struct B(Option<Box<C>>)
+struct B(Option<Box<C>>);
 
 #[derive(CandidType, Deserialize)]
-struct C(A)
+struct C(A);
 
 type X = Box<Y>;
 #[derive(CandidType, Deserialize)]
-struct Y(Box<Z>)
+struct Y(Box<Z>);
 
 #[derive(CandidType, Deserialize)]
-struct Z(A)
+struct Z(A);
 
 pub trait SERVICE {
   pub fn f(arg0: A, arg1: B, arg2: C, arg3: X, arg4: Y, arg5: Z) -> ();

--- a/rust/candid/tests/assets/ok/cyclic.rs
+++ b/rust/candid/tests/assets/ok/cyclic.rs
@@ -15,6 +15,17 @@ struct Y(Box<Z>);
 #[derive(CandidType, Deserialize)]
 struct Z(A);
 
-pub trait SERVICE {
-  pub fn f(arg0: A, arg1: B, arg2: C, arg3: X, arg4: Y, arg5: Z) -> ();
+struct SERVICE(candid::Principal);
+impl SERVICE{
+  pub async fn f(
+    &self,
+    arg0: A,
+    arg1: B,
+    arg2: C,
+    arg3: X,
+    arg4: Y,
+    arg5: Z,
+  ) -> () {
+    ic_cdk::call(self.0, "f", (arg0,arg1,arg2,arg3,arg4,arg5,)).await.unwrap()
+  }
 }

--- a/rust/candid/tests/assets/ok/cyclic.rs
+++ b/rust/candid/tests/assets/ok/cyclic.rs
@@ -3,14 +3,14 @@
 
 type A = Option<B>;
 #[derive(CandidType, Deserialize)]
-struct B(Option<C>);
+struct B(Option<Box<C>>);
 
 #[derive(CandidType, Deserialize)]
 struct C(A);
 
 type X = Y;
 #[derive(CandidType, Deserialize)]
-struct Y(Z);
+struct Y(Box<Z>);
 
 #[derive(CandidType, Deserialize)]
 struct Z(A);

--- a/rust/candid/tests/assets/ok/cyclic.rs
+++ b/rust/candid/tests/assets/ok/cyclic.rs
@@ -1,5 +1,7 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 type C = Box<A>;
 type B = Option<C>;
@@ -19,7 +21,7 @@ impl SERVICE{
     arg3: X,
     arg4: Y,
     arg5: Z,
-  ) -> () {
-    ic_cdk::call(self.0, "f", (arg0,arg1,arg2,arg3,arg4,arg5,)).await.unwrap()
+  ) -> CallResult<()> {
+    ic_cdk::call(self.0, "f", (arg0,arg1,arg2,arg3,arg4,arg5,)).await
   }
 }

--- a/rust/candid/tests/assets/ok/cyclic.rs
+++ b/rust/candid/tests/assets/ok/cyclic.rs
@@ -1,20 +1,14 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type A = Option<Box<B>>;
+type C = Box<A>;
+type B = Option<C>;
 #[derive(CandidType, Deserialize)]
-struct B(Option<Box<C>>);
+struct A(Option<B>);
 
-#[derive(CandidType, Deserialize)]
-struct C(A);
-
-type X = Box<Y>;
-#[derive(CandidType, Deserialize)]
-struct Y(Box<Z>);
-
-#[derive(CandidType, Deserialize)]
-struct Z(A);
-
+type Z = Box<A>;
+type Y = Z;
+type X = Y;
 struct SERVICE(candid::Principal);
 impl SERVICE{
   pub async fn f(

--- a/rust/candid/tests/assets/ok/escape.rs
+++ b/rust/candid/tests/assets/ok/escape.rs
@@ -9,4 +9,9 @@ struct t {
   _1020746185_: candid::Nat,
 }
 
-pub trait SERVICE { pub fn _2635468193_(arg0: t) -> (); }
+struct SERVICE(candid::Principal);
+impl SERVICE{
+  pub async fn _2635468193_(&self, arg0: t) -> () {
+    ic_cdk::call(self.0, "\n\'\"\'\'\"\"\r\t", (arg0,)).await.unwrap()
+  }
+}

--- a/rust/candid/tests/assets/ok/escape.rs
+++ b/rust/candid/tests/assets/ok/escape.rs
@@ -7,6 +7,6 @@ struct t {
   _39_: candid::Nat,
   _7621_: candid::Nat,
   _1020746185_: candid::Nat,
-}
+};
 
 pub trait SERVICE { pub fn _2635468193_(arg0: t) -> (); }

--- a/rust/candid/tests/assets/ok/escape.rs
+++ b/rust/candid/tests/assets/ok/escape.rs
@@ -3,9 +3,13 @@
 
 #[derive(CandidType, Deserialize)]
 struct t {
+  #[serde(rename="\"")]
   _34_: candid::Nat,
+  #[serde(rename="\'")]
   _39_: candid::Nat,
+  #[serde(rename="\"\'")]
   _7621_: candid::Nat,
+  #[serde(rename="\\\n\'\"")]
   _1020746185_: candid::Nat,
 }
 

--- a/rust/candid/tests/assets/ok/escape.rs
+++ b/rust/candid/tests/assets/ok/escape.rs
@@ -9,3 +9,4 @@ struct t {
   _1020746185_: candid::Nat,
 }
 
+pub trait SERVICE { pub fn _2635468193_(arg0: t) -> (); }

--- a/rust/candid/tests/assets/ok/escape.rs
+++ b/rust/candid/tests/assets/ok/escape.rs
@@ -1,5 +1,7 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize)]
 struct t {
@@ -15,7 +17,7 @@ struct t {
 
 struct SERVICE(candid::Principal);
 impl SERVICE{
-  pub async fn _2635468193_(&self, arg0: t) -> () {
-    ic_cdk::call(self.0, "\n\'\"\'\'\"\"\r\t", (arg0,)).await.unwrap()
+  pub async fn _2635468193_(&self, arg0: t) -> CallResult<()> {
+    ic_cdk::call(self.0, "\n\'\"\'\'\"\"\r\t", (arg0,)).await
   }
 }

--- a/rust/candid/tests/assets/ok/escape.rs
+++ b/rust/candid/tests/assets/ok/escape.rs
@@ -1,0 +1,11 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+#[derive(CandidType, Deserialize)]
+struct t {
+  _34_: candid::Nat,
+  _39_: candid::Nat,
+  _7621_: candid::Nat,
+  _1020746185_: candid::Nat,
+}
+

--- a/rust/candid/tests/assets/ok/escape.rs
+++ b/rust/candid/tests/assets/ok/escape.rs
@@ -7,6 +7,6 @@ struct t {
   _39_: candid::Nat,
   _7621_: candid::Nat,
   _1020746185_: candid::Nat,
-};
+}
 
 pub trait SERVICE { pub fn _2635468193_(arg0: t) -> (); }

--- a/rust/candid/tests/assets/ok/example.rs
+++ b/rust/candid/tests/assets/ok/example.rs
@@ -1,32 +1,32 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type A = B;
+type A = Box<B>;
 #[derive(CandidType, Deserialize)]
-struct B(Option<A>);
+struct B(Option<A>)
 
-type List = Option<List_inner>;
+type List = Option<Box<List_inner>>;
 #[derive(CandidType, Deserialize)]
-struct List_inner { head: candid::Int, tail: List };
-
-#[derive(CandidType, Deserialize)]
-enum a { a, b(Box<b>) };
+struct List_inner { head: candid::Int, tail: List }
 
 #[derive(CandidType, Deserialize)]
-struct b (candid::Int,candid::Nat,);
+enum a { a, b(Box<b>) }
+
+#[derive(CandidType, Deserialize)]
+struct b (candid::Int,candid::Nat,)
 
 type broker = candid::Service;
 type f = candid::Func;
 #[derive(CandidType, Deserialize)]
-enum h_arg1 { A(candid::Nat), B(Option<String>) };
+enum h_arg1 { A(candid::Nat), B(Option<String>) }
 
 #[derive(CandidType, Deserialize)]
-struct h_ret0 { _42_: Box<h_ret0_42>, id: candid::Nat };
+struct h_ret0 { _42_: Box<h_ret0_42>, id: candid::Nat }
 
 #[derive(CandidType, Deserialize)]
-struct h_ret0_42 {};
+struct h_ret0_42 {}
 
-type list = Option<node>;
+type list = Option<Box<node>>;
 type my_type = candid::Principal;
 #[derive(CandidType, Deserialize)]
 struct nested {
@@ -37,32 +37,32 @@ struct nested {
   _40_: candid::Nat,
   _41_: Box<nested_41>,
   _42_: candid::Nat,
-};
+}
 
 #[derive(CandidType, Deserialize)]
-struct nested_3 { _0_: candid::Nat, _42_: candid::Nat, _43_: u8 };
+struct nested_3 { _0_: candid::Nat, _42_: candid::Nat, _43_: u8 }
 
 #[derive(CandidType, Deserialize)]
-enum nested_41 { _42_, A, B, C };
+enum nested_41 { _42_, A, B, C }
 
 #[derive(CandidType, Deserialize)]
-struct node { head: candid::Nat, tail: list };
+struct node { head: candid::Nat, tail: list }
 
 type s = candid::Service;
 #[derive(CandidType, Deserialize)]
-struct stream(Option<Box<stream_inner>>);
+struct stream(Option<Box<stream_inner>>)
 
 #[derive(CandidType, Deserialize)]
-struct stream_inner { head: candid::Nat, next: candid::Func };
+struct stream_inner { head: candid::Nat, next: candid::Func }
 
 #[derive(CandidType, Deserialize)]
-struct t(candid::Func);
+struct t(candid::Func)
 
 #[derive(CandidType, Deserialize)]
 enum tree {
   branch{ val: candid::Int, left: Box<tree>, right: Box<tree> },
   leaf(candid::Int),
-};
+}
 
 pub trait SERVICE {
   pub fn f(arg0: list, arg1: Vec<u8>, arg2: Option<bool>) -> ();

--- a/rust/candid/tests/assets/ok/example.rs
+++ b/rust/candid/tests/assets/ok/example.rs
@@ -1,31 +1,33 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type A = B
-type B = Option<A>
-type List = Option<List_inner>
+type A = B;
 #[derive(CandidType, Deserialize)]
-struct List_inner { head: candid::Int, tail: List }
+struct B(Option<A>);
+
+type List = Option<List_inner>;
+#[derive(CandidType, Deserialize)]
+struct List_inner { head: candid::Int, tail: List };
 
 #[derive(CandidType, Deserialize)]
-enum a { a, b(b) }
+enum a { a, b(b) };
 
 #[derive(CandidType, Deserialize)]
-struct b (candid::Int,candid::Nat,)
+struct b (candid::Int,candid::Nat,);
 
-type broker = candid::Service
-type f = candid::Func
+type broker = candid::Service;
+type f = candid::Func;
 #[derive(CandidType, Deserialize)]
-enum h_arg1 { A(candid::Nat), B(Option<String>) }
-
-#[derive(CandidType, Deserialize)]
-struct h_ret0 { _42_: h_ret0_42, id: candid::Nat }
+enum h_arg1 { A(candid::Nat), B(Option<String>) };
 
 #[derive(CandidType, Deserialize)]
-struct h_ret0_42 {}
+struct h_ret0 { _42_: h_ret0_42, id: candid::Nat };
 
-type list = Option<node>
-type my_type = candid::Principal
+#[derive(CandidType, Deserialize)]
+struct h_ret0_42 {};
+
+type list = Option<node>;
+type my_type = candid::Principal;
 #[derive(CandidType, Deserialize)]
 struct nested {
   _0_: candid::Nat,
@@ -35,28 +37,32 @@ struct nested {
   _40_: candid::Nat,
   _41_: nested_41,
   _42_: candid::Nat,
-}
+};
 
 #[derive(CandidType, Deserialize)]
-struct nested_3 { _0_: candid::Nat, _42_: candid::Nat, _43_: u8 }
+struct nested_3 { _0_: candid::Nat, _42_: candid::Nat, _43_: u8 };
 
 #[derive(CandidType, Deserialize)]
-enum nested_41 { _42_, A, B, C }
+enum nested_41 { _42_, A, B, C };
 
 #[derive(CandidType, Deserialize)]
-struct node { head: candid::Nat, tail: list }
+struct node { head: candid::Nat, tail: list };
 
-type s = candid::Service
-type stream = Option<stream_inner>
+type s = candid::Service;
 #[derive(CandidType, Deserialize)]
-struct stream_inner { head: candid::Nat, next: candid::Func }
+struct stream(Option<stream_inner>);
 
-type t = candid::Func
+#[derive(CandidType, Deserialize)]
+struct stream_inner { head: candid::Nat, next: candid::Func };
+
+#[derive(CandidType, Deserialize)]
+struct t(candid::Func);
+
 #[derive(CandidType, Deserialize)]
 enum tree {
   branch{ val: candid::Int, left: tree, right: tree },
   leaf(candid::Int),
-}
+};
 
 pub trait SERVICE {
   pub fn f(arg0: list, arg1: Vec<u8>, arg2: Option<bool>) -> ();

--- a/rust/candid/tests/assets/ok/example.rs
+++ b/rust/candid/tests/assets/ok/example.rs
@@ -64,15 +64,30 @@ enum tree {
   leaf(candid::Int),
 }
 
-pub trait SERVICE {
-  pub fn f(arg0: list, arg1: Vec<u8>, arg2: Option<bool>) -> ();
-  pub fn g(arg0: my_type, arg1: List, arg2: Option<List>, arg3: nested) -> (
-    candid::Int,
-    broker,
-  );
-  pub fn h(arg0: Vec<Option<String>>, arg1: h_arg1, arg2: Option<List>) -> (
-    h_ret0,
-  );
-  pub fn i(arg0: List, arg1: candid::Func) -> (Option<List>);
-  pub fn x(arg0: a, arg1: b) -> (Option<a>, Option<b>);
+struct SERVICE(candid::Principal);
+impl SERVICE{
+  pub async fn f(&self, arg0: list, arg1: Vec<u8>, arg2: Option<bool>) -> () {
+    ic_cdk::call(self.0, "f", (arg0,arg1,arg2,)).await.unwrap()
+  }
+  pub async fn g(
+    &self,
+    arg0: my_type,
+    arg1: List,
+    arg2: Option<List>,
+    arg3: nested,
+  ) -> (candid::Int, broker) {
+    ic_cdk::call(self.0, "g", (arg0,arg1,arg2,arg3,)).await.unwrap()
+  }
+  pub async fn h(
+    &self,
+    arg0: Vec<Option<String>>,
+    arg1: h_arg1,
+    arg2: Option<List>,
+  ) -> (h_ret0) { ic_cdk::call(self.0, "h", (arg0,arg1,arg2,)).await.unwrap() }
+  pub async fn i(&self, arg0: List, arg1: candid::Func) -> (Option<List>) {
+    ic_cdk::call(self.0, "i", (arg0,arg1,)).await.unwrap()
+  }
+  pub async fn x(&self, arg0: a, arg1: b) -> (Option<a>, Option<b>) {
+    ic_cdk::call(self.0, "x", (arg0,arg1,)).await.unwrap()
+  }
 }

--- a/rust/candid/tests/assets/ok/example.rs
+++ b/rust/candid/tests/assets/ok/example.rs
@@ -10,7 +10,7 @@ type List = Option<List_inner>;
 struct List_inner { head: candid::Int, tail: List };
 
 #[derive(CandidType, Deserialize)]
-enum a { a, b(b) };
+enum a { a, b(Box<b>) };
 
 #[derive(CandidType, Deserialize)]
 struct b (candid::Int,candid::Nat,);
@@ -21,7 +21,7 @@ type f = candid::Func;
 enum h_arg1 { A(candid::Nat), B(Option<String>) };
 
 #[derive(CandidType, Deserialize)]
-struct h_ret0 { _42_: h_ret0_42, id: candid::Nat };
+struct h_ret0 { _42_: Box<h_ret0_42>, id: candid::Nat };
 
 #[derive(CandidType, Deserialize)]
 struct h_ret0_42 {};
@@ -33,9 +33,9 @@ struct nested {
   _0_: candid::Nat,
   _1_: candid::Nat,
   _2_: (candid::Nat,candid::Int,),
-  _3_: nested_3,
+  _3_: Box<nested_3>,
   _40_: candid::Nat,
-  _41_: nested_41,
+  _41_: Box<nested_41>,
   _42_: candid::Nat,
 };
 
@@ -50,7 +50,7 @@ struct node { head: candid::Nat, tail: list };
 
 type s = candid::Service;
 #[derive(CandidType, Deserialize)]
-struct stream(Option<stream_inner>);
+struct stream(Option<Box<stream_inner>>);
 
 #[derive(CandidType, Deserialize)]
 struct stream_inner { head: candid::Nat, next: candid::Func };
@@ -60,7 +60,7 @@ struct t(candid::Func);
 
 #[derive(CandidType, Deserialize)]
 enum tree {
-  branch{ val: candid::Int, left: tree, right: tree },
+  branch{ val: candid::Int, left: Box<tree>, right: Box<tree> },
   leaf(candid::Int),
 };
 

--- a/rust/candid/tests/assets/ok/example.rs
+++ b/rust/candid/tests/assets/ok/example.rs
@@ -1,5 +1,7 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize)]
 struct node { head: candid::Nat, tail: Box<list> }
@@ -50,28 +52,33 @@ enum a { a, b(b) }
 
 struct SERVICE(candid::Principal);
 impl SERVICE{
-  pub async fn f(&self, arg0: list, arg1: Vec<u8>, arg2: Option<bool>) -> () {
-    ic_cdk::call(self.0, "f", (arg0,arg1,arg2,)).await.unwrap()
-  }
+  pub async fn f(
+    &self,
+    arg0: list,
+    arg1: Vec<u8>,
+    arg2: Option<bool>,
+  ) -> CallResult<()> { ic_cdk::call(self.0, "f", (arg0,arg1,arg2,)).await }
   pub async fn g(
     &self,
     arg0: my_type,
     arg1: List,
     arg2: Option<List>,
     arg3: nested,
-  ) -> (candid::Int, broker) {
-    ic_cdk::call(self.0, "g", (arg0,arg1,arg2,arg3,)).await.unwrap()
+  ) -> CallResult<(candid::Int,broker,)> {
+    ic_cdk::call(self.0, "g", (arg0,arg1,arg2,arg3,)).await
   }
   pub async fn h(
     &self,
     arg0: Vec<Option<String>>,
     arg1: h_arg1,
     arg2: Option<List>,
-  ) -> (h_ret0) { ic_cdk::call(self.0, "h", (arg0,arg1,arg2,)).await.unwrap() }
-  pub async fn i(&self, arg0: List, arg1: candid::Func) -> (Option<List>) {
-    ic_cdk::call(self.0, "i", (arg0,arg1,)).await.unwrap()
+  ) -> CallResult<(h_ret0,)> {
+    ic_cdk::call(self.0, "h", (arg0,arg1,arg2,)).await
   }
-  pub async fn x(&self, arg0: a, arg1: b) -> (Option<a>, Option<b>) {
-    ic_cdk::call(self.0, "x", (arg0,arg1,)).await.unwrap()
-  }
+  pub async fn i(&self, arg0: List, arg1: candid::Func) -> CallResult<
+    (Option<List>,)
+  > { ic_cdk::call(self.0, "i", (arg0,arg1,)).await }
+  pub async fn x(&self, arg0: a, arg1: b) -> CallResult<
+    (Option<a>,Option<b>,)
+  > { ic_cdk::call(self.0, "x", (arg0,arg1,)).await }
 }

--- a/rust/candid/tests/assets/ok/example.rs
+++ b/rust/candid/tests/assets/ok/example.rs
@@ -6,18 +6,24 @@ type B = Option<A>
 type List = Option<List_inner>
 #[derive(CandidType, Deserialize)]
 struct List_inner { head: candid::Int, tail: List }
+
 #[derive(CandidType, Deserialize)]
 enum a { a, b(b) }
+
 #[derive(CandidType, Deserialize)]
 struct b (candid::Int,candid::Nat,)
+
 type broker = candid::Service
 type f = candid::Func
 #[derive(CandidType, Deserialize)]
 enum h_arg1 { A(candid::Nat), B(Option<String>) }
+
 #[derive(CandidType, Deserialize)]
 struct h_ret0 { _42_: h_ret0_42, id: candid::Nat }
+
 #[derive(CandidType, Deserialize)]
 struct h_ret0_42 {}
+
 type list = Option<node>
 type my_type = candid::Principal
 #[derive(CandidType, Deserialize)]
@@ -30,16 +36,21 @@ struct nested {
   _41_: nested_41,
   _42_: candid::Nat,
 }
+
 #[derive(CandidType, Deserialize)]
 struct nested_3 { _0_: candid::Nat, _42_: candid::Nat, _43_: u8 }
+
 #[derive(CandidType, Deserialize)]
 enum nested_41 { _42_, A, B, C }
+
 #[derive(CandidType, Deserialize)]
 struct node { head: candid::Nat, tail: list }
+
 type s = candid::Service
 type stream = Option<stream_inner>
 #[derive(CandidType, Deserialize)]
 struct stream_inner { head: candid::Nat, next: candid::Func }
+
 type t = candid::Func
 #[derive(CandidType, Deserialize)]
 enum tree {
@@ -47,3 +58,15 @@ enum tree {
   leaf(candid::Int),
 }
 
+pub trait SERVICE {
+  pub fn f(arg0: list, arg1: Vec<u8>, arg2: Option<bool>) -> ();
+  pub fn g(arg0: my_type, arg1: List, arg2: Option<List>, arg3: nested) -> (
+    candid::Int,
+    broker,
+  );
+  pub fn h(arg0: Vec<Option<String>>, arg1: h_arg1, arg2: Option<List>) -> (
+    h_ret0,
+  );
+  pub fn i(arg0: List, arg1: candid::Func) -> (Option<List>);
+  pub fn x(arg0: a, arg1: b) -> (Option<a>, Option<b>);
+}

--- a/rust/candid/tests/assets/ok/example.rs
+++ b/rust/candid/tests/assets/ok/example.rs
@@ -1,43 +1,18 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type A = Box<B>;
 #[derive(CandidType, Deserialize)]
-struct B(Option<A>);
-
-type List = Option<Box<List_inner>>;
-#[derive(CandidType, Deserialize)]
-struct List_inner { head: candid::Int, tail: List }
+struct node { head: candid::Nat, tail: Box<list> }
 
 #[derive(CandidType, Deserialize)]
-enum a { a, b(Box<b>) }
+struct list(Option<node>);
 
-#[derive(CandidType, Deserialize)]
-struct b (candid::Int,candid::Nat,)
-
-type broker = candid::Service;
-type f = candid::Func;
-#[derive(CandidType, Deserialize)]
-enum h_arg1 { A(candid::Nat), B(Option<String>) }
-
-#[derive(CandidType, Deserialize)]
-struct h_ret0 { _42_: Box<h_ret0_42>, id: candid::Nat }
-
-#[derive(CandidType, Deserialize)]
-struct h_ret0_42 {}
-
-type list = Option<Box<node>>;
 type my_type = candid::Principal;
 #[derive(CandidType, Deserialize)]
-struct nested {
-  _0_: candid::Nat,
-  _1_: candid::Nat,
-  _2_: (candid::Nat,candid::Int,),
-  _3_: Box<nested_3>,
-  _40_: candid::Nat,
-  _41_: Box<nested_41>,
-  _42_: candid::Nat,
-}
+struct List_inner { head: candid::Int, tail: Box<List> }
+
+#[derive(CandidType, Deserialize)]
+struct List(Option<List_inner>);
 
 #[derive(CandidType, Deserialize)]
 struct nested_3 { _0_: candid::Nat, _42_: candid::Nat, _43_: u8 }
@@ -46,23 +21,32 @@ struct nested_3 { _0_: candid::Nat, _42_: candid::Nat, _43_: u8 }
 enum nested_41 { _42_, A, B, C }
 
 #[derive(CandidType, Deserialize)]
-struct node { head: candid::Nat, tail: list }
-
-type s = candid::Service;
-#[derive(CandidType, Deserialize)]
-struct stream(Option<Box<stream_inner>>);
-
-#[derive(CandidType, Deserialize)]
-struct stream_inner { head: candid::Nat, next: candid::Func }
-
-#[derive(CandidType, Deserialize)]
-struct t(candid::Func);
-
-#[derive(CandidType, Deserialize)]
-enum tree {
-  branch{ val: candid::Int, left: Box<tree>, right: Box<tree> },
-  leaf(candid::Int),
+struct nested {
+  _0_: candid::Nat,
+  _1_: candid::Nat,
+  _2_: (candid::Nat,candid::Int,),
+  _3_: nested_3,
+  _40_: candid::Nat,
+  _41_: nested_41,
+  _42_: candid::Nat,
 }
+
+type broker = candid::Service;
+#[derive(CandidType, Deserialize)]
+enum h_arg1 { A(candid::Nat), B(Option<String>) }
+
+#[derive(CandidType, Deserialize)]
+struct h_ret0_42 {}
+
+#[derive(CandidType, Deserialize)]
+struct h_ret0 { _42_: h_ret0_42, id: candid::Nat }
+
+type f = candid::Func;
+#[derive(CandidType, Deserialize)]
+struct b (candid::Int,candid::Nat,)
+
+#[derive(CandidType, Deserialize)]
+enum a { a, b(b) }
 
 struct SERVICE(candid::Principal);
 impl SERVICE{

--- a/rust/candid/tests/assets/ok/example.rs
+++ b/rust/candid/tests/assets/ok/example.rs
@@ -3,7 +3,7 @@
 
 type A = Box<B>;
 #[derive(CandidType, Deserialize)]
-struct B(Option<A>)
+struct B(Option<A>);
 
 type List = Option<Box<List_inner>>;
 #[derive(CandidType, Deserialize)]
@@ -50,13 +50,13 @@ struct node { head: candid::Nat, tail: list }
 
 type s = candid::Service;
 #[derive(CandidType, Deserialize)]
-struct stream(Option<Box<stream_inner>>)
+struct stream(Option<Box<stream_inner>>);
 
 #[derive(CandidType, Deserialize)]
 struct stream_inner { head: candid::Nat, next: candid::Func }
 
 #[derive(CandidType, Deserialize)]
-struct t(candid::Func)
+struct t(candid::Func);
 
 #[derive(CandidType, Deserialize)]
 enum tree {

--- a/rust/candid/tests/assets/ok/example.rs
+++ b/rust/candid/tests/assets/ok/example.rs
@@ -1,0 +1,49 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+type A = B
+type B = Option<A>
+type List = Option<List_inner>
+#[derive(CandidType, Deserialize)]
+struct List_inner { head: candid::Int, tail: List }
+#[derive(CandidType, Deserialize)]
+enum a { a, b(b) }
+#[derive(CandidType, Deserialize)]
+struct b (candid::Int,candid::Nat,)
+type broker = candid::Service
+type f = candid::Func
+#[derive(CandidType, Deserialize)]
+enum h_arg1 { A(candid::Nat), B(Option<String>) }
+#[derive(CandidType, Deserialize)]
+struct h_ret0 { _42_: h_ret0_42, id: candid::Nat }
+#[derive(CandidType, Deserialize)]
+struct h_ret0_42 {}
+type list = Option<node>
+type my_type = candid::Principal
+#[derive(CandidType, Deserialize)]
+struct nested {
+  _0_: candid::Nat,
+  _1_: candid::Nat,
+  _2_: (candid::Nat,candid::Int,),
+  _3_: nested_3,
+  _40_: candid::Nat,
+  _41_: nested_41,
+  _42_: candid::Nat,
+}
+#[derive(CandidType, Deserialize)]
+struct nested_3 { _0_: candid::Nat, _42_: candid::Nat, _43_: u8 }
+#[derive(CandidType, Deserialize)]
+enum nested_41 { _42_, A, B, C }
+#[derive(CandidType, Deserialize)]
+struct node { head: candid::Nat, tail: list }
+type s = candid::Service
+type stream = Option<stream_inner>
+#[derive(CandidType, Deserialize)]
+struct stream_inner { head: candid::Nat, next: candid::Func }
+type t = candid::Func
+#[derive(CandidType, Deserialize)]
+enum tree {
+  branch{ val: candid::Int, left: tree, right: tree },
+  leaf(candid::Int),
+}
+

--- a/rust/candid/tests/assets/ok/fieldnat.rs
+++ b/rust/candid/tests/assets/ok/fieldnat.rs
@@ -2,28 +2,28 @@
 // You may want to manually adjust some of the types.
 
 #[derive(CandidType, Deserialize)]
-struct bar_arg0 { _50_: candid::Int };
+struct bar_arg0 { _50_: candid::Int }
 
 #[derive(CandidType, Deserialize)]
-struct baz_arg0 { _2_: candid::Int, _50_: candid::Nat };
+struct baz_arg0 { _2_: candid::Int, _50_: candid::Nat }
 
 #[derive(CandidType, Deserialize)]
-struct baz_ret0 {};
+struct baz_ret0 {}
 
 #[derive(CandidType, Deserialize)]
-enum bib_ret0 { _0_(candid::Int) };
+enum bib_ret0 { _0_(candid::Int) }
 
 #[derive(CandidType, Deserialize)]
-struct foo_arg0 { _2_: candid::Int };
+struct foo_arg0 { _2_: candid::Int }
 
 #[derive(CandidType, Deserialize)]
-struct foo_ret0 { _2_: candid::Int, _2: candid::Int };
+struct foo_ret0 { _2_: candid::Int, _2: candid::Int }
 
 #[derive(CandidType, Deserialize)]
-struct non_tuple { _1_: String, _2_: String };
+struct non_tuple { _1_: String, _2_: String }
 
 #[derive(CandidType, Deserialize)]
-struct tuple (String,String,);
+struct tuple (String,String,)
 
 pub trait SERVICE {
   pub fn bab(arg0: candid::Int, arg1: candid::Nat) -> ();

--- a/rust/candid/tests/assets/ok/fieldnat.rs
+++ b/rust/candid/tests/assets/ok/fieldnat.rs
@@ -25,12 +25,27 @@ struct non_tuple { _1_: String, _2_: String }
 #[derive(CandidType, Deserialize)]
 struct tuple (String,String,)
 
-pub trait SERVICE {
-  pub fn bab(arg0: candid::Int, arg1: candid::Nat) -> ();
-  pub fn bar(arg0: bar_arg0) -> ();
-  pub fn bas(arg0: (candid::Int,candid::Int,)) -> ((String,candid::Nat,));
-  pub fn baz(arg0: baz_arg0) -> (baz_ret0);
-  pub fn bba(arg0: tuple) -> (non_tuple);
-  pub fn bib(arg0: (candid::Int,)) -> (bib_ret0);
-  pub fn foo(arg0: foo_arg0) -> (foo_ret0);
+struct SERVICE(candid::Principal);
+impl SERVICE{
+  pub async fn bab(&self, arg0: candid::Int, arg1: candid::Nat) -> () {
+    ic_cdk::call(self.0, "bab", (arg0,arg1,)).await.unwrap()
+  }
+  pub async fn bar(&self, arg0: bar_arg0) -> () {
+    ic_cdk::call(self.0, "bar", (arg0,)).await.unwrap()
+  }
+  pub async fn bas(&self, arg0: (candid::Int,candid::Int,)) -> (
+    (String,candid::Nat,),
+  ) { ic_cdk::call(self.0, "bas", (arg0,)).await.unwrap() }
+  pub async fn baz(&self, arg0: baz_arg0) -> (baz_ret0) {
+    ic_cdk::call(self.0, "baz", (arg0,)).await.unwrap()
+  }
+  pub async fn bba(&self, arg0: tuple) -> (non_tuple) {
+    ic_cdk::call(self.0, "bba", (arg0,)).await.unwrap()
+  }
+  pub async fn bib(&self, arg0: (candid::Int,)) -> (bib_ret0) {
+    ic_cdk::call(self.0, "bib", (arg0,)).await.unwrap()
+  }
+  pub async fn foo(&self, arg0: foo_arg0) -> (foo_ret0) {
+    ic_cdk::call(self.0, "foo", (arg0,)).await.unwrap()
+  }
 }

--- a/rust/candid/tests/assets/ok/fieldnat.rs
+++ b/rust/candid/tests/assets/ok/fieldnat.rs
@@ -1,0 +1,20 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+#[derive(CandidType, Deserialize)]
+struct bar_arg0 { _50_: candid::Int }
+#[derive(CandidType, Deserialize)]
+struct baz_arg0 { _2_: candid::Int, _50_: candid::Nat }
+#[derive(CandidType, Deserialize)]
+struct baz_ret0 {}
+#[derive(CandidType, Deserialize)]
+enum bib_ret0 { _0_(candid::Int) }
+#[derive(CandidType, Deserialize)]
+struct foo_arg0 { _2_: candid::Int }
+#[derive(CandidType, Deserialize)]
+struct foo_ret0 { _2_: candid::Int, _2: candid::Int }
+#[derive(CandidType, Deserialize)]
+struct non_tuple { _1_: String, _2_: String }
+#[derive(CandidType, Deserialize)]
+struct tuple (String,String,)
+

--- a/rust/candid/tests/assets/ok/fieldnat.rs
+++ b/rust/candid/tests/assets/ok/fieldnat.rs
@@ -3,18 +3,34 @@
 
 #[derive(CandidType, Deserialize)]
 struct bar_arg0 { _50_: candid::Int }
+
 #[derive(CandidType, Deserialize)]
 struct baz_arg0 { _2_: candid::Int, _50_: candid::Nat }
+
 #[derive(CandidType, Deserialize)]
 struct baz_ret0 {}
+
 #[derive(CandidType, Deserialize)]
 enum bib_ret0 { _0_(candid::Int) }
+
 #[derive(CandidType, Deserialize)]
 struct foo_arg0 { _2_: candid::Int }
+
 #[derive(CandidType, Deserialize)]
 struct foo_ret0 { _2_: candid::Int, _2: candid::Int }
+
 #[derive(CandidType, Deserialize)]
 struct non_tuple { _1_: String, _2_: String }
+
 #[derive(CandidType, Deserialize)]
 struct tuple (String,String,)
 
+pub trait SERVICE {
+  pub fn bab(arg0: candid::Int, arg1: candid::Nat) -> ();
+  pub fn bar(arg0: bar_arg0) -> ();
+  pub fn bas(arg0: (candid::Int,candid::Int,)) -> ((String,candid::Nat,));
+  pub fn baz(arg0: baz_arg0) -> (baz_ret0);
+  pub fn bba(arg0: tuple) -> (non_tuple);
+  pub fn bib(arg0: (candid::Int,)) -> (bib_ret0);
+  pub fn foo(arg0: foo_arg0) -> (foo_ret0);
+}

--- a/rust/candid/tests/assets/ok/fieldnat.rs
+++ b/rust/candid/tests/assets/ok/fieldnat.rs
@@ -1,5 +1,7 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize)]
 struct bar_arg0 { #[serde(rename="2")] _50_: candid::Int }
@@ -27,25 +29,25 @@ struct foo_ret0 { _2_: candid::Int, _2: candid::Int }
 
 struct SERVICE(candid::Principal);
 impl SERVICE{
-  pub async fn bab(&self, arg0: candid::Int, arg1: candid::Nat) -> () {
-    ic_cdk::call(self.0, "bab", (arg0,arg1,)).await.unwrap()
+  pub async fn bab(&self, arg0: candid::Int, arg1: candid::Nat) -> CallResult<
+    ()
+  > { ic_cdk::call(self.0, "bab", (arg0,arg1,)).await }
+  pub async fn bar(&self, arg0: bar_arg0) -> CallResult<()> {
+    ic_cdk::call(self.0, "bar", (arg0,)).await
   }
-  pub async fn bar(&self, arg0: bar_arg0) -> () {
-    ic_cdk::call(self.0, "bar", (arg0,)).await.unwrap()
+  pub async fn bas(&self, arg0: (candid::Int,candid::Int,)) -> CallResult<
+    ((String,candid::Nat,),)
+  > { ic_cdk::call(self.0, "bas", (arg0,)).await }
+  pub async fn baz(&self, arg0: baz_arg0) -> CallResult<(baz_ret0,)> {
+    ic_cdk::call(self.0, "baz", (arg0,)).await
   }
-  pub async fn bas(&self, arg0: (candid::Int,candid::Int,)) -> (
-    (String,candid::Nat,),
-  ) { ic_cdk::call(self.0, "bas", (arg0,)).await.unwrap() }
-  pub async fn baz(&self, arg0: baz_arg0) -> (baz_ret0) {
-    ic_cdk::call(self.0, "baz", (arg0,)).await.unwrap()
+  pub async fn bba(&self, arg0: tuple) -> CallResult<(non_tuple,)> {
+    ic_cdk::call(self.0, "bba", (arg0,)).await
   }
-  pub async fn bba(&self, arg0: tuple) -> (non_tuple) {
-    ic_cdk::call(self.0, "bba", (arg0,)).await.unwrap()
+  pub async fn bib(&self, arg0: (candid::Int,)) -> CallResult<(bib_ret0,)> {
+    ic_cdk::call(self.0, "bib", (arg0,)).await
   }
-  pub async fn bib(&self, arg0: (candid::Int,)) -> (bib_ret0) {
-    ic_cdk::call(self.0, "bib", (arg0,)).await.unwrap()
-  }
-  pub async fn foo(&self, arg0: foo_arg0) -> (foo_ret0) {
-    ic_cdk::call(self.0, "foo", (arg0,)).await.unwrap()
+  pub async fn foo(&self, arg0: foo_arg0) -> CallResult<(foo_ret0,)> {
+    ic_cdk::call(self.0, "foo", (arg0,)).await
   }
 }

--- a/rust/candid/tests/assets/ok/fieldnat.rs
+++ b/rust/candid/tests/assets/ok/fieldnat.rs
@@ -2,10 +2,10 @@
 // You may want to manually adjust some of the types.
 
 #[derive(CandidType, Deserialize)]
-struct bar_arg0 { _50_: candid::Int }
+struct bar_arg0 { #[serde(rename="2")] _50_: candid::Int }
 
 #[derive(CandidType, Deserialize)]
-struct baz_arg0 { _2_: candid::Int, _50_: candid::Nat }
+struct baz_arg0 { _2_: candid::Int, #[serde(rename="2")] _50_: candid::Nat }
 
 #[derive(CandidType, Deserialize)]
 struct baz_ret0 {}

--- a/rust/candid/tests/assets/ok/fieldnat.rs
+++ b/rust/candid/tests/assets/ok/fieldnat.rs
@@ -2,28 +2,28 @@
 // You may want to manually adjust some of the types.
 
 #[derive(CandidType, Deserialize)]
-struct bar_arg0 { _50_: candid::Int }
+struct bar_arg0 { _50_: candid::Int };
 
 #[derive(CandidType, Deserialize)]
-struct baz_arg0 { _2_: candid::Int, _50_: candid::Nat }
+struct baz_arg0 { _2_: candid::Int, _50_: candid::Nat };
 
 #[derive(CandidType, Deserialize)]
-struct baz_ret0 {}
+struct baz_ret0 {};
 
 #[derive(CandidType, Deserialize)]
-enum bib_ret0 { _0_(candid::Int) }
+enum bib_ret0 { _0_(candid::Int) };
 
 #[derive(CandidType, Deserialize)]
-struct foo_arg0 { _2_: candid::Int }
+struct foo_arg0 { _2_: candid::Int };
 
 #[derive(CandidType, Deserialize)]
-struct foo_ret0 { _2_: candid::Int, _2: candid::Int }
+struct foo_ret0 { _2_: candid::Int, _2: candid::Int };
 
 #[derive(CandidType, Deserialize)]
-struct non_tuple { _1_: String, _2_: String }
+struct non_tuple { _1_: String, _2_: String };
 
 #[derive(CandidType, Deserialize)]
-struct tuple (String,String,)
+struct tuple (String,String,);
 
 pub trait SERVICE {
   pub fn bab(arg0: candid::Int, arg1: candid::Nat) -> ();

--- a/rust/candid/tests/assets/ok/fieldnat.rs
+++ b/rust/candid/tests/assets/ok/fieldnat.rs
@@ -11,6 +11,12 @@ struct baz_arg0 { _2_: candid::Int, #[serde(rename="2")] _50_: candid::Nat }
 struct baz_ret0 {}
 
 #[derive(CandidType, Deserialize)]
+struct tuple (String,String,)
+
+#[derive(CandidType, Deserialize)]
+struct non_tuple { _1_: String, _2_: String }
+
+#[derive(CandidType, Deserialize)]
 enum bib_ret0 { _0_(candid::Int) }
 
 #[derive(CandidType, Deserialize)]
@@ -18,12 +24,6 @@ struct foo_arg0 { _2_: candid::Int }
 
 #[derive(CandidType, Deserialize)]
 struct foo_ret0 { _2_: candid::Int, _2: candid::Int }
-
-#[derive(CandidType, Deserialize)]
-struct non_tuple { _1_: String, _2_: String }
-
-#[derive(CandidType, Deserialize)]
-struct tuple (String,String,)
 
 struct SERVICE(candid::Principal);
 impl SERVICE{

--- a/rust/candid/tests/assets/ok/keyword.rs
+++ b/rust/candid/tests/assets/ok/keyword.rs
@@ -2,33 +2,39 @@
 // You may want to manually adjust some of the types.
 
 #[derive(CandidType, Deserialize)]
-struct field_arg0 { test: u16, _1291438163_: u8 }
+struct field_arg0 { test: u16, _1291438163_: u8 };
 
 #[derive(CandidType, Deserialize)]
-struct field_ret0 {}
+struct field_ret0 {};
 
 #[derive(CandidType, Deserialize)]
-struct fieldnat_arg0 { _2_: candid::Int, _50_: candid::Nat }
+struct fieldnat_arg0 { _2_: candid::Int, _50_: candid::Nat };
 
 #[derive(CandidType, Deserialize)]
 enum r#if {
   branch{ val: candid::Int, left: r#if, right: r#if },
   leaf(candid::Int),
-}
+};
 
-type list = Option<node>
+type list = Option<node>;
 #[derive(CandidType, Deserialize)]
-struct node { head: candid::Nat, tail: list }
+struct node { head: candid::Nat, tail: list };
 
-type o = Option<o>
-type r#return = candid::Service
-type stream = Option<stream_inner>
 #[derive(CandidType, Deserialize)]
-struct stream_inner { head: candid::Nat, next: candid::Func }
+struct o(Option<o>);
 
-type t = candid::Func
+type r#return = candid::Service;
 #[derive(CandidType, Deserialize)]
-enum variant_arg0 { A, B, C, D(f64) }
+struct stream(Option<stream_inner>);
+
+#[derive(CandidType, Deserialize)]
+struct stream_inner { head: candid::Nat, next: candid::Func };
+
+#[derive(CandidType, Deserialize)]
+struct t(candid::Func);
+
+#[derive(CandidType, Deserialize)]
+enum variant_arg0 { A, B, C, D(f64) };
 
 pub trait SERVICE {
   pub fn Oneway() -> ();

--- a/rust/candid/tests/assets/ok/keyword.rs
+++ b/rust/candid/tests/assets/ok/keyword.rs
@@ -2,6 +2,9 @@
 // You may want to manually adjust some of the types.
 
 #[derive(CandidType, Deserialize)]
+struct o(Option<Box<o>>);
+
+#[derive(CandidType, Deserialize)]
 struct field_arg0 { test: u16, _1291438163_: u8 }
 
 #[derive(CandidType, Deserialize)]
@@ -15,25 +18,24 @@ struct fieldnat_arg0 {
 }
 
 #[derive(CandidType, Deserialize)]
+struct node { head: candid::Nat, tail: Box<list> }
+
+#[derive(CandidType, Deserialize)]
+struct list(Option<node>);
+
+#[derive(CandidType, Deserialize)]
 enum r#if {
   branch{ val: candid::Int, left: Box<r#if>, right: Box<r#if> },
   leaf(candid::Int),
 }
 
-type list = Option<Box<node>>;
-#[derive(CandidType, Deserialize)]
-struct node { head: candid::Nat, tail: list }
-
-#[derive(CandidType, Deserialize)]
-struct o(Option<Box<o>>);
-
-type r#return = candid::Service;
-#[derive(CandidType, Deserialize)]
-struct stream(Option<Box<stream_inner>>);
-
 #[derive(CandidType, Deserialize)]
 struct stream_inner { head: candid::Nat, next: candid::Func }
 
+#[derive(CandidType, Deserialize)]
+struct stream(Option<stream_inner>);
+
+type r#return = candid::Service;
 #[derive(CandidType, Deserialize)]
 struct t(candid::Func);
 

--- a/rust/candid/tests/assets/ok/keyword.rs
+++ b/rust/candid/tests/assets/ok/keyword.rs
@@ -21,17 +21,17 @@ type list = Option<Box<node>>;
 struct node { head: candid::Nat, tail: list }
 
 #[derive(CandidType, Deserialize)]
-struct o(Option<Box<o>>)
+struct o(Option<Box<o>>);
 
 type r#return = candid::Service;
 #[derive(CandidType, Deserialize)]
-struct stream(Option<Box<stream_inner>>)
+struct stream(Option<Box<stream_inner>>);
 
 #[derive(CandidType, Deserialize)]
 struct stream_inner { head: candid::Nat, next: candid::Func }
 
 #[derive(CandidType, Deserialize)]
-struct t(candid::Func)
+struct t(candid::Func);
 
 #[derive(CandidType, Deserialize)]
 enum variant_arg0 { A, B, C, D(f64) }

--- a/rust/candid/tests/assets/ok/keyword.rs
+++ b/rust/candid/tests/assets/ok/keyword.rs
@@ -12,7 +12,7 @@ struct fieldnat_arg0 { _2_: candid::Int, _50_: candid::Nat };
 
 #[derive(CandidType, Deserialize)]
 enum r#if {
-  branch{ val: candid::Int, left: r#if, right: r#if },
+  branch{ val: candid::Int, left: Box<r#if>, right: Box<r#if> },
   leaf(candid::Int),
 };
 
@@ -21,11 +21,11 @@ type list = Option<node>;
 struct node { head: candid::Nat, tail: list };
 
 #[derive(CandidType, Deserialize)]
-struct o(Option<o>);
+struct o(Option<Box<o>>);
 
 type r#return = candid::Service;
 #[derive(CandidType, Deserialize)]
-struct stream(Option<stream_inner>);
+struct stream(Option<Box<stream_inner>>);
 
 #[derive(CandidType, Deserialize)]
 struct stream_inner { head: candid::Nat, next: candid::Func };

--- a/rust/candid/tests/assets/ok/keyword.rs
+++ b/rust/candid/tests/assets/ok/keyword.rs
@@ -8,7 +8,11 @@ struct field_arg0 { test: u16, _1291438163_: u8 }
 struct field_ret0 {}
 
 #[derive(CandidType, Deserialize)]
-struct fieldnat_arg0 { _2_: candid::Int, _50_: candid::Nat }
+struct fieldnat_arg0 {
+  _2_: candid::Int,
+  #[serde(rename="2")]
+  _50_: candid::Nat,
+}
 
 #[derive(CandidType, Deserialize)]
 enum r#if {

--- a/rust/candid/tests/assets/ok/keyword.rs
+++ b/rust/candid/tests/assets/ok/keyword.rs
@@ -3,24 +3,43 @@
 
 #[derive(CandidType, Deserialize)]
 struct field_arg0 { test: u16, _1291438163_: u8 }
+
 #[derive(CandidType, Deserialize)]
 struct field_ret0 {}
+
 #[derive(CandidType, Deserialize)]
 struct fieldnat_arg0 { _2_: candid::Int, _50_: candid::Nat }
+
 #[derive(CandidType, Deserialize)]
 enum r#if {
   branch{ val: candid::Int, left: r#if, right: r#if },
   leaf(candid::Int),
 }
+
 type list = Option<node>
 #[derive(CandidType, Deserialize)]
 struct node { head: candid::Nat, tail: list }
+
 type o = Option<o>
 type r#return = candid::Service
 type stream = Option<stream_inner>
 #[derive(CandidType, Deserialize)]
 struct stream_inner { head: candid::Nat, next: candid::Func }
+
 type t = candid::Func
 #[derive(CandidType, Deserialize)]
 enum variant_arg0 { A, B, C, D(f64) }
 
+pub trait SERVICE {
+  pub fn Oneway() -> ();
+  pub fn f_(arg0: o) -> (o);
+  pub fn field(arg0: field_arg0) -> (field_ret0);
+  pub fn fieldnat(arg0: fieldnat_arg0) -> ((candid::Int,));
+  pub fn oneway(arg0: u8) -> ();
+  pub fn oneway_(arg0: u8) -> ();
+  pub fn query(arg0: Vec<u8>) -> (Vec<u8>);
+  pub fn r#return(arg0: o) -> (o);
+  pub fn service(arg0: r#return) -> ();
+  pub fn tuple(arg0: (candid::Int,Vec<u8>,String,)) -> ((candid::Int,u8,));
+  pub fn variant(arg0: variant_arg0) -> ();
+}

--- a/rust/candid/tests/assets/ok/keyword.rs
+++ b/rust/candid/tests/assets/ok/keyword.rs
@@ -36,16 +36,39 @@ struct t(candid::Func);
 #[derive(CandidType, Deserialize)]
 enum variant_arg0 { A, B, C, D(f64) }
 
-pub trait SERVICE {
-  pub fn Oneway() -> ();
-  pub fn f_(arg0: o) -> (o);
-  pub fn field(arg0: field_arg0) -> (field_ret0);
-  pub fn fieldnat(arg0: fieldnat_arg0) -> ((candid::Int,));
-  pub fn oneway(arg0: u8) -> ();
-  pub fn oneway_(arg0: u8) -> ();
-  pub fn query(arg0: Vec<u8>) -> (Vec<u8>);
-  pub fn r#return(arg0: o) -> (o);
-  pub fn service(arg0: r#return) -> ();
-  pub fn tuple(arg0: (candid::Int,Vec<u8>,String,)) -> ((candid::Int,u8,));
-  pub fn variant(arg0: variant_arg0) -> ();
+struct SERVICE(candid::Principal);
+impl SERVICE{
+  pub async fn Oneway(&self) -> () {
+    ic_cdk::call(self.0, "Oneway", ()).await.unwrap()
+  }
+  pub async fn f_(&self, arg0: o) -> (o) {
+    ic_cdk::call(self.0, "f_", (arg0,)).await.unwrap()
+  }
+  pub async fn field(&self, arg0: field_arg0) -> (field_ret0) {
+    ic_cdk::call(self.0, "field", (arg0,)).await.unwrap()
+  }
+  pub async fn fieldnat(&self, arg0: fieldnat_arg0) -> ((candid::Int,)) {
+    ic_cdk::call(self.0, "fieldnat", (arg0,)).await.unwrap()
+  }
+  pub async fn oneway(&self, arg0: u8) -> () {
+    ic_cdk::call(self.0, "oneway", (arg0,)).await.unwrap()
+  }
+  pub async fn oneway_(&self, arg0: u8) -> () {
+    ic_cdk::call(self.0, "oneway_", (arg0,)).await.unwrap()
+  }
+  pub async fn query(&self, arg0: Vec<u8>) -> (Vec<u8>) {
+    ic_cdk::call(self.0, "query", (arg0,)).await.unwrap()
+  }
+  pub async fn r#return(&self, arg0: o) -> (o) {
+    ic_cdk::call(self.0, "return", (arg0,)).await.unwrap()
+  }
+  pub async fn service(&self, arg0: r#return) -> () {
+    ic_cdk::call(self.0, "service", (arg0,)).await.unwrap()
+  }
+  pub async fn tuple(&self, arg0: (candid::Int,Vec<u8>,String,)) -> (
+    (candid::Int,u8,),
+  ) { ic_cdk::call(self.0, "tuple", (arg0,)).await.unwrap() }
+  pub async fn variant(&self, arg0: variant_arg0) -> () {
+    ic_cdk::call(self.0, "variant", (arg0,)).await.unwrap()
+  }
 }

--- a/rust/candid/tests/assets/ok/keyword.rs
+++ b/rust/candid/tests/assets/ok/keyword.rs
@@ -1,5 +1,7 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize)]
 struct o(Option<Box<o>>);
@@ -44,37 +46,37 @@ enum variant_arg0 { A, B, C, D(f64) }
 
 struct SERVICE(candid::Principal);
 impl SERVICE{
-  pub async fn Oneway(&self) -> () {
-    ic_cdk::call(self.0, "Oneway", ()).await.unwrap()
+  pub async fn Oneway(&self) -> CallResult<()> {
+    ic_cdk::call(self.0, "Oneway", ()).await
   }
-  pub async fn f_(&self, arg0: o) -> (o) {
-    ic_cdk::call(self.0, "f_", (arg0,)).await.unwrap()
+  pub async fn f_(&self, arg0: o) -> CallResult<(o,)> {
+    ic_cdk::call(self.0, "f_", (arg0,)).await
   }
-  pub async fn field(&self, arg0: field_arg0) -> (field_ret0) {
-    ic_cdk::call(self.0, "field", (arg0,)).await.unwrap()
+  pub async fn field(&self, arg0: field_arg0) -> CallResult<(field_ret0,)> {
+    ic_cdk::call(self.0, "field", (arg0,)).await
   }
-  pub async fn fieldnat(&self, arg0: fieldnat_arg0) -> ((candid::Int,)) {
-    ic_cdk::call(self.0, "fieldnat", (arg0,)).await.unwrap()
+  pub async fn fieldnat(&self, arg0: fieldnat_arg0) -> CallResult<
+    ((candid::Int,),)
+  > { ic_cdk::call(self.0, "fieldnat", (arg0,)).await }
+  pub async fn oneway(&self, arg0: u8) -> CallResult<()> {
+    ic_cdk::call(self.0, "oneway", (arg0,)).await
   }
-  pub async fn oneway(&self, arg0: u8) -> () {
-    ic_cdk::call(self.0, "oneway", (arg0,)).await.unwrap()
+  pub async fn oneway_(&self, arg0: u8) -> CallResult<()> {
+    ic_cdk::call(self.0, "oneway_", (arg0,)).await
   }
-  pub async fn oneway_(&self, arg0: u8) -> () {
-    ic_cdk::call(self.0, "oneway_", (arg0,)).await.unwrap()
+  pub async fn query(&self, arg0: Vec<u8>) -> CallResult<(Vec<u8>,)> {
+    ic_cdk::call(self.0, "query", (arg0,)).await
   }
-  pub async fn query(&self, arg0: Vec<u8>) -> (Vec<u8>) {
-    ic_cdk::call(self.0, "query", (arg0,)).await.unwrap()
+  pub async fn r#return(&self, arg0: o) -> CallResult<(o,)> {
+    ic_cdk::call(self.0, "return", (arg0,)).await
   }
-  pub async fn r#return(&self, arg0: o) -> (o) {
-    ic_cdk::call(self.0, "return", (arg0,)).await.unwrap()
+  pub async fn service(&self, arg0: r#return) -> CallResult<()> {
+    ic_cdk::call(self.0, "service", (arg0,)).await
   }
-  pub async fn service(&self, arg0: r#return) -> () {
-    ic_cdk::call(self.0, "service", (arg0,)).await.unwrap()
-  }
-  pub async fn tuple(&self, arg0: (candid::Int,Vec<u8>,String,)) -> (
-    (candid::Int,u8,),
-  ) { ic_cdk::call(self.0, "tuple", (arg0,)).await.unwrap() }
-  pub async fn variant(&self, arg0: variant_arg0) -> () {
-    ic_cdk::call(self.0, "variant", (arg0,)).await.unwrap()
+  pub async fn tuple(&self, arg0: (candid::Int,Vec<u8>,String,)) -> CallResult<
+    ((candid::Int,u8,),)
+  > { ic_cdk::call(self.0, "tuple", (arg0,)).await }
+  pub async fn variant(&self, arg0: variant_arg0) -> CallResult<()> {
+    ic_cdk::call(self.0, "variant", (arg0,)).await
   }
 }

--- a/rust/candid/tests/assets/ok/keyword.rs
+++ b/rust/candid/tests/assets/ok/keyword.rs
@@ -1,0 +1,26 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+#[derive(CandidType, Deserialize)]
+struct field_arg0 { test: u16, _1291438163_: u8 }
+#[derive(CandidType, Deserialize)]
+struct field_ret0 {}
+#[derive(CandidType, Deserialize)]
+struct fieldnat_arg0 { _2_: candid::Int, _50_: candid::Nat }
+#[derive(CandidType, Deserialize)]
+enum r#if {
+  branch{ val: candid::Int, left: r#if, right: r#if },
+  leaf(candid::Int),
+}
+type list = Option<node>
+#[derive(CandidType, Deserialize)]
+struct node { head: candid::Nat, tail: list }
+type o = Option<o>
+type r#return = candid::Service
+type stream = Option<stream_inner>
+#[derive(CandidType, Deserialize)]
+struct stream_inner { head: candid::Nat, next: candid::Func }
+type t = candid::Func
+#[derive(CandidType, Deserialize)]
+enum variant_arg0 { A, B, C, D(f64) }
+

--- a/rust/candid/tests/assets/ok/keyword.rs
+++ b/rust/candid/tests/assets/ok/keyword.rs
@@ -2,39 +2,39 @@
 // You may want to manually adjust some of the types.
 
 #[derive(CandidType, Deserialize)]
-struct field_arg0 { test: u16, _1291438163_: u8 };
+struct field_arg0 { test: u16, _1291438163_: u8 }
 
 #[derive(CandidType, Deserialize)]
-struct field_ret0 {};
+struct field_ret0 {}
 
 #[derive(CandidType, Deserialize)]
-struct fieldnat_arg0 { _2_: candid::Int, _50_: candid::Nat };
+struct fieldnat_arg0 { _2_: candid::Int, _50_: candid::Nat }
 
 #[derive(CandidType, Deserialize)]
 enum r#if {
   branch{ val: candid::Int, left: Box<r#if>, right: Box<r#if> },
   leaf(candid::Int),
-};
+}
 
-type list = Option<node>;
+type list = Option<Box<node>>;
 #[derive(CandidType, Deserialize)]
-struct node { head: candid::Nat, tail: list };
+struct node { head: candid::Nat, tail: list }
 
 #[derive(CandidType, Deserialize)]
-struct o(Option<Box<o>>);
+struct o(Option<Box<o>>)
 
 type r#return = candid::Service;
 #[derive(CandidType, Deserialize)]
-struct stream(Option<Box<stream_inner>>);
+struct stream(Option<Box<stream_inner>>)
 
 #[derive(CandidType, Deserialize)]
-struct stream_inner { head: candid::Nat, next: candid::Func };
+struct stream_inner { head: candid::Nat, next: candid::Func }
 
 #[derive(CandidType, Deserialize)]
-struct t(candid::Func);
+struct t(candid::Func)
 
 #[derive(CandidType, Deserialize)]
-enum variant_arg0 { A, B, C, D(f64) };
+enum variant_arg0 { A, B, C, D(f64) }
 
 pub trait SERVICE {
   pub fn Oneway() -> ();

--- a/rust/candid/tests/assets/ok/recursion.rs
+++ b/rust/candid/tests/assets/ok/recursion.rs
@@ -1,23 +1,29 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type A = B
-type B = Option<A>
-type list = Option<node>
+type A = B;
 #[derive(CandidType, Deserialize)]
-struct node { head: candid::Nat, tail: list }
+struct B(Option<A>);
 
-type s = candid::Service
-type stream = Option<stream_inner>
+type list = Option<node>;
 #[derive(CandidType, Deserialize)]
-struct stream_inner { head: candid::Nat, next: candid::Func }
+struct node { head: candid::Nat, tail: list };
 
-type t = candid::Func
+type s = candid::Service;
+#[derive(CandidType, Deserialize)]
+struct stream(Option<stream_inner>);
+
+#[derive(CandidType, Deserialize)]
+struct stream_inner { head: candid::Nat, next: candid::Func };
+
+#[derive(CandidType, Deserialize)]
+struct t(candid::Func);
+
 #[derive(CandidType, Deserialize)]
 enum tree {
   branch{ val: candid::Int, left: tree, right: tree },
   leaf(candid::Int),
-}
+};
 
 pub trait SERVICE {
   pub fn f(arg0: s) -> ();

--- a/rust/candid/tests/assets/ok/recursion.rs
+++ b/rust/candid/tests/assets/ok/recursion.rs
@@ -1,29 +1,29 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type A = B;
+type A = Box<B>;
 #[derive(CandidType, Deserialize)]
-struct B(Option<A>);
+struct B(Option<A>)
 
-type list = Option<node>;
+type list = Option<Box<node>>;
 #[derive(CandidType, Deserialize)]
-struct node { head: candid::Nat, tail: list };
+struct node { head: candid::Nat, tail: list }
 
 type s = candid::Service;
 #[derive(CandidType, Deserialize)]
-struct stream(Option<Box<stream_inner>>);
+struct stream(Option<Box<stream_inner>>)
 
 #[derive(CandidType, Deserialize)]
-struct stream_inner { head: candid::Nat, next: candid::Func };
+struct stream_inner { head: candid::Nat, next: candid::Func }
 
 #[derive(CandidType, Deserialize)]
-struct t(candid::Func);
+struct t(candid::Func)
 
 #[derive(CandidType, Deserialize)]
 enum tree {
   branch{ val: candid::Int, left: Box<tree>, right: Box<tree> },
   leaf(candid::Int),
-};
+}
 
 pub trait SERVICE {
   pub fn f(arg0: s) -> ();

--- a/rust/candid/tests/assets/ok/recursion.rs
+++ b/rust/candid/tests/assets/ok/recursion.rs
@@ -1,0 +1,19 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+type A = B
+type B = Option<A>
+type list = Option<node>
+#[derive(CandidType, Deserialize)]
+struct node { head: candid::Nat, tail: list }
+type s = candid::Service
+type stream = Option<stream_inner>
+#[derive(CandidType, Deserialize)]
+struct stream_inner { head: candid::Nat, next: candid::Func }
+type t = candid::Func
+#[derive(CandidType, Deserialize)]
+enum tree {
+  branch{ val: candid::Int, left: tree, right: tree },
+  leaf(candid::Int),
+}
+

--- a/rust/candid/tests/assets/ok/recursion.rs
+++ b/rust/candid/tests/assets/ok/recursion.rs
@@ -1,29 +1,31 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
+type t = candid::Func;
+#[derive(CandidType, Deserialize)]
+struct node { head: candid::Nat, tail: Box<list> }
+
+#[derive(CandidType, Deserialize)]
+struct list(Option<node>);
+
 type A = Box<B>;
 #[derive(CandidType, Deserialize)]
 struct B(Option<A>);
-
-type list = Option<Box<node>>;
-#[derive(CandidType, Deserialize)]
-struct node { head: candid::Nat, tail: list }
-
-type s = candid::Service;
-#[derive(CandidType, Deserialize)]
-struct stream(Option<Box<stream_inner>>);
-
-#[derive(CandidType, Deserialize)]
-struct stream_inner { head: candid::Nat, next: candid::Func }
-
-#[derive(CandidType, Deserialize)]
-struct t(candid::Func);
 
 #[derive(CandidType, Deserialize)]
 enum tree {
   branch{ val: candid::Int, left: Box<tree>, right: Box<tree> },
   leaf(candid::Int),
 }
+
+#[derive(CandidType, Deserialize)]
+struct stream_inner { head: candid::Nat, next: candid::Func }
+
+#[derive(CandidType, Deserialize)]
+struct stream(Option<stream_inner>);
+
+#[derive(CandidType, Deserialize)]
+struct s(candid::Service);
 
 struct SERVICE(candid::Principal);
 impl SERVICE{

--- a/rust/candid/tests/assets/ok/recursion.rs
+++ b/rust/candid/tests/assets/ok/recursion.rs
@@ -1,5 +1,7 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 type t = candid::Func;
 #[derive(CandidType, Deserialize)]
@@ -29,10 +31,10 @@ struct s(candid::Service);
 
 struct SERVICE(candid::Principal);
 impl SERVICE{
-  pub async fn f(&self, arg0: s) -> () {
-    ic_cdk::call(self.0, "f", (arg0,)).await.unwrap()
+  pub async fn f(&self, arg0: s) -> CallResult<()> {
+    ic_cdk::call(self.0, "f", (arg0,)).await
   }
-  pub async fn g(&self, arg0: list) -> (B, tree, stream) {
-    ic_cdk::call(self.0, "g", (arg0,)).await.unwrap()
+  pub async fn g(&self, arg0: list) -> CallResult<(B,tree,stream,)> {
+    ic_cdk::call(self.0, "g", (arg0,)).await
   }
 }

--- a/rust/candid/tests/assets/ok/recursion.rs
+++ b/rust/candid/tests/assets/ok/recursion.rs
@@ -11,7 +11,7 @@ struct node { head: candid::Nat, tail: list };
 
 type s = candid::Service;
 #[derive(CandidType, Deserialize)]
-struct stream(Option<stream_inner>);
+struct stream(Option<Box<stream_inner>>);
 
 #[derive(CandidType, Deserialize)]
 struct stream_inner { head: candid::Nat, next: candid::Func };
@@ -21,7 +21,7 @@ struct t(candid::Func);
 
 #[derive(CandidType, Deserialize)]
 enum tree {
-  branch{ val: candid::Int, left: tree, right: tree },
+  branch{ val: candid::Int, left: Box<tree>, right: Box<tree> },
   leaf(candid::Int),
 };
 

--- a/rust/candid/tests/assets/ok/recursion.rs
+++ b/rust/candid/tests/assets/ok/recursion.rs
@@ -3,7 +3,7 @@
 
 type A = Box<B>;
 #[derive(CandidType, Deserialize)]
-struct B(Option<A>)
+struct B(Option<A>);
 
 type list = Option<Box<node>>;
 #[derive(CandidType, Deserialize)]
@@ -11,13 +11,13 @@ struct node { head: candid::Nat, tail: list }
 
 type s = candid::Service;
 #[derive(CandidType, Deserialize)]
-struct stream(Option<Box<stream_inner>>)
+struct stream(Option<Box<stream_inner>>);
 
 #[derive(CandidType, Deserialize)]
 struct stream_inner { head: candid::Nat, next: candid::Func }
 
 #[derive(CandidType, Deserialize)]
-struct t(candid::Func)
+struct t(candid::Func);
 
 #[derive(CandidType, Deserialize)]
 enum tree {

--- a/rust/candid/tests/assets/ok/recursion.rs
+++ b/rust/candid/tests/assets/ok/recursion.rs
@@ -6,10 +6,12 @@ type B = Option<A>
 type list = Option<node>
 #[derive(CandidType, Deserialize)]
 struct node { head: candid::Nat, tail: list }
+
 type s = candid::Service
 type stream = Option<stream_inner>
 #[derive(CandidType, Deserialize)]
 struct stream_inner { head: candid::Nat, next: candid::Func }
+
 type t = candid::Func
 #[derive(CandidType, Deserialize)]
 enum tree {
@@ -17,3 +19,7 @@ enum tree {
   leaf(candid::Int),
 }
 
+pub trait SERVICE {
+  pub fn f(arg0: s) -> ();
+  pub fn g(arg0: list) -> (B, tree, stream);
+}

--- a/rust/candid/tests/assets/ok/recursion.rs
+++ b/rust/candid/tests/assets/ok/recursion.rs
@@ -25,7 +25,12 @@ enum tree {
   leaf(candid::Int),
 }
 
-pub trait SERVICE {
-  pub fn f(arg0: s) -> ();
-  pub fn g(arg0: list) -> (B, tree, stream);
+struct SERVICE(candid::Principal);
+impl SERVICE{
+  pub async fn f(&self, arg0: s) -> () {
+    ic_cdk::call(self.0, "f", (arg0,)).await.unwrap()
+  }
+  pub async fn g(&self, arg0: list) -> (B, tree, stream) {
+    ic_cdk::call(self.0, "g", (arg0,)).await.unwrap()
+  }
 }

--- a/rust/candid/tests/assets/ok/recursive_class.rs
+++ b/rust/candid/tests/assets/ok/recursive_class.rs
@@ -2,6 +2,6 @@
 // You may want to manually adjust some of the types.
 
 #[derive(CandidType, Deserialize)]
-struct s(candid::Service)
+struct s(candid::Service);
 
 pub trait SERVICE { pub fn next() -> (s); }

--- a/rust/candid/tests/assets/ok/recursive_class.rs
+++ b/rust/candid/tests/assets/ok/recursive_class.rs
@@ -1,5 +1,7 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type s = candid::Service
+#[derive(CandidType, Deserialize)]
+struct s(candid::Service);
+
 pub trait SERVICE { pub fn next() -> (s); }

--- a/rust/candid/tests/assets/ok/recursive_class.rs
+++ b/rust/candid/tests/assets/ok/recursive_class.rs
@@ -1,12 +1,14 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize)]
 struct s(candid::Service);
 
 struct SERVICE(candid::Principal);
 impl SERVICE{
-  pub async fn next(&self) -> (s) {
-    ic_cdk::call(self.0, "next", ()).await.unwrap()
+  pub async fn next(&self) -> CallResult<(s,)> {
+    ic_cdk::call(self.0, "next", ()).await
   }
 }

--- a/rust/candid/tests/assets/ok/recursive_class.rs
+++ b/rust/candid/tests/assets/ok/recursive_class.rs
@@ -2,4 +2,4 @@
 // You may want to manually adjust some of the types.
 
 type s = candid::Service
-
+pub trait SERVICE { pub fn next() -> (s); }

--- a/rust/candid/tests/assets/ok/recursive_class.rs
+++ b/rust/candid/tests/assets/ok/recursive_class.rs
@@ -2,6 +2,6 @@
 // You may want to manually adjust some of the types.
 
 #[derive(CandidType, Deserialize)]
-struct s(candid::Service);
+struct s(candid::Service)
 
 pub trait SERVICE { pub fn next() -> (s); }

--- a/rust/candid/tests/assets/ok/recursive_class.rs
+++ b/rust/candid/tests/assets/ok/recursive_class.rs
@@ -1,0 +1,5 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+type s = candid::Service
+

--- a/rust/candid/tests/assets/ok/recursive_class.rs
+++ b/rust/candid/tests/assets/ok/recursive_class.rs
@@ -4,4 +4,9 @@
 #[derive(CandidType, Deserialize)]
 struct s(candid::Service);
 
-pub trait SERVICE { pub fn next() -> (s); }
+struct SERVICE(candid::Principal);
+impl SERVICE{
+  pub async fn next(&self) -> (s) {
+    ic_cdk::call(self.0, "next", ()).await.unwrap()
+  }
+}

--- a/rust/candid/tests/assets/ok/service.rs
+++ b/rust/candid/tests/assets/ok/service.rs
@@ -1,0 +1,9 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+type Func = candid::Func
+type Service = candid::Service
+type Service2 = Service
+#[derive(CandidType, Deserialize)]
+enum asVariant_ret0 { a(Service2), b{ f: Option<Func> } }
+

--- a/rust/candid/tests/assets/ok/service.rs
+++ b/rust/candid/tests/assets/ok/service.rs
@@ -9,9 +9,18 @@ type Service2 = Box<Service>;
 #[derive(CandidType, Deserialize)]
 enum asVariant_ret0 { a(Service2), b{ f: Option<Func> } }
 
-pub trait SERVICE {
-  pub fn asArray() -> (Vec<Service2>, Vec<Func>);
-  pub fn asPrincipal() -> (Service2, Func);
-  pub fn asRecord() -> ((Service2,Option<Service>,Func,));
-  pub fn asVariant() -> (asVariant_ret0);
+struct SERVICE(candid::Principal);
+impl SERVICE{
+  pub async fn asArray(&self) -> (Vec<Service2>, Vec<Func>) {
+    ic_cdk::call(self.0, "asArray", ()).await.unwrap()
+  }
+  pub async fn asPrincipal(&self) -> (Service2, Func) {
+    ic_cdk::call(self.0, "asPrincipal", ()).await.unwrap()
+  }
+  pub async fn asRecord(&self) -> ((Service2,Option<Service>,Func,)) {
+    ic_cdk::call(self.0, "asRecord", ()).await.unwrap()
+  }
+  pub async fn asVariant(&self) -> (asVariant_ret0) {
+    ic_cdk::call(self.0, "asVariant", ()).await.unwrap()
+  }
 }

--- a/rust/candid/tests/assets/ok/service.rs
+++ b/rust/candid/tests/assets/ok/service.rs
@@ -7,3 +7,9 @@ type Service2 = Service
 #[derive(CandidType, Deserialize)]
 enum asVariant_ret0 { a(Service2), b{ f: Option<Func> } }
 
+pub trait SERVICE {
+  pub fn asArray() -> (Vec<Service2>, Vec<Func>);
+  pub fn asPrincipal() -> (Service2, Func);
+  pub fn asRecord() -> ((Service2,Option<Service>,Func,));
+  pub fn asVariant() -> (asVariant_ret0);
+}

--- a/rust/candid/tests/assets/ok/service.rs
+++ b/rust/candid/tests/assets/ok/service.rs
@@ -3,7 +3,7 @@
 
 type Func = candid::Func;
 #[derive(CandidType, Deserialize)]
-struct Service(candid::Service)
+struct Service(candid::Service);
 
 type Service2 = Box<Service>;
 #[derive(CandidType, Deserialize)]

--- a/rust/candid/tests/assets/ok/service.rs
+++ b/rust/candid/tests/assets/ok/service.rs
@@ -3,11 +3,11 @@
 
 type Func = candid::Func;
 #[derive(CandidType, Deserialize)]
-struct Service(candid::Service);
+struct Service(candid::Service)
 
-type Service2 = Service;
+type Service2 = Box<Service>;
 #[derive(CandidType, Deserialize)]
-enum asVariant_ret0 { a(Service2), b{ f: Option<Func> } };
+enum asVariant_ret0 { a(Service2), b{ f: Option<Func> } }
 
 pub trait SERVICE {
   pub fn asArray() -> (Vec<Service2>, Vec<Func>);

--- a/rust/candid/tests/assets/ok/service.rs
+++ b/rust/candid/tests/assets/ok/service.rs
@@ -1,5 +1,7 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 type Func = candid::Func;
 #[derive(CandidType, Deserialize)]
@@ -11,16 +13,16 @@ enum asVariant_ret0 { a(Service2), b{ f: Option<Func> } }
 
 struct SERVICE(candid::Principal);
 impl SERVICE{
-  pub async fn asArray(&self) -> (Vec<Service2>, Vec<Func>) {
-    ic_cdk::call(self.0, "asArray", ()).await.unwrap()
+  pub async fn asArray(&self) -> CallResult<(Vec<Service2>,Vec<Func>,)> {
+    ic_cdk::call(self.0, "asArray", ()).await
   }
-  pub async fn asPrincipal(&self) -> (Service2, Func) {
-    ic_cdk::call(self.0, "asPrincipal", ()).await.unwrap()
+  pub async fn asPrincipal(&self) -> CallResult<(Service2,Func,)> {
+    ic_cdk::call(self.0, "asPrincipal", ()).await
   }
-  pub async fn asRecord(&self) -> ((Service2,Option<Service>,Func,)) {
-    ic_cdk::call(self.0, "asRecord", ()).await.unwrap()
-  }
-  pub async fn asVariant(&self) -> (asVariant_ret0) {
-    ic_cdk::call(self.0, "asVariant", ()).await.unwrap()
+  pub async fn asRecord(&self) -> CallResult<
+    ((Service2,Option<Service>,Func,),)
+  > { ic_cdk::call(self.0, "asRecord", ()).await }
+  pub async fn asVariant(&self) -> CallResult<(asVariant_ret0,)> {
+    ic_cdk::call(self.0, "asVariant", ()).await
   }
 }

--- a/rust/candid/tests/assets/ok/service.rs
+++ b/rust/candid/tests/assets/ok/service.rs
@@ -1,11 +1,13 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 
-type Func = candid::Func
-type Service = candid::Service
-type Service2 = Service
+type Func = candid::Func;
 #[derive(CandidType, Deserialize)]
-enum asVariant_ret0 { a(Service2), b{ f: Option<Func> } }
+struct Service(candid::Service);
+
+type Service2 = Service;
+#[derive(CandidType, Deserialize)]
+enum asVariant_ret0 { a(Service2), b{ f: Option<Func> } };
 
 pub trait SERVICE {
   pub fn asArray() -> (Vec<Service2>, Vec<Func>);

--- a/rust/candid/tests/assets/ok/unicode.rs
+++ b/rust/candid/tests/assets/ok/unicode.rs
@@ -12,9 +12,18 @@ struct A {
 #[derive(CandidType, Deserialize)]
 enum B { _0_, _650764729_, _1036827129_, _3099250646_ }
 
-pub trait SERVICE {
-  pub fn _0_(arg0: candid::Nat) -> (candid::Nat);
-  pub fn _356566390_() -> ();
-  pub fn _3300066460_(arg0: A) -> (B);
-  pub fn _2669435454_(arg0: candid::Nat) -> (candid::Nat);
+struct SERVICE(candid::Principal);
+impl SERVICE{
+  pub async fn _0_(&self, arg0: candid::Nat) -> (candid::Nat) {
+    ic_cdk::call(self.0, "", (arg0,)).await.unwrap()
+  }
+  pub async fn _356566390_(&self) -> () {
+    ic_cdk::call(self.0, "✈️  🚗 ⛱️ ", ()).await.unwrap()
+  }
+  pub async fn _3300066460_(&self, arg0: A) -> (B) {
+    ic_cdk::call(self.0, "函数名", (arg0,)).await.unwrap()
+  }
+  pub async fn _2669435454_(&self, arg0: candid::Nat) -> (candid::Nat) {
+    ic_cdk::call(self.0, "👀", (arg0,)).await.unwrap()
+  }
 }

--- a/rust/candid/tests/assets/ok/unicode.rs
+++ b/rust/candid/tests/assets/ok/unicode.rs
@@ -8,6 +8,13 @@ struct A {
   _2119362116_: candid::Nat,
   _3133479156_: candid::Nat,
 }
+
 #[derive(CandidType, Deserialize)]
 enum B { _0_, _650764729_, _1036827129_, _3099250646_ }
 
+pub trait SERVICE {
+  pub fn _0_(arg0: candid::Nat) -> (candid::Nat);
+  pub fn _356566390_() -> ();
+  pub fn _3300066460_(arg0: A) -> (B);
+  pub fn _2669435454_(arg0: candid::Nat) -> (candid::Nat);
+}

--- a/rust/candid/tests/assets/ok/unicode.rs
+++ b/rust/candid/tests/assets/ok/unicode.rs
@@ -3,14 +3,27 @@
 
 #[derive(CandidType, Deserialize)]
 struct A {
+  #[serde(rename="\u{e000}")]
   _11864174_: candid::Nat,
+  #[serde(rename="📦🍦")]
   _1832283146_: candid::Nat,
+  #[serde(rename="字段名")]
   _2119362116_: candid::Nat,
+  #[serde(rename="字 段 名2")]
   _3133479156_: candid::Nat,
 }
 
 #[derive(CandidType, Deserialize)]
-enum B { _0_, _650764729_, _1036827129_, _3099250646_ }
+enum B {
+  #[serde(rename="")]
+  _0_,
+  #[serde(rename="空的")]
+  _650764729_,
+  #[serde(rename="  空的  ")]
+  _1036827129_,
+  #[serde(rename="1⃣️2⃣️3⃣️")]
+  _3099250646_,
+}
 
 struct SERVICE(candid::Principal);
 impl SERVICE{

--- a/rust/candid/tests/assets/ok/unicode.rs
+++ b/rust/candid/tests/assets/ok/unicode.rs
@@ -1,5 +1,7 @@
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
+use ic_cdk::export::candid::{self, CandidType, Deserialize};
+use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize)]
 struct A {
@@ -27,16 +29,16 @@ enum B {
 
 struct SERVICE(candid::Principal);
 impl SERVICE{
-  pub async fn _0_(&self, arg0: candid::Nat) -> (candid::Nat) {
-    ic_cdk::call(self.0, "", (arg0,)).await.unwrap()
+  pub async fn _0_(&self, arg0: candid::Nat) -> CallResult<(candid::Nat,)> {
+    ic_cdk::call(self.0, "", (arg0,)).await
   }
-  pub async fn _356566390_(&self) -> () {
-    ic_cdk::call(self.0, "✈️  🚗 ⛱️ ", ()).await.unwrap()
+  pub async fn _356566390_(&self) -> CallResult<()> {
+    ic_cdk::call(self.0, "✈️  🚗 ⛱️ ", ()).await
   }
-  pub async fn _3300066460_(&self, arg0: A) -> (B) {
-    ic_cdk::call(self.0, "函数名", (arg0,)).await.unwrap()
+  pub async fn _3300066460_(&self, arg0: A) -> CallResult<(B,)> {
+    ic_cdk::call(self.0, "函数名", (arg0,)).await
   }
-  pub async fn _2669435454_(&self, arg0: candid::Nat) -> (candid::Nat) {
-    ic_cdk::call(self.0, "👀", (arg0,)).await.unwrap()
-  }
+  pub async fn _2669435454_(&self, arg0: candid::Nat) -> CallResult<
+    (candid::Nat,)
+  > { ic_cdk::call(self.0, "👀", (arg0,)).await }
 }

--- a/rust/candid/tests/assets/ok/unicode.rs
+++ b/rust/candid/tests/assets/ok/unicode.rs
@@ -7,10 +7,10 @@ struct A {
   _1832283146_: candid::Nat,
   _2119362116_: candid::Nat,
   _3133479156_: candid::Nat,
-};
+}
 
 #[derive(CandidType, Deserialize)]
-enum B { _0_, _650764729_, _1036827129_, _3099250646_ };
+enum B { _0_, _650764729_, _1036827129_, _3099250646_ }
 
 pub trait SERVICE {
   pub fn _0_(arg0: candid::Nat) -> (candid::Nat);

--- a/rust/candid/tests/assets/ok/unicode.rs
+++ b/rust/candid/tests/assets/ok/unicode.rs
@@ -1,0 +1,13 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+
+#[derive(CandidType, Deserialize)]
+struct A {
+  _11864174_: candid::Nat,
+  _1832283146_: candid::Nat,
+  _2119362116_: candid::Nat,
+  _3133479156_: candid::Nat,
+}
+#[derive(CandidType, Deserialize)]
+enum B { _0_, _650764729_, _1036827129_, _3099250646_ }
+

--- a/rust/candid/tests/assets/ok/unicode.rs
+++ b/rust/candid/tests/assets/ok/unicode.rs
@@ -7,10 +7,10 @@ struct A {
   _1832283146_: candid::Nat,
   _2119362116_: candid::Nat,
   _3133479156_: candid::Nat,
-}
+};
 
 #[derive(CandidType, Deserialize)]
-enum B { _0_, _650764729_, _1036827129_, _3099250646_ }
+enum B { _0_, _650764729_, _1036827129_, _3099250646_ };
 
 pub trait SERVICE {
   pub fn _0_(arg0: candid::Nat) -> (candid::Nat);

--- a/rust/candid/tests/parse_type.rs
+++ b/rust/candid/tests/parse_type.rs
@@ -1,4 +1,4 @@
-use candid::bindings::{candid as candid_export, javascript, motoko, typescript};
+use candid::bindings::{candid as candid_export, javascript, motoko, rust, typescript};
 use candid::parser::types::{to_pretty, IDLProg};
 use candid::parser::typing::{check_file, check_prog, TypeEnv};
 use goldenfile::Mint;
@@ -61,6 +61,11 @@ fn compiler_test(resource: &str) {
                         writeln!(output, "{}", content).unwrap();
                     }
                 }
+            }
+            {
+                let mut output = mint.new_goldenfile(filename.with_extension("rs")).unwrap();
+                let content = rust::compile(&env, &actor);
+                writeln!(output, "{}", content).unwrap();
             }
             {
                 let mut output = mint.new_goldenfile(filename.with_extension("js")).unwrap();

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -24,7 +24,7 @@ enum Command {
     Bind {
         /// Specifies did file for code generation
         input: PathBuf,
-        #[structopt(short, long, possible_values = &["js", "ts", "did", "mo"])]
+        #[structopt(short, long, possible_values = &["js", "ts", "did", "mo", "rs"])]
         /// Specifies target language
         target: String,
     },
@@ -190,6 +190,7 @@ fn main() -> Result<()> {
                 "ts" => candid::bindings::typescript::compile(&env, &actor),
                 "did" => candid::bindings::candid::compile(&env, &actor),
                 "mo" => candid::bindings::motoko::compile(&env, &actor),
+                "rs" => candid::bindings::rust::compile(&env, &actor),
                 _ => unreachable!(),
             };
             println!("{}", content);


### PR DESCRIPTION
First pass of https://github.com/dfinity/candid/issues/255

Generate a default binding, and allow users to make adjustment in their codebase.

Todo
- [x] identify where to put Box
- [x] serde rename for number field
- [x] ic_cdk::call