### PR TITLE
feat: derive CandidType for Rc and Arc

### DIFF
--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -32,7 +32,7 @@ num-bigint = "0.4.2"
 num-traits = "0.2.12"
 paste = "1.0.0"
 pretty = "0.10.0"
-serde = { version = "1.0.118", features = ["derive"] }
+serde = { version = "1.0.118", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 thiserror = "1.0.20"
 anyhow = "1.0"

--- a/rust/candid/src/types/impls.rs
+++ b/rust/candid/src/types/impls.rs
@@ -394,6 +394,36 @@ where
     }
 }
 
+impl<T> CandidType for std::rc::Rc<T>
+where
+    T: CandidType,
+{
+    fn _ty() -> Type {
+        T::ty()
+    }
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_ref().idl_serialize(serializer)
+    }
+}
+
+impl<T> CandidType for std::sync::Arc<T>
+where
+    T: CandidType,
+{
+    fn _ty() -> Type {
+        T::ty()
+    }
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_ref().idl_serialize(serializer)
+    }
+}
+
 macro_rules! tuple_impls {
     ($($len:expr => ($($n:tt $name:ident)+))+) => {
         $(

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -362,6 +362,19 @@ fn test_serde_bytes() {
 }
 
 #[test]
+fn test_rc_bytes() {
+    use serde_bytes::ByteBuf;
+    all_check(
+        std::rc::Rc::new(ByteBuf::from(vec![1u8, 2u8, 3u8])),
+        "4449444c016d7b010003010203",
+    );
+    all_check(
+        std::sync::Arc::new(ByteBuf::from(vec![1u8, 2u8, 3u8])),
+        "4449444c016d7b010003010203",
+    );
+}
+
+#[test]
 fn test_keyword_label() {
     #[derive(PartialEq, Debug, Deserialize, CandidType)]
     struct A {


### PR DESCRIPTION
It is often desirable to use reference counting in canisters for large
blobs to avoid expensive copies.  Unfortunately, this optimization
requires defining new types and implementing CandidType for them
(example:
https://github.com/dfinity/certified-assets/commit/47804eb70f44d2e5c73da26f0009540330293eb2).

This change adds impls for Rc and Arc to the candid library to make
these optimizations less painful to implement.