### PR TITLE
feat: derive Serialize for Int, Nat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## [Unreleased]
+
+* Derive `Serialize` for `Int` and `Nat`
+
+### Added
+
 ## 2022-07-13
 
 ### Rust (0.7.15)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,9 +3,9 @@
 
 ## [Unreleased]
 
-* Derive `Serialize` for `Int` and `Nat`
-
 ### Added
+
+* Derive `Serialize` for `Int` and `Nat`
 
 ## 2022-07-13
 

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -28,7 +28,7 @@ lalrpop-util = "0.19.0"
 leb128 = "0.2.4"
 logos = "0.12"
 num_enum = "0.5.1"
-num-bigint = "0.4.2"
+num-bigint = { version = "0.4.2", features = ["serde"] }
 num-traits = "0.2.12"
 paste = "1.0.0"
 pretty = "0.10.0"

--- a/rust/candid/src/types/number.rs
+++ b/rust/candid/src/types/number.rs
@@ -3,13 +3,16 @@
 use super::{CandidType, Serializer, Type, TypeId};
 use crate::Error;
 use num_bigint::{BigInt, BigUint};
-use serde::de::{self, Deserialize, Visitor};
+use serde::{
+    de::{self, Deserialize, Visitor},
+    Serialize,
+};
 use std::convert::From;
 use std::{fmt, io};
 
-#[derive(Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Hash, Default)]
+#[derive(Serialize, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Hash, Default)]
 pub struct Int(pub BigInt);
-#[derive(Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Hash, Default)]
+#[derive(Serialize, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Hash, Default)]
 pub struct Nat(pub BigUint);
 
 impl From<BigInt> for Int {


### PR DESCRIPTION
Improve UX.
Make it possible to derive `Serialize` for structs which have `Int` or `Nat` in fields.

