### PR TITLE
spec: subtype checking only for reference types

### DIFF
--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -909,7 +909,7 @@ Coercion into `reserved` is the constant map (this is arbitrarily using `null` a
 _ : <t> ~> null : reserved
 ```
 
-NB: No rule is needed for type `empty`, because there are no values of that type. By construction, `<v> : <t> ~> _ : empty` will not hold.
+NB: No rule is needed for type `empty`, because there are no values of that type. By construction, `_ : empty ~> _ : _` will not hold.
 
 #### Vectors
 
@@ -939,7 +939,7 @@ not (<v> : <t> ~> _ : <t'>)
 opt <v> : opt <t> ~> null : opt <t'>
 ```
 
-Coercing a non-null, non-optional and non-reserved type at an option type treats it as an optional value, if it has a suitable type:
+Coercing a non-null, non-optional and non-reserved type at an option type treats it as an optional value, if it can be decoded successfully:
 ```
 not (null <: <t'>)
 <v> : <t> ~> <v'> : <t'>
@@ -991,7 +991,7 @@ variant { <nat> = <v'> } : variant { <nat> : <t'>; _;* }
 
 #### References
 
-Function and services reference values are untyped, so the coercion function is the identity here:
+For function and services reference values, the coercion relation checks whether the given types are actually subtypes of the expected type, and fails else:
 
 ```
 func <functype> <: func <functype'>

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -994,7 +994,7 @@ variant { <nat> = <v'> } : variant { <nat> : <t'>; _;* }
 
 #### References
 
-For function and services reference values, the coercion relation checks whether the given types are actually subtypes of the expected type, and fails else:
+For function and services reference values, the coercion relation checks whether the given types are actually subtypes of the expected type, and fails otherwise:
 
 ```
 func <functype> <: func <functype'>

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -890,7 +890,7 @@ To describe these values, we re-use the syntax of the textual representation.
 
 #### Primitive Types
 
-On primitve types, coercion is the identity:
+On primitive types, coercion is the identity:
 ```
 <t> ∈ <numtype>, bool, text, null
 ---------------------------------
@@ -942,6 +942,7 @@ opt <v> : opt <t> ~> null : opt <t'>
 
 Coercing a non-null, non-optional and non-reserved type at an option type treats it as an optional value, if it can be decoded successfully:
 ```
+not (null <: <t>)
 not (null <: <t'>)
 <v> : <t> ~> <v'> : <t'>
 --------------------------------

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -924,8 +924,9 @@ vec { <v>;* } : vec <t> ~> vec { <v'>;* } : vec <t'>
 
 The null value coerces into any option type:
 ```
+null <: <t>
 -----------------------------
-null : _ ~> null : opt <t>
+null : <t> ~> null : opt <t'>
 ```
 
 An optional value coerces at an option type, if the constituent value has a suitable type, and else goes to `null`:
@@ -949,6 +950,8 @@ not (null <: <t'>)
 
 Any other value goes to `null`:
 ```
+---------------------------------
+<v> : reserved ~> null : opt <t'>
 
 not (null <: <t'>)
 not (<v> : <t> ~> _ : <t'>)
@@ -1038,6 +1041,11 @@ The relations above have certain properties. As in the previous section, `<v> : 
   (<v> : <t>) ⟺ <v> : <t> ~> <v> : <t>
   ```
 
+* Well-typedness:
+  ```
+  <v> : <t> ~> <v'> : <t'> ⇒ <v'> : <t'>
+  ```
+
 * Soundness of subtyping (or, alternatively, well-definedness of coercion)
   ```
   <t> <: <t'> ⇒ ∀ <v> : <t> ∃ <v'>. <v> : <t> ~> <v'> : <t'>
@@ -1054,17 +1062,16 @@ The relations above have certain properties. As in the previous section, `<v> : 
 
 * NB: Transitive coherence does not hold:
   ```
-  <t1> <: <t2>, <t2> <: <t3>
+  <v1> : <t1> ~> <v2> : <t2>
+  <v2> : <t2> ~> <v3> : <t3>
+  <v1> : <t1> ~> <v3'> : <t3>
   ```
   does not imply
   ```
-  C[<t1> ~> <t3>] = C[<t2> ~> <t3>] ⚬ C[<t1> ~> <t2>]
+  <v3> = <v3'>
   ```
 
-  However, it implies
-  ```
-  C[<t1> ~> <t3>] ~ (C[<t2> ~> <t3>] ⚬ C[<t1> ~> <t2>])
-  ```
+  However, it implies `<v3> ~ <v3'>`, 
   where ~ is the smallest homomorphic, reflexive, symmetric relation that satisfies `∀ v. opt v ~ null`.
 
 The goal of “subtyping completeness” has not been cast into a formal formulation yet.


### PR DESCRIPTION
Fix #295 