### PR TITLE
Typo in serialization of v* (I think)

### DIFF
--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1177,7 +1177,7 @@ M(_ : reserved) = .
 M : <val> -> <constype> -> i8*
 M(null : opt <datatype>) = i8(0)
 M(?v   : opt <datatype>) = i8(1) M(v : <datatype>)
-M(v*   : vec <datatype>) = leb128(|v*|) M(v : <datatype>)*
+M(v^N  : vec <datatype>) = leb128(N) M(v : <datatype>)^N
 M(kv*  : record {<fieldtype>*}) = M(kv : <fieldtype>)*
 M(kv   : variant {<fieldtype>*}) = leb128(i) M(kv : <fieldtype>*[i])
 

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1177,7 +1177,7 @@ M(_ : reserved) = .
 M : <val> -> <constype> -> i8*
 M(null : opt <datatype>) = i8(0)
 M(?v   : opt <datatype>) = i8(1) M(v : <datatype>)
-M(v*   : vec <datatype>) = leb128(N) M(v : <datatype>)*
+M(v*   : vec <datatype>) = leb128(|v*|) M(v : <datatype>)*
 M(kv*  : record {<fieldtype>*}) = M(kv : <fieldtype>)*
 M(kv   : variant {<fieldtype>*}) = leb128(i) M(kv : <fieldtype>*[i])
 


### PR DESCRIPTION
unbound `N` should be `|v*|`, me thinks.

