### PR TITLE
Make encoding functions public

### DIFF
--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -83,10 +83,14 @@ impl ValueSerializer {
     pub fn get_result(&self) -> &[u8] {
         &self.value
     }
+
+    #[doc(hidden)]
     pub fn write_leb128(&mut self, value: u64) -> Result<()> {
         leb128_encode(&mut self.value, value)?;
         Ok(())
     }
+    
+    #[doc(hidden)]
     pub fn write(&mut self, bytes: &[u8]) -> Result<()> {
         use std::io::Write;
         self.value.write_all(bytes)?;
@@ -336,6 +340,7 @@ impl TypeSerialize {
         Ok(())
     }
 
+    #[doc(hidden)]
     pub fn push_type(&mut self, t: &Type) -> Result<()> {
         self.args.push(t.clone());
         self.build_type(t)
@@ -394,6 +399,7 @@ impl TypeSerialize {
         Ok(())
     }
 
+    #[doc(hidden)]
     pub fn serialize(&mut self) -> Result<()> {
         leb128_encode(&mut self.result, self.type_table.len() as u64)?;
         self.result.append(&mut self.type_table.concat());

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -83,11 +83,11 @@ impl ValueSerializer {
     pub fn get_result(&self) -> &[u8] {
         &self.value
     }
-    fn write_leb128(&mut self, value: u64) -> Result<()> {
+    pub fn write_leb128(&mut self, value: u64) -> Result<()> {
         leb128_encode(&mut self.value, value)?;
         Ok(())
     }
-    fn write(&mut self, bytes: &[u8]) -> Result<()> {
+    pub fn write(&mut self, bytes: &[u8]) -> Result<()> {
         use std::io::Write;
         self.value.write_all(bytes)?;
         Ok(())
@@ -336,7 +336,7 @@ impl TypeSerialize {
         Ok(())
     }
 
-    fn push_type(&mut self, t: &Type) -> Result<()> {
+    pub fn push_type(&mut self, t: &Type) -> Result<()> {
         self.args.push(t.clone());
         self.build_type(t)
     }
@@ -394,7 +394,7 @@ impl TypeSerialize {
         Ok(())
     }
 
-    fn serialize(&mut self) -> Result<()> {
+    pub fn serialize(&mut self) -> Result<()> {
         leb128_encode(&mut self.result, self.type_table.len() as u64)?;
         self.result.append(&mut self.type_table.concat());
 

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -83,13 +83,11 @@ impl ValueSerializer {
     pub fn get_result(&self) -> &[u8] {
         &self.value
     }
-
     #[doc(hidden)]
     pub fn write_leb128(&mut self, value: u64) -> Result<()> {
         leb128_encode(&mut self.value, value)?;
         Ok(())
     }
-    
     #[doc(hidden)]
     pub fn write(&mut self, bytes: &[u8]) -> Result<()> {
         use std::io::Write;
@@ -339,13 +337,11 @@ impl TypeSerialize {
         self.type_table[idx] = buf;
         Ok(())
     }
-
     #[doc(hidden)]
     pub fn push_type(&mut self, t: &Type) -> Result<()> {
         self.args.push(t.clone());
         self.build_type(t)
     }
-
     fn encode(&self, buf: &mut Vec<u8>, t: &Type) -> Result<()> {
         if let Type::Var(id) = t {
             let actual_type = self.env.rec_find_type(id)?;
@@ -398,7 +394,6 @@ impl TypeSerialize {
         }?;
         Ok(())
     }
-
     #[doc(hidden)]
     pub fn serialize(&mut self) -> Result<()> {
         leb128_encode(&mut self.result, self.type_table.len() as u64)?;


### PR DESCRIPTION
**Overview**
Many APIs of candid encoding are private. This makes it harder to use this library in case of unusual scenarios implementation.
In one of my projects (ic-event-hub) I need to be able to transfer a (possibly very big) batch of objects between canisters in as few messages as possible, as efficiently as possible. I can achieve that using `ValueSerializer` and `TypeSerialize` structs, filling messages with objects sequentially. But in order to do that, I'm using a custom `candid` fork where all methods of these structs are public.

Here is the PR with some of these methods made public (enough to achieve what I want). But I strongly recommend the team managing this repo to choose more open policy in terms of method visibility and to make everything public. Yes, this will increase the risk of error making for beginners. But for experienced developers who understand the internals this is actually a lot more useful, because it allows them to program custom serialization logic on top of this library.

**Considerations**
This PR doesn't affect performance or security, but it could be useful to mark affected methods as `FOR ADVANCED USE ONLY` in the docs.
