### PR TITLE
add allowing trailing data modifications of decoding functions

### DIFF
--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -28,7 +28,7 @@ impl<'de> IDLDeserialize<'de> {
             .with_context(|| format!("Cannot parse header {}", &hex::encode(bytes)))?;
         Ok(IDLDeserialize {
             de,
-            allow_trailing: false
+            allow_trailing: false,
         })
     }
     /// Create a new deserializer with IDL binary message, but allows trailing bytes
@@ -37,7 +37,7 @@ impl<'de> IDLDeserialize<'de> {
             .with_context(|| format!("Cannot parse header {}", &hex::encode(bytes)))?;
         Ok(IDLDeserialize {
             de,
-            allow_trailing: true
+            allow_trailing: true,
         })
     }
     /// Deserialize one value from deserializer.

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -95,6 +95,17 @@ where
     Ok(res)
 }
 
+/// Same as decode_args, but allows trailing data
+pub fn decode_args_allow_trailing<'a, Tuple>(bytes: &'a [u8]) -> Result<Tuple>
+    where
+        Tuple: ArgumentDecoder<'a>,
+{
+    let mut de = IDLDeserialize::new_allow_trailing(bytes)?;
+    let res = ArgumentDecoder::decode(&mut de)?;
+    de.done()?;
+    Ok(res)
+}
+
 /// Decode a single argument.
 ///
 /// Example:
@@ -113,6 +124,15 @@ where
     T: Deserialize<'a> + CandidType,
 {
     let (res,) = decode_args(bytes)?;
+    Ok(res)
+}
+
+/// Same as decode_one, but allows trailing data
+pub fn decode_one_allow_trailing<'a, T>(bytes: &'a [u8]) -> Result<T>
+    where
+        T: Deserialize<'a> + CandidType,
+{
+    let (res,) = decode_args_allow_trailing(bytes)?;
     Ok(res)
 }
 

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -94,18 +94,16 @@ where
     de.done()?;
     Ok(res)
 }
-
 /// Same as decode_args, but allows trailing data
 pub fn decode_args_allow_trailing<'a, Tuple>(bytes: &'a [u8]) -> Result<Tuple>
-    where
-        Tuple: ArgumentDecoder<'a>,
+where
+    Tuple: ArgumentDecoder<'a>,
 {
     let mut de = IDLDeserialize::new_allow_trailing(bytes)?;
     let res = ArgumentDecoder::decode(&mut de)?;
     de.done()?;
     Ok(res)
 }
-
 /// Decode a single argument.
 ///
 /// Example:
@@ -126,16 +124,14 @@ where
     let (res,) = decode_args(bytes)?;
     Ok(res)
 }
-
 /// Same as decode_one, but allows trailing data
 pub fn decode_one_allow_trailing<'a, T>(bytes: &'a [u8]) -> Result<T>
-    where
-        T: Deserialize<'a> + CandidType,
+where
+    T: Deserialize<'a> + CandidType,
 {
     let (res,) = decode_args_allow_trailing(bytes)?;
     Ok(res)
 }
-
 /// Serialize an encoding of a tuple and write it to a `Write` buffer.
 ///
 /// ```


### PR DESCRIPTION
**Overview**
I'm building a stable memory allocator that works with `CandidType`'s. Sometimes an allocated block, containing a candid encoded value, has some leftover free bytes at the end (alignment). I'm adding these new functions in order to achieve two things:
1. not break any existing code;
2. be able to deserialize the data from such blocks, despite trailing bytes.

I could fix it on my side, but this would require to add another 4 bytes of data to each block, which is something I don't want to do. Since candid is already able to determine the payload size of a message, it seems like a waste of memory.

Please, take a look @chenyan-dfinity, when you have time.