### PR TITLE
Rust: derive `Copy`, `Eq`, `Default` for `Reserved`

### DIFF
--- a/rust/candid/src/types/reserved.rs
+++ b/rust/candid/src/types/reserved.rs
@@ -4,7 +4,7 @@ use super::{CandidType, Serializer, Type, TypeId};
 use serde::de::{self, Deserialize, Deserializer, Visitor};
 use std::fmt;
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Reserved;
 #[derive(PartialEq, Debug)]
 pub enum Empty {}


### PR DESCRIPTION
Without these traits it is awkward to mark a field of a struct
as reserved if the struct itself derives theses traits.
