### PR TITLE
feat: Expose `FuncVisitor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "candid"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."

--- a/rust/candid/src/types/reference.rs
+++ b/rust/candid/src/types/reference.rs
@@ -43,30 +43,33 @@ impl CandidType for Service {
     }
 }
 
+/// A [`Visitor`] to extract [`Func`]s.
+pub struct FuncVisitor;
+
+impl<'de> Visitor<'de> for FuncVisitor {
+    type Value = Func;
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("Func value")
+    }
+    fn visit_byte_buf<E: de::Error>(self, bytes: Vec<u8>) -> Result<Func, E> {
+        if bytes[0] != 5u8 {
+            return Err(de::Error::custom("not func"));
+        }
+        let mut bytes = &bytes[1..];
+        let len = leb128::read::unsigned(&mut bytes).map_err(E::custom)? as usize;
+        let mut buf = vec![0; len];
+        bytes.read_exact(&mut buf).map_err(E::custom)?;
+        let method = String::from_utf8(buf).map_err(E::custom)?;
+        let principal = Principal::try_from(bytes).map_err(E::custom)?;
+        Ok(Func { principal, method })
+    }
+}
+
 impl<'de> Deserialize<'de> for Func {
     fn deserialize<D>(deserializer: D) -> Result<Func, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        struct FuncVisitor;
-        impl<'de> Visitor<'de> for FuncVisitor {
-            type Value = Func;
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("Func value")
-            }
-            fn visit_byte_buf<E: de::Error>(self, bytes: Vec<u8>) -> Result<Func, E> {
-                if bytes[0] != 5u8 {
-                    return Err(de::Error::custom("not func"));
-                }
-                let mut bytes = &bytes[1..];
-                let len = leb128::read::unsigned(&mut bytes).map_err(E::custom)? as usize;
-                let mut buf = vec![0; len];
-                bytes.read_exact(&mut buf).map_err(E::custom)?;
-                let method = String::from_utf8(buf).map_err(E::custom)?;
-                let principal = Principal::try_from(bytes).map_err(E::custom)?;
-                Ok(Func { principal, method })
-            }
-        }
         deserializer.deserialize_any(FuncVisitor)
     }
 }


### PR DESCRIPTION
**Overview**
Exposing this enables more customization in function serialization and helps get around #273.

**Requirements**
N/A

**Considered Solutions**
N/A

**Recommended Solution**
N/A

**Considerations**
Makes `FuncVisitor` a part of the public interface.
