### PR TITLE
fix: disable serde's rc feature

### DIFF
--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -32,7 +32,7 @@ num-bigint = { version = "0.4.2", features = ["serde"] }
 num-traits = "0.2.12"
 paste = "1.0.0"
 pretty = "0.10.0"
-serde = { version = "1.0.118", features = ["derive", "rc"] }
+serde = { version = "1.0.118", features = ["derive"] }
 serde_bytes = "0.11"
 thiserror = "1.0.20"
 anyhow = "1.0"

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -17,6 +17,9 @@ use serde::de::{self, Visitor};
 use std::fmt::Write;
 use std::{collections::VecDeque, io::Cursor, mem::replace};
 
+pub mod rc;
+pub mod arc;
+
 /// Use this struct to deserialize a sequence of Rust values (heterogeneous) from IDL binary message.
 pub struct IDLDeserialize<'de> {
     de: Deserializer<'de>,

--- a/rust/candid/src/de/arc.rs
+++ b/rust/candid/src/de/arc.rs
@@ -1,0 +1,28 @@
+//! This module provides functions to serialize and deserialize types
+//! under [std::sync::Arc] shared reference type.
+//!
+//! # Examples
+//!
+//! ```
+//! use candid::{CandidType, Deserialize};
+//! use serde_bytes::ByteBuf;
+//! use std::sync::Arc;
+//!
+//! #[derive(CandidType, Deserialize, PartialEq)]
+//! struct ArcBytes(#[serde(with = "candid::de::arc")] Arc<ByteBuf>);
+//! ```
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::sync::Arc;
+
+pub fn serialize<T: Serialize, S: Serializer>(
+    data: &Arc<T>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    T::serialize(data, serializer)
+}
+
+pub fn deserialize<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Arc<T>, D::Error> {
+    T::deserialize(deserializer).map(Arc::new)
+}

--- a/rust/candid/src/de/rc.rs
+++ b/rust/candid/src/de/rc.rs
@@ -1,0 +1,29 @@
+/// This module provides functions to serialize and deserialize types
+/// under [std::rc::Rc] shared reference type.
+///
+/// # Examples
+///
+/// ```
+/// use candid::{CandidType, Deserialize};
+/// use serde_bytes::ByteBuf;
+/// use std::rc::Rc;
+///
+/// #[derive(CandidType, Deserialize, PartialEq)]
+/// struct RcBytes(#[serde(with = "candid::de::rc")] Rc<ByteBuf>);
+/// ```
+
+use std::rc::Rc;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+pub fn serialize<T: Serialize, S: Serializer>(
+    data: &Rc<T>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    T::serialize(data, serializer)
+}
+
+pub fn deserialize<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Rc<T>, D::Error> {
+    T::deserialize(deserializer).map(Rc::new)
+}

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -364,12 +364,20 @@ fn test_serde_bytes() {
 #[test]
 fn test_rc_bytes() {
     use serde_bytes::ByteBuf;
+    use std::rc::Rc;
+    use std::sync::Arc;
+
+    #[derive(CandidType, Deserialize, PartialEq, Debug)]
+    struct RcBytes(#[serde(with = "candid::de::rc")] Rc<ByteBuf>);
+    #[derive(CandidType, Deserialize, PartialEq, Debug)]
+    struct ArcBytes(#[serde(with = "candid::de::arc")] Arc<ByteBuf>);
+
     all_check(
-        std::rc::Rc::new(ByteBuf::from(vec![1u8, 2u8, 3u8])),
+        RcBytes(Rc::new(ByteBuf::from(vec![1u8, 2u8, 3u8]))),
         "4449444c016d7b010003010203",
     );
     all_check(
-        std::sync::Arc::new(ByteBuf::from(vec![1u8, 2u8, 3u8])),
+        ArcBytes(Arc::new(ByteBuf::from(vec![1u8, 2u8, 3u8]))),
         "4449444c016d7b010003010203",
     );
 }


### PR DESCRIPTION
Some clients don't want to have serde's rc feature enabled because they find it too dangerous. This change makes it easy to use Candid for shared types without serde's rc feature.