### PR TITLE
chore: use ic-types 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,8 +770,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ic-types"
-version = "0.4.0-beta.0"
-source = "git+https://github.com/dfinity/ic-types?branch=lwshang/principal_overhaul#0ce76396b98b6c685485592b25387fbffc6b33a1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67e4edc28c09d29ab97b50410245c91d71756eaf3956212e3488cd6eb75fda4"
 dependencies = [
  "crc32fast",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,12 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base32"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
-
-[[package]]
 name = "beef"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +175,15 @@ name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array 0.14.5",
 ]
@@ -426,6 +429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array 0.14.5",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +461,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
 name = "dhall"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,7 +486,7 @@ dependencies = [
  "quote 1.0.17",
  "serde",
  "serde_cbor",
- "sha2",
+ "sha2 0.9.9",
  "url",
 ]
 
@@ -530,6 +549,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.5",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -741,16 +770,15 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ic-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e78ec6f58886cdc252d6f912dc794211bd6bbc39ddc9dcda434b2dc16c335b3"
+version = "0.4.0-beta.0"
+source = "git+https://github.com/dfinity/ic-types?branch=lwshang/principal_overhaul#0ce76396b98b6c685485592b25387fbffc6b33a1"
 dependencies = [
- "base32",
  "crc32fast",
+ "data-encoding",
  "hex",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.10.2",
  "thiserror",
 ]
 
@@ -1599,6 +1627,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "1.4.3"
 candid_derive = { path = "../candid_derive", version = "=0.4.5" }
 codespan-reporting = "0.11"
 hex = "0.4.2"
-ic-types = { git = "https:/github.com/dfinity/ic-types", branch="lwshang/principal_overhaul"}
+ic-types = "0.4"
 lalrpop-util = "0.19.0"
 leb128 = "0.2.4"
 logos = "0.12"

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "1.4.3"
 candid_derive = { path = "../candid_derive", version = "=0.4.5" }
 codespan-reporting = "0.11"
 hex = "0.4.2"
-ic-types = "0.3"
+ic-types = { git = "https:/github.com/dfinity/ic-types", branch="lwshang/principal_overhaul"}
 lalrpop-util = "0.19.0"
 leb128 = "0.2.4"
 logos = "0.12"


### PR DESCRIPTION
`Principal` got overhaul in `ic-types`. Update and make sure `Candid` is not broken.
