### PR TITLE
Allow Candid UI configuration via `postMessage()`

### DIFF
--- a/tools/ui/src/candid.ts
+++ b/tools/ui/src/candid.ts
@@ -50,7 +50,7 @@ export async function fetchActor(canisterId: Principal): Promise<ActorSubclass> 
   const maybeDid = new URLSearchParams(window.location.search).get(
     "did"
   );
-  const base64Source = (await EXTERNAL_CONFIG_PROMISE)?.candid || maybeDid;
+  const base64Source = (await EXTERNAL_CONFIG_PROMISE)?.candid || window.history.state?.candid || maybeDid;
   if (base64Source) {
     js = await didToJs(window.atob(base64Source));
   } else {

--- a/tools/ui/src/candid.ts
+++ b/tools/ui/src/candid.ts
@@ -50,7 +50,7 @@ export async function fetchActor(canisterId: Principal): Promise<ActorSubclass> 
   const maybeDid = new URLSearchParams(window.location.search).get(
     "did"
   );
-  const base64Source = maybeDid || (await EXTERNAL_CONFIG_PROMISE)?.candid;
+  const base64Source = (await EXTERNAL_CONFIG_PROMISE)?.candid || maybeDid;
   if (base64Source) {
     js = await didToJs(window.atob(base64Source));
   } else {

--- a/tools/ui/src/candid.ts
+++ b/tools/ui/src/candid.ts
@@ -1,3 +1,4 @@
+import { EXTERNAL_CONFIG_PROMISE } from './external';
 import { Actor, HttpAgent, ActorSubclass, CanisterStatus } from '@dfinity/agent';
 import {
   IDL, InputBox, renderInput, renderValue
@@ -49,9 +50,9 @@ export async function fetchActor(canisterId: Principal): Promise<ActorSubclass> 
   const maybeDid = new URLSearchParams(window.location.search).get(
     "did"
   );
-  if (maybeDid) {
-    const source = window.atob(maybeDid);
-    js = await didToJs(source);
+  const base64Source = maybeDid || (await EXTERNAL_CONFIG_PROMISE)?.candid;
+  if (base64Source) {
+    js = await didToJs(window.atob(base64Source));
   } else {
     js = await getDidJsFromMetadata(canisterId);
     if (!js) {
@@ -107,6 +108,10 @@ export async function getNames(canisterId: Principal) {
   } catch(err) {
     return undefined;
   }
+}
+
+async function getDidJsFromPostMessage(canisterId: Principal): Promise<undefined | string> {
+  return new Promise((resolve,reject)=>{})
 }
 
 async function getDidJsFromMetadata(canisterId: Principal): Promise<undefined | string> {

--- a/tools/ui/src/external.ts
+++ b/tools/ui/src/external.ts
@@ -33,7 +33,7 @@ window.addEventListener("message", ({ origin, source, data }) => {
   if (typeof data === "string" && data.startsWith(messagePrefix)) {
     if (allowedExternalOrigins.includes(origin)) {
       const message = JSON.parse(data.substring(messagePrefix.length));
-      console.log("Received message:", message);
+      console.log("Candid UI received message:", message);
       try {
         if (
           message?.acknowledge !== undefined &&
@@ -52,7 +52,7 @@ window.addEventListener("message", ({ origin, source, data }) => {
       }
       messageListeners.forEach((listener) => listener(message));
     } else {
-      console.warn("Received message from unexpected origin:", origin);
+      console.warn("Candid UI received message from unexpected origin:", origin);
     }
   }
 });

--- a/tools/ui/src/external.ts
+++ b/tools/ui/src/external.ts
@@ -1,0 +1,66 @@
+interface ExternalConfig {
+  candid?: string;
+}
+
+type MessageListener = (message: any) => void;
+
+const hasExternalConfig = new URLSearchParams(window.location.search).has(
+  "external-config"
+);
+
+const messagePrefix = "CandidUI";
+
+// Starting with a hard-coded origin list for security
+const allowedExternalOrigins = [
+  "http://ryjl3-tyaaa-aaaaa-aaaba-cai.localhost:8000", // Motoko Playground (local)
+  "https://m7sm4-2iaaa-aaaab-qabra-cai.raw.ic0.app", // Motoko Playground (mainnet)
+];
+
+const messageListeners: MessageListener[] = [];
+
+export function addMessageListener(listener: MessageListener) {
+  messageListeners.push(listener);
+}
+
+export function removeMessageListener(listener: MessageListener) {
+  const index = messageListeners.indexOf(listener);
+  if (index !== -1) {
+    messageListeners.splice(index, 1);
+  }
+}
+
+/**
+ * Use this global promise to safely access `external-config` data provided through `postMessage()`.
+ */
+export const EXTERNAL_CONFIG_PROMISE: Promise<ExternalConfig> = new Promise(
+  (resolve) => {
+    if (!hasExternalConfig) {
+      return resolve({});
+    }
+    let resolved = false;
+
+    // Listen for "config" messages
+    addMessageListener((message) => {
+      if (message?.type === "config") {
+        resolved = true;
+        return resolve({ ...message.config });
+      }
+    });
+
+    setTimeout(() => {
+      if (!resolved) {
+        console.error("External config timeout");
+        resolve({});
+      }
+    }, 1000);
+  }
+);
+
+window.addEventListener("message", ({ origin, source, data }) => {
+  if (allowedExternalOrigins.includes(origin)) {
+    if (typeof data === "string" && data.startsWith(messagePrefix)) {
+      const message = JSON.parse(data.substring(messagePrefix.length));
+      messageListeners.forEach((listener) => listener(message));
+    }
+  }
+});

--- a/tools/ui/src/index.ts
+++ b/tools/ui/src/index.ts
@@ -1,30 +1,32 @@
-import { fetchActor, render, getCycles, getNames } from './candid';
-import { Principal } from '@dfinity/principal';
+import { fetchActor, render, getCycles, getNames } from "./candid";
+import { Principal } from "@dfinity/principal";
 
 async function main() {
   const params = new URLSearchParams(window.location.search);
-  const cid = params.get('id');
+  const cid = params.get("id");
   if (!cid) {
     document.body.innerHTML = `<div id="main-content">
-<label>Provide a canister ID: </label>
-<input id="id" type="text"><br>
-<label>Choose a did file (optional) </label>
-<input id="did" type="file" accept=".did"><br>
-<button id="btn" class="btn">Go</button>
-</div>
-`;
-    const id = (document.getElementById('id') as HTMLInputElement)!;
-    const did = (document.getElementById('did')! as HTMLInputElement)!;
-    const btn = document.getElementById('btn')!;
-    btn.addEventListener('click', () => {
-      params.set('id', id.value);
+    <label>Provide a canister ID: </label>
+    <input id="id" type="text"><br>
+    <label>Choose a did file (optional) </label>
+    <input id="did" type="file" accept=".did"><br>
+    <button id="btn" class="btn">Go</button>
+    </div>
+    `;
+    const id = (document.getElementById("id") as HTMLInputElement)!;
+    const did = (document.getElementById("did")! as HTMLInputElement)!;
+    const btn = document.getElementById("btn")!;
+    btn.addEventListener("click", () => {
+      params.set("id", id.value);
       if (did.files!.length > 0) {
         const reader = new FileReader();
-        reader.addEventListener('load', () => {
+        reader.addEventListener("load", () => {
           const encoded = reader.result as string;
-          const hex = encoded.substr(encoded.indexOf(',') + 1);
-          params.set('did', hex);
-          window.location.href = `?${params}`;
+          const hex = encoded.substr(encoded.indexOf(",") + 1);
+          // update URL with Candid data and refresh
+          window.history.pushState({}, "", window.location.search);
+          window.history.pushState({ candid: hex }, "", `?${params}`);
+          window.location.reload();
         });
         reader.readAsDataURL(did.files![0]);
       } else {
@@ -38,21 +40,28 @@ async function main() {
     const actor = await fetchActor(canisterId);
     const names = await getNames(canisterId);
     render(canisterId, actor, profiling);
-    const app = document.getElementById('app');
-    const progress = document.getElementById('progress');
+    const app = document.getElementById("app");
+    const progress = document.getElementById("progress");
     progress!.remove();
-    app!.style.display = 'block';
+    app!.style.display = "block";
   }
 }
 
-main().catch(err => {
-  const div = document.createElement('div');
-  div.innerText = 'An error happened in Candid canister:';
-  const pre = document.createElement('pre');
+main().catch((err) => {
+  const div = document.createElement("div");
+  div.innerText = "An error happened in Candid canister:";
+  const pre = document.createElement("pre");
   pre.innerHTML = err.stack;
   div.appendChild(pre);
-  const progress = document.getElementById('progress');
+  const progress = document.getElementById("progress");
   progress!.remove();
   document.body.appendChild(div);
   throw err;
+});
+
+// Reload when going back after uploading custom Candid data
+window.addEventListener("popstate", (event) => {
+  if (event.state) {
+    window.location.reload();
+  }
 });

--- a/tools/ui/src/index.ts
+++ b/tools/ui/src/index.ts
@@ -1,9 +1,9 @@
-import { fetchActor, render, getCycles, getNames } from './candid';
-import { Principal } from '@dfinity/principal';
+import { fetchActor, render, getCycles, getNames } from "./candid";
+import { Principal } from "@dfinity/principal";
 
 async function main() {
   const params = new URLSearchParams(window.location.search);
-  const cid = params.get('id');
+  const cid = params.get("id");
   if (!cid) {
     document.body.innerHTML = `<div id="main-content">
 <label>Provide a canister ID: </label>
@@ -13,17 +13,17 @@ async function main() {
 <button id="btn" class="btn">Go</button>
 </div>
 `;
-    const id = (document.getElementById('id') as HTMLInputElement)!;
-    const did = (document.getElementById('did')! as HTMLInputElement)!;
-    const btn = document.getElementById('btn')!;
-    btn.addEventListener('click', () => {
-      params.set('id', id.value);
+    const id = (document.getElementById("id") as HTMLInputElement)!;
+    const did = (document.getElementById("did")! as HTMLInputElement)!;
+    const btn = document.getElementById("btn")!;
+    btn.addEventListener("click", () => {
+      params.set("id", id.value);
       if (did.files!.length > 0) {
         const reader = new FileReader();
-        reader.addEventListener('load', () => {
+        reader.addEventListener("load", () => {
           const encoded = reader.result as string;
-          const hex = encoded.substr(encoded.indexOf(',') + 1);
-          params.set('did', hex);
+          const hex = encoded.substr(encoded.indexOf(",") + 1);
+          params.set("did", hex);
           window.location.href = `?${params}`;
         });
         reader.readAsDataURL(did.files![0]);
@@ -38,20 +38,20 @@ async function main() {
     const actor = await fetchActor(canisterId);
     const names = await getNames(canisterId);
     render(canisterId, actor, profiling);
-    const app = document.getElementById('app');
-    const progress = document.getElementById('progress');
+    const app = document.getElementById("app");
+    const progress = document.getElementById("progress");
     progress!.remove();
-    app!.style.display = 'block';
+    app!.style.display = "block";
   }
 }
 
-main().catch(err => {
-  const div = document.createElement('div');
-  div.innerText = 'An error happened in Candid canister:';
-  const pre = document.createElement('pre');
+main().catch((err) => {
+  const div = document.createElement("div");
+  div.innerText = "An error happened in Candid canister:";
+  const pre = document.createElement("pre");
   pre.innerHTML = err.stack;
   div.appendChild(pre);
-  const progress = document.getElementById('progress');
+  const progress = document.getElementById("progress");
   progress!.remove();
   document.body.appendChild(div);
   throw err;

--- a/tools/ui/src/index.ts
+++ b/tools/ui/src/index.ts
@@ -1,9 +1,9 @@
-import { fetchActor, render, getCycles, getNames } from "./candid";
-import { Principal } from "@dfinity/principal";
+import { fetchActor, render, getCycles, getNames } from './candid';
+import { Principal } from '@dfinity/principal';
 
 async function main() {
   const params = new URLSearchParams(window.location.search);
-  const cid = params.get("id");
+  const cid = params.get('id');
   if (!cid) {
     document.body.innerHTML = `<div id="main-content">
 <label>Provide a canister ID: </label>
@@ -13,17 +13,17 @@ async function main() {
 <button id="btn" class="btn">Go</button>
 </div>
 `;
-    const id = (document.getElementById("id") as HTMLInputElement)!;
-    const did = (document.getElementById("did")! as HTMLInputElement)!;
-    const btn = document.getElementById("btn")!;
-    btn.addEventListener("click", () => {
-      params.set("id", id.value);
+    const id = (document.getElementById('id') as HTMLInputElement)!;
+    const did = (document.getElementById('did')! as HTMLInputElement)!;
+    const btn = document.getElementById('btn')!;
+    btn.addEventListener('click', () => {
+      params.set('id', id.value);
       if (did.files!.length > 0) {
         const reader = new FileReader();
-        reader.addEventListener("load", () => {
+        reader.addEventListener('load', () => {
           const encoded = reader.result as string;
-          const hex = encoded.substr(encoded.indexOf(",") + 1);
-          params.set("did", hex);
+          const hex = encoded.substr(encoded.indexOf(',') + 1);
+          params.set('did', hex);
           window.location.href = `?${params}`;
         });
         reader.readAsDataURL(did.files![0]);
@@ -38,20 +38,20 @@ async function main() {
     const actor = await fetchActor(canisterId);
     const names = await getNames(canisterId);
     render(canisterId, actor, profiling);
-    const app = document.getElementById("app");
-    const progress = document.getElementById("progress");
+    const app = document.getElementById('app');
+    const progress = document.getElementById('progress');
     progress!.remove();
-    app!.style.display = "block";
+    app!.style.display = 'block';
   }
 }
 
-main().catch((err) => {
-  const div = document.createElement("div");
-  div.innerText = "An error happened in Candid canister:";
-  const pre = document.createElement("pre");
+main().catch(err => {
+  const div = document.createElement('div');
+  div.innerText = 'An error happened in Candid canister:';
+  const pre = document.createElement('pre');
   pre.innerHTML = err.stack;
   div.appendChild(pre);
-  const progress = document.getElementById("progress");
+  const progress = document.getElementById('progress');
   progress!.remove();
   document.body.appendChild(div);
   throw err;


### PR DESCRIPTION
**Overview**
This PR introduces a way to configure the Candid UI with the browser `postMessage()` API as an alternative to query parameters. This is necessary because the `did` query string tends to surpass the URL character limit in Motoko Playground's embedded Candid UI (see dfinity/motoko-playground#122 for more details). 

**Requirements**
- Ability to send `did` interfaces larger than the ~2048-character URL limit. 

**Other Possible Solutions**
- Using the iframe `name` attribute (however, this only works from within the same origin)

**Recommended Solution**
- Listening for specially formatted browser messages when the `...&external-config` URL query parameter is provided to the Candid UI. For [security reasons](https://gist.github.com/jedp/3005816), this feature will initially use a limited domain whitelist (specified in `/tools/ui/src/external.ts`). 

Here is an example of how to use this feature from an external application (subject to change):
```js
const iframe = ...;
iframe.addEventListener('load', (event) => {
  const message = {
    type: "config",
    config: {
      candid: candid ? btoa(candid) : undefined,
    },
  };
  event.target.contentWindow?.postMessage(
    `CandidUI${JSON.stringify(message)}`,
    CANDID_UI_CANISTER_URL
  );
}, false);
```

**Considerations**
- This change is fully backwards-compatible. The `postMessage()` configuration is only activated when the `external-data` query parameter is present, and there is a 1-second timeout in case someone was previously passing a query parameter named `external-data` for any reason.
- I'm airing on the side of security with this implementation, but we could gradually improve public usability and documentation as this feature becomes more stable over time. 