### PR TITLE
feat: mute `special opt FIXME` warning via feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "candid"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."
@@ -58,3 +58,4 @@ path = "benches/benchmark.rs"
 cdk = ["candid_derive/cdk"]
 configs = ["serde_dhall"]
 random = ["configs", "arbitrary", "fake", "rand"]
+mute_warnings = []

--- a/rust/candid/src/types/subtype.rs
+++ b/rust/candid/src/types/subtype.rs
@@ -42,6 +42,7 @@ pub fn subtype(gamma: &mut Gamma, env: &TypeEnv, t1: &Type, t2: &Type) -> Result
             Ok(())
         }
         (t1, Opt(_)) => {
+            #[cfg(not(feature = "mute_warnings"))]
             eprintln!("FIX ME! {} <: {} via special opt rule.\nThis means the sender and receiver type has diverged, and can cause data loss.", t1, t2);
             Ok(())
         }


### PR DESCRIPTION
**Overview**
This warning needs to be silence-able so it doesn't spam `STDERR` when some variance is expected (icx-proxy).

**Considered Solutions**
Feature flags. Callbacks (global or on `IDLDeserialize`).

**Recommended Solution**
Feature flags short term. `IDLDeserialize` callback long term.

**Considerations**
N/A
