### PR TITLE
fix: `deserialize_ignored_any` should be untyped

### DIFF
--- a/rust/candid/tests/types.rs
+++ b/rust/candid/tests/types.rs
@@ -1,7 +1,81 @@
 #![allow(dead_code)]
 
-use candid::types::{get_type, Label, Type};
-use candid::{candid_method, CandidType, Int};
+use std::fmt::Debug;
+
+use candid::{
+    candid_method,
+    parser::value::{IDLValue, IDLValueVisitor},
+    types::{get_type, Label, Serializer, Type},
+    CandidType, Decode, Deserialize, Encode, Int, ser::IDLBuilder,
+};
+use serde::de::DeserializeOwned;
+
+#[test]
+fn any_val() {
+
+    fn test_embed<T: DeserializeOwned+Debug+CandidType+PartialEq>(value: T) -> IDLValue {
+        #[derive(Debug, Clone, PartialEq)]
+        struct IDLValueEmbed(IDLValue);
+        impl CandidType for IDLValueEmbed {
+            fn _ty() -> Type {
+                Type::Reserved
+            }
+            fn idl_serialize<S: Serializer>(&self, _serializer: S) -> Result<(), S::Error> {
+                unimplemented!("IDLValueEmbed is not serializable")
+            }
+        }
+        impl<'de> Deserialize<'de> for IDLValueEmbed {
+            fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                deserializer
+                    .deserialize_ignored_any(IDLValueVisitor)
+                    .map(IDLValueEmbed)
+            }
+        }
+
+        #[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize)]
+        struct Embed<T> {
+            value: T,
+        }
+        
+        let orig = Embed { value };
+        let bytes1 = Encode!(&orig)
+        .unwrap();
+    
+        let idl_value = Decode!(&bytes1, Embed<IDLValueEmbed>).unwrap();
+        let bytes2 = IDLBuilder::new().value_arg(&idl_value.value.0).unwrap().serialize_to_vec().unwrap();
+        let new = Decode!(&bytes2, T).unwrap();
+        assert_eq!(orig.value, new);
+        idl_value.value.0
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize)]
+    enum E {
+        Foo,
+        Bar(bool, i32),
+        Baz { a: i32, b: u32 },
+        Newtype(bool),
+    }
+    #[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize)]
+    struct G<T, E> {
+        g1: T,
+        g2: E,
+    }
+    
+    let v = test_embed(E::Foo);
+    assert!(matches!(v, IDLValue::Variant(_)));
+
+    let v = test_embed(E::Bar(true, 42));
+    assert!(matches!(v, IDLValue::Variant(_)));
+
+    let v = test_embed(G{
+        g1: E::Bar(true, 42),
+        g2: G{
+            g1: E::Baz{ a: -199, b: 14 },
+            g2: E::Newtype(false),
+        },
+    });
+    assert!(matches!(v, IDLValue::Record(_)));
+}
 
 #[test]
 fn test_primitive() {


### PR DESCRIPTION
And some tests as well.

**Overview**
Prevents `IDLValueVisitor` from hitting [this panic](https://github.com/dfinity/candid/blob/master/rust/candid/src/parser/value.rs#L539).

**Requirements**
New `any_val` test passes.

**Considered Solutions**
Removing or modifying [this branch](https://github.com/dfinity/candid/blob/master/rust/candid/src/de.rs#L858).

**Recommended Solution**
This doesn't break all the other tests and doesn't appear to impact the `IgnoreAny` visitor, which is the only other visitor which uses this path.

**Considerations**
Any external visitors using the ignore pathway may experience strange enum behavior, but those are already kind of uncharted waters.