### PR TITLE
refactor!: move Principal here and no re-export ic-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,23 +4,33 @@ version = 3
 
 [[package]]
 name = "abnf"
-version = "0.6.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47feb9fbcef700639ef28e04ca2a87eab8161a01a075ee227b15c90143805462"
+checksum = "33741baa462d86e43fdec5e8ffca7c6ac82847ad06cbfb382c1bdbf527de9e6b"
+dependencies = [
+ "abnf-core",
+ "nom",
+]
+
+[[package]]
+name = "abnf-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c44e09c43ae1c368fb91a03a566472d0087c26cf7e1b9e8e289c14ede681dd7d"
 dependencies = [
  "nom",
 ]
 
 [[package]]
 name = "abnf_to_pest"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372baaa5d3a422d8816b513bcdb2c120078c8614f7ecbcc3baf34a1634bbbe2e"
+checksum = "939d59666dd9a7964a3a5312b9d24c9c107630752ee64f2dd5038189a23fe331"
 dependencies = [
  "abnf",
  "indexmap",
- "itertools 0.9.0",
- "pretty 0.5.2",
+ "itertools",
+ "pretty 0.11.3",
 ]
 
 [[package]]
@@ -31,6 +41,12 @@ checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
@@ -160,15 +176,6 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
@@ -185,7 +192,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde",
 ]
 
 [[package]]
@@ -233,7 +239,7 @@ dependencies = [
  "serde_dhall",
  "serde_json",
  "serde_test",
- "sha2 0.10.2",
+ "sha2",
  "test-generator",
  "thiserror",
 ]
@@ -254,7 +260,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "candid",
- "clap",
+ "clap 2.34.0",
  "env_logger",
  "log",
  "predicates 1.0.8",
@@ -275,6 +281,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half 1.8.2",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,9 +317,30 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+dependencies = [
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "textwrap 0.15.1",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -332,16 +386,17 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
- "clap",
+ "ciborium",
+ "clap 3.2.22",
  "criterion-plot",
- "csv",
- "itertools 0.10.3",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -349,7 +404,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -358,12 +412,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.3",
+ "itertools",
 ]
 
 [[package]]
@@ -428,28 +482,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,33 +489,34 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "dhall"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d7b648a24d2edd4ba9f31fe42c831080522d1cf35bca3522887ba0d802745"
+checksum = "ec26264de25a8e3642fbb37abb24a6c6be9e19795444e6cf1bb88be5c2d55cc7"
 dependencies = [
  "abnf_to_pest",
  "annotate-snippets",
  "elsa",
+ "half 2.1.0",
  "hex",
- "itertools 0.9.0",
+ "home",
+ "itertools",
  "lazy_static",
+ "minicbor",
  "once_cell",
  "percent-encoding",
  "pest",
  "pest_consume",
  "pest_generator",
  "quote 1.0.21",
- "serde",
- "serde_cbor",
- "sha2 0.9.9",
+ "sha2",
  "url",
 ]
 
 [[package]]
 name = "dhall_proc_macros"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64ba6f41d9b223e2e1d7c97a1145a1aa03e57d65e1c9c2baa29f194caf322c9"
+checksum = "efcdb228bf802b21cd843e5ac3959b6255966238e5ec06d2e4bc6b9935475653"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -497,7 +530,7 @@ dependencies = [
  "anyhow",
  "candid",
  "candiff",
- "clap",
+ "clap 2.34.0",
  "hex",
  "pretty-hex",
  "rand",
@@ -524,20 +557,11 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer",
  "crypto-common",
 ]
 
@@ -704,6 +728,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "half"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +765,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "humantime"
@@ -777,27 +819,12 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -825,7 +852,7 @@ dependencies = [
  "bit-set",
  "diff",
  "ena",
- "itertools 0.10.3",
+ "itertools",
  "lalrpop-util",
  "petgraph",
  "pico-args",
@@ -857,19 +884,6 @@ name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -941,6 +955,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a20020e8e2d1881d8736f64011bb5ff99f1db9947ce3089706945c8915695cb"
+dependencies = [
+ "half 1.8.2",
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8608fb1c805b5b6b3d5ab7bd95c40c396df622b64d77b2d621a5eae1eed050ee"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,13 +989,12 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nom"
-version = "5.1.2"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
- "lexical-core",
  "memchr",
- "version_check",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1038,10 +1078,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
+name = "os_str_bytes"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parking_lot"
@@ -1229,7 +1269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
- "itertools 0.10.3",
+ "itertools",
  "predicates-core",
 ]
 
@@ -1251,21 +1291,24 @@ dependencies = [
 
 [[package]]
 name = "pretty"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60c0d9f6fc88ecdd245d90c1920ff76a430ab34303fc778d33b1d0a4c3bf6d3"
-dependencies = [
- "typed-arena 1.7.0",
-]
-
-[[package]]
-name = "pretty"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad9940b913ee56ddd94aec2d3cd179dd47068236f42a1a6415ccf9d880ce2a61"
 dependencies = [
  "arrayvec",
- "typed-arena 2.0.1",
+ "typed-arena",
+]
+
+[[package]]
+name = "pretty"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f3aa1e3ca87d3b124db7461265ac176b40c277f37e503eaa29c9c75c037846"
+dependencies = [
+ "arrayvec",
+ "log",
+ "typed-arena",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1502,7 +1545,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half",
+ "half 1.8.2",
  "serde",
 ]
 
@@ -1519,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "serde_dhall"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1393976875f3080d8cd1ff54083129e2e6a30d7a62582b67c3eb5924789e8e75"
+checksum = "8e1875f011ba1a37810617c9325b590a2539f44adae194578eafa681a276ec98"
 dependencies = [
  "dhall",
  "dhall_proc_macros",
@@ -1536,7 +1579,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
- "itoa 1.0.3",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1558,20 +1601,7 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
@@ -1582,7 +1612,7 @@ checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest",
 ]
 
 [[package]]
@@ -1624,12 +1654,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "string_cache"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,7 +1678,7 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -1766,6 +1790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+
+[[package]]
 name = "thiserror"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,12 +1857,6 @@ checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "typed-arena"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
 
 [[package]]
 name = "typed-arena"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.43",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,11 +210,13 @@ dependencies = [
  "byteorder",
  "candid_derive",
  "codespan-reporting",
+ "crc32fast",
  "criterion",
+ "data-encoding",
  "fake",
  "goldenfile",
  "hex",
- "ic-types",
+ "impls",
  "lalrpop",
  "lalrpop-util",
  "leb128",
@@ -227,7 +229,11 @@ dependencies = [
  "rand",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_dhall",
+ "serde_json",
+ "serde_test",
+ "sha2 0.10.2",
  "test-generator",
  "thiserror",
 ]
@@ -734,21 +740,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
-name = "ic-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a17269dff0ec6ca4c3d04e18fca97d018ff53d809e6d92348fc22f9588e1a5"
-dependencies = [
- "crc32fast",
- "data-encoding",
- "hex",
- "serde",
- "serde_bytes",
- "sha2 0.10.2",
- "thiserror",
-]
-
-[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +749,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "impls"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
 
 [[package]]
 name = "indexmap"
@@ -1541,6 +1538,15 @@ checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa 1.0.3",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c17d2112159132660b4c5399e274f676fb75a2f8d70b7468f18f045b71138ed"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "candid"
-version = "0.7.18"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 2022-09-27 (Rust 0.8.0)
+
+* Move `Principal` into this crate, no more re-export `ic-types`
+
 ## 2022-09-22 (Rust 0.7.17)
 
 * Bump `ic-types` to `0.5` (fixing `lookup_path` for hash trees)

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -20,7 +20,7 @@ lalrpop = "0.19.0"
 
 [dependencies]
 byteorder = "1.4.3"
-candid_derive = { path = "../candid_derive", version = "0.5" }
+candid_derive = { path = "../candid_derive", version = "=0.5.0" }
 codespan-reporting = "0.11"
 crc32fast = "1.3.0"
 data-encoding = "2.3.2"

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -41,7 +41,7 @@ anyhow = "1.0"
 binread = { version = "2.1", features = ["debug_template"] }
 
 arbitrary = { version = "1.0", optional = true }
-serde_dhall = { version = "0.10.0", default-features = false, optional = true }
+serde_dhall = { version = "0.12.0", default-features = false, optional = true }
 fake = { version = "2.4", optional = true }
 rand = { version = "0.8", optional = true }
 
@@ -49,7 +49,7 @@ rand = { version = "0.8", optional = true }
 goldenfile = "1.1.0"
 test-generator = "0.3.0"
 rand = "0.8"
-criterion = "0.3"
+criterion = "0.4"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.74"

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -20,7 +20,7 @@ lalrpop = "0.19.0"
 
 [dependencies]
 byteorder = "1.4.3"
-candid_derive = { path = "../candid_derive", version = "=0.4.5" }
+candid_derive = { path = "../candid_derive", version = "0.5" }
 codespan-reporting = "0.11"
 crc32fast = "1.3.0"
 data-encoding = "2.3.2"
@@ -62,7 +62,6 @@ harness = false
 path = "benches/benchmark.rs"
 
 [features]
-cdk = ["candid_derive/cdk"]
 configs = ["serde_dhall"]
 random = ["configs", "arbitrary", "fake", "rand"]
 mute_warnings = []

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.7.18"
+version = "0.8.0"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -22,8 +22,9 @@ lalrpop = "0.19.0"
 byteorder = "1.4.3"
 candid_derive = { path = "../candid_derive", version = "=0.4.5" }
 codespan-reporting = "0.11"
+crc32fast = "1.3.0"
+data-encoding = "2.3.2"
 hex = "0.4.2"
-ic-types = "0.5"
 lalrpop-util = "0.19.0"
 leb128 = "0.2.4"
 logos = "0.12"
@@ -34,6 +35,7 @@ paste = "1.0.0"
 pretty = "0.10.0"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_bytes = "0.11"
+sha2 = "0.10.1"
 thiserror = "1.0.20"
 anyhow = "1.0"
 binread = { version = "2.1", features = ["debug_template"] }
@@ -48,6 +50,11 @@ goldenfile = "1.1.0"
 test-generator = "0.3.0"
 rand = "0.8"
 criterion = "0.3"
+serde = { version = "1.0.133", features = ["derive"] }
+serde_cbor = "0.11.2"
+serde_json = "1.0.74"
+serde_test = "1.0.137"
+impls = "1"
 
 [[bench]]
 name = "benchmark"

--- a/rust/candid/src/types/mod.rs
+++ b/rust/candid/src/types/mod.rs
@@ -4,7 +4,6 @@
 //!    We do not use Serde's `Serialize` trait because Candid requires serializing types along with the values.
 //!    This is difficult to achieve in `Serialize`, especially for enum types.
 
-pub use ic_types;
 use serde::ser::Error;
 
 mod impls;

--- a/rust/candid/src/types/principal.rs
+++ b/rust/candid/src/types/principal.rs
@@ -1,6 +1,95 @@
 use super::{CandidType, Serializer, Type, TypeId};
+use sha2::{Digest, Sha224};
+use std::convert::TryFrom;
+use std::fmt::Write;
+use thiserror::Error;
 
-pub use ic_types::Principal;
+/// An error happened while encoding, decoding or serializing a [`Principal`].
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum PrincipalError {
+    #[error("Bytes is longer than 29 bytes.")]
+    BytesTooLong(),
+
+    #[error("Text must be in valid Base32 encoding.")]
+    InvalidBase32(),
+
+    #[error("Text is too short.")]
+    TextTooShort(),
+
+    #[error("Text is too long.")]
+    TextTooLong(),
+
+    #[error("CRC32 check sequence doesn't match with calculated from Principal bytes.")]
+    CheckSequenceNotMatch(),
+
+    #[error(r#"Text should be separated by - (dash) every 5 characters: expected "{0}""#)]
+    AbnormalGrouped(Principal),
+}
+
+/// Generic ID on Internet Computer.
+///
+/// Principals are generic identifiers for canisters, users
+/// and possibly other concepts in the future.
+/// As far as most uses of the IC are concerned they are
+/// opaque binary blobs with a length between 0 and 29 bytes,
+/// and there is intentionally no mechanism to tell canister ids and user ids apart.
+///
+/// Note a principal is not necessarily tied with a public key-pair,
+/// yet we need at least a key-pair of a related principal to sign
+/// requests.
+///
+/// A Principal can be serialized to a byte array ([`Vec<u8>`]) or a text
+/// representation, but the inner structure of the byte representation
+/// is kept private.
+///
+/// Example of using a Principal object:
+/// ```
+/// # use candid::Principal;
+/// let text = "aaaaa-aa";  // The management canister ID.
+/// let principal = Principal::from_text(text).expect("Could not decode the principal.");
+/// assert_eq!(principal.as_slice(), &[] as &[u8]);
+/// assert_eq!(principal.to_text(), text);
+/// ```
+///
+/// Serialization is enabled with the "serde" feature. It supports serializing
+/// to a byte bufer for non-human readable serializer, and a string version for human
+/// readable serializers.
+///
+/// ```
+/// # use candid::Principal;
+/// use serde::{Deserialize, Serialize};
+/// use std::str::FromStr;
+///
+/// #[derive(Serialize)]
+/// struct Data {
+///     id: Principal,
+/// }
+///
+/// let id = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+///
+/// // JSON is human readable, so this will serialize to a textual
+/// // representation of the Principal.
+/// assert_eq!(
+///     serde_json::to_string(&Data { id: id.clone() }).unwrap(),
+///     r#"{"id":"2chl6-4hpzw-vqaaa-aaaaa-c"}"#
+/// );
+///
+/// // CBOR is not human readable, so will serialize to bytes.
+/// assert_eq!(
+///     serde_cbor::to_vec(&Data { id: id.clone() }).unwrap(),
+///     &[161, 98, 105, 100, 73, 239, 205, 171, 0, 0, 0, 0, 0, 1],
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Principal {
+    /// Length.
+    len: u8,
+
+    /// The content buffer. When returning slices this should always be sized according to
+    /// `len`.
+    bytes: [u8; Self::MAX_LENGTH_IN_BYTES],
+}
 
 impl CandidType for Principal {
     fn id() -> TypeId {
@@ -14,5 +103,268 @@ impl CandidType for Principal {
         S: Serializer,
     {
         serializer.serialize_principal(self.as_slice())
+    }
+}
+
+impl Principal {
+    const MAX_LENGTH_IN_BYTES: usize = 29;
+    const CRC_LENGTH_IN_BYTES: usize = 4;
+
+    const SELF_AUTHENTICATING_TAG: u8 = 2;
+    const ANONYMOUS_TAG: u8 = 4;
+
+    /// Construct a [`Principal`] of the IC management canister
+    pub const fn management_canister() -> Self {
+        Self {
+            len: 0,
+            bytes: [0; Self::MAX_LENGTH_IN_BYTES],
+        }
+    }
+
+    /// Construct a self-authenticating ID from public key
+    pub fn self_authenticating<P: AsRef<[u8]>>(public_key: P) -> Self {
+        let public_key = public_key.as_ref();
+        let hash = Sha224::digest(public_key);
+        let mut bytes = [0; Self::MAX_LENGTH_IN_BYTES];
+        bytes[..Self::MAX_LENGTH_IN_BYTES - 1].copy_from_slice(hash.as_slice());
+        bytes[Self::MAX_LENGTH_IN_BYTES - 1] = Self::SELF_AUTHENTICATING_TAG;
+
+        Self {
+            len: Self::MAX_LENGTH_IN_BYTES as u8,
+            bytes,
+        }
+    }
+
+    /// Construct an anonymous ID.
+    pub const fn anonymous() -> Self {
+        let mut bytes = [0; Self::MAX_LENGTH_IN_BYTES];
+        bytes[0] = Self::ANONYMOUS_TAG;
+        Self { len: 1, bytes }
+    }
+
+    /// Construct a [`Principal`] from a slice of bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the slice is longer than 29 bytes.
+    pub const fn from_slice(slice: &[u8]) -> Self {
+        match Self::try_from_slice(slice) {
+            Ok(v) => v,
+            _ => panic!("slice length exceeds capacity"),
+        }
+    }
+
+    /// Construct a [`Principal`] from a slice of bytes.
+    pub const fn try_from_slice(slice: &[u8]) -> Result<Self, PrincipalError> {
+        const MAX_LENGTH_IN_BYTES: usize = Principal::MAX_LENGTH_IN_BYTES;
+        match slice.len() {
+            len @ 0..=MAX_LENGTH_IN_BYTES => {
+                let mut bytes = [0; MAX_LENGTH_IN_BYTES];
+                let mut i = 0;
+                while i < len {
+                    bytes[i] = slice[i];
+                    i += 1;
+                }
+                Ok(Self {
+                    len: len as u8,
+                    bytes,
+                })
+            }
+            _ => Err(PrincipalError::BytesTooLong()),
+        }
+    }
+
+    /// Parse a [`Principal`] from text representation.
+    pub fn from_text<S: AsRef<str>>(text: S) -> Result<Self, PrincipalError> {
+        // Strategy: Parse very liberally, then pretty-print and compare output
+        // This is both simpler and yields better error messages
+
+        let mut s = text.as_ref().to_string();
+        s.make_ascii_uppercase();
+        s.retain(|c| c != '-');
+        match data_encoding::BASE32_NOPAD.decode(s.as_bytes()) {
+            Ok(bytes) => {
+                if bytes.len() < Self::CRC_LENGTH_IN_BYTES {
+                    return Err(PrincipalError::TextTooShort());
+                }
+
+                let crc_bytes = &bytes[..Self::CRC_LENGTH_IN_BYTES];
+                let data_bytes = &bytes[Self::CRC_LENGTH_IN_BYTES..];
+                if data_bytes.len() > Self::MAX_LENGTH_IN_BYTES {
+                    return Err(PrincipalError::TextTooLong());
+                }
+
+                if crc32fast::hash(data_bytes).to_be_bytes() != crc_bytes {
+                    return Err(PrincipalError::CheckSequenceNotMatch());
+                }
+
+                // Already checked data_bytes.len() <= MAX_LENGTH_IN_BYTES
+                // safe to unwrap here
+                let result = Self::try_from_slice(data_bytes).unwrap();
+                let expected = format!("{}", result);
+
+                // In the Spec:
+                // The textual representation is conventionally printed with lower case letters,
+                // but parsed case-insensitively.
+                if text.as_ref().to_ascii_lowercase() != expected {
+                    return Err(PrincipalError::AbnormalGrouped(result));
+                }
+                Ok(result)
+            }
+            _ => Err(PrincipalError::InvalidBase32()),
+        }
+    }
+
+    /// Convert [`Principal`] to text representation.
+    pub fn to_text(&self) -> String {
+        format!("{}", self)
+    }
+
+    /// Return the [`Principal`]'s underlying slice of bytes.
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.bytes[..self.len as usize]
+    }
+}
+
+impl std::fmt::Display for Principal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let blob: &[u8] = self.as_slice();
+
+        // calc checksum
+        let checksum = crc32fast::hash(blob);
+
+        // combine blobs
+        let mut bytes = vec![];
+        bytes.extend_from_slice(&checksum.to_be_bytes());
+        bytes.extend_from_slice(blob);
+
+        // base32
+        let mut s = data_encoding::BASE32_NOPAD.encode(&bytes);
+        s.make_ascii_lowercase();
+
+        // write out string with dashes
+        let mut s = s.as_str();
+        while s.len() > 5 {
+            f.write_str(&s[..5])?;
+            f.write_char('-')?;
+            s = &s[5..];
+        }
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for Principal {
+    type Err = PrincipalError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Principal::from_text(s)
+    }
+}
+
+impl TryFrom<&str> for Principal {
+    type Error = PrincipalError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Principal::from_text(s)
+    }
+}
+
+impl TryFrom<Vec<u8>> for Principal {
+    type Error = PrincipalError;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(bytes.as_slice())
+    }
+}
+
+impl TryFrom<&Vec<u8>> for Principal {
+    type Error = PrincipalError;
+
+    fn try_from(bytes: &Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(bytes.as_slice())
+    }
+}
+
+impl TryFrom<&[u8]> for Principal {
+    type Error = PrincipalError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        Self::try_from_slice(bytes)
+    }
+}
+
+impl AsRef<[u8]> for Principal {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+// Serialization
+impl serde::Serialize for Principal {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            self.to_text().serialize(serializer)
+        } else {
+            serializer.serialize_bytes(self.as_slice())
+        }
+    }
+}
+
+// Deserialization
+mod deserialize {
+    use super::Principal;
+    use std::convert::TryFrom;
+
+    // Simple visitor for deserialization from bytes. We don't support other number types
+    // as there's no need for it.
+    pub(super) struct PrincipalVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for PrincipalVisitor {
+        type Value = super::Principal;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("bytes or string")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Principal::from_text(v).map_err(E::custom)
+        }
+
+        fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Principal::try_from(value).map_err(E::custom)
+        }
+        /// This visitor should only be used by the Candid crate.
+        fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            if v.is_empty() || v[0] != 2u8 {
+                Err(E::custom("Not called by Candid"))
+            } else {
+                Principal::try_from(&v[1..]).map_err(E::custom)
+            }
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Principal {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Principal, D::Error> {
+        use serde::de::Error;
+        if deserializer.is_human_readable() {
+            deserializer
+                .deserialize_str(deserialize::PrincipalVisitor)
+                .map_err(D::Error::custom)
+        } else {
+            deserializer
+                .deserialize_bytes(deserialize::PrincipalVisitor)
+                .map_err(D::Error::custom)
+        }
     }
 }

--- a/rust/candid/src/types/reference.rs
+++ b/rust/candid/src/types/reference.rs
@@ -1,7 +1,7 @@
 //! Data structure for Candid value Func and Service
 
+use super::principal::Principal;
 use super::{CandidType, Function, Serializer, Type};
-use ic_types::Principal;
 use serde::de::{self, Deserialize, Visitor};
 use std::convert::TryFrom;
 use std::{fmt, io::Read};

--- a/rust/candid/tests/principal.rs
+++ b/rust/candid/tests/principal.rs
@@ -1,0 +1,273 @@
+#![allow(deprecated)]
+
+use candid::types::principal::{Principal, PrincipalError};
+
+const MANAGEMENT_CANISTER_BYTES: [u8; 0] = [];
+const MANAGEMENT_CANISTER_TEXT: &str = "aaaaa-aa";
+
+const ANONYMOUS_CANISTER_BYTES: [u8; 1] = [4u8];
+const ANONYMOUS_CANISTER_TEXT: &str = "2vxsx-fae";
+
+const TEST_CASE_BYTES: [u8; 9] = [0xef, 0xcd, 0xab, 0, 0, 0, 0, 0, 1];
+const TEST_CASE_TEXT: &str = "2chl6-4hpzw-vqaaa-aaaaa-c";
+
+mod convert_from_bytes {
+    use super::*;
+
+    #[test]
+    fn try_from_test_case_ok() {
+        assert!(Principal::try_from_slice(&TEST_CASE_BYTES).is_ok());
+    }
+
+    #[test]
+    fn try_from_slice_length_0_29_ok() {
+        let array = [0u8; 29];
+        for len in 0..30 {
+            assert!(Principal::try_from_slice(&array[..len]).is_ok());
+        }
+    }
+
+    #[test]
+    fn try_from_slice_length_30_err() {
+        assert_eq!(
+            Principal::try_from_slice(&[0u8; 30]),
+            Err(PrincipalError::BytesTooLong())
+        );
+    }
+
+    #[test]
+    fn from_test_case_ok() {
+        Principal::from_slice(&TEST_CASE_BYTES);
+    }
+
+    #[test]
+    fn from_slice_length_0_29_ok() {
+        let array = [0u8; 29];
+        for len in 0..30 {
+            Principal::from_slice(&array[..len]);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_slice_length_30_err() {
+        Principal::from_slice(&[0u8; 30]);
+    }
+}
+
+mod convert_from_text {
+    use super::*;
+
+    #[test]
+    fn convert_from_test_case_ok() {
+        // input must be 8~63 chars including `-`s
+        // using empty blob as shortest test case
+        assert!(Principal::from_text(TEST_CASE_TEXT).is_ok());
+    }
+
+    #[test]
+    fn convert_from_management_canister_text_ok() {
+        // input must be 8~63 chars including `-`s
+        // using empty blob as shortest test case
+        assert!(Principal::from_text(MANAGEMENT_CANISTER_TEXT).is_ok());
+    }
+
+    #[test]
+    fn convert_from_29_0u8_ok() {
+        // input must be 8~63 chars including `-`s
+        // using [0u8; 29] as longest test case
+        assert!(Principal::from_text(
+            "bnkmk-jqaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaa"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn convert_from_6a_invalid_base_32() {
+        assert_eq!(
+            Principal::from_text("aaaaa-a"),
+            Err(PrincipalError::InvalidBase32())
+        );
+    }
+
+    #[test]
+    fn convert_from_5a_text_too_short() {
+        assert_eq!(
+            Principal::from_text("aaaaa"),
+            Err(PrincipalError::TextTooShort())
+        );
+    }
+
+    #[test]
+    fn convert_from_30_0u8_text_too_long() {
+        assert_eq!(
+            Principal::from_text(
+                "aacd5-niaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa"
+            ),
+            Err(PrincipalError::TextTooLong())
+        );
+    }
+
+    #[test]
+    fn convert_from_wrong_dash_position_err() {
+        assert_eq!(
+            Principal::from_text("aaaaaaa"),
+            Err(PrincipalError::AbnormalGrouped(
+                Principal::management_canister()
+            ))
+        );
+        assert_eq!(
+            Principal::from_text("aaaaaa-a"),
+            Err(PrincipalError::AbnormalGrouped(
+                Principal::management_canister()
+            ))
+        );
+        assert_eq!(
+            Principal::from_text("aaaaaaa-"),
+            Err(PrincipalError::AbnormalGrouped(
+                Principal::management_canister()
+            ))
+        );
+        assert_eq!(
+            Principal::from_text("-aaaaaaa"),
+            Err(PrincipalError::AbnormalGrouped(
+                Principal::management_canister()
+            ))
+        );
+        assert_eq!(
+            Principal::from_text("aaa-aaaa"),
+            Err(PrincipalError::AbnormalGrouped(
+                Principal::management_canister()
+            ))
+        );
+    }
+
+    #[test]
+    fn convert_from_uppercase_ok() {
+        assert_eq!(
+            Principal::from_text("AAAAA-AA"),
+            Ok(Principal::management_canister())
+        );
+        assert_eq!(
+            Principal::from_text("aaaaa-AA"),
+            Ok(Principal::management_canister())
+        );
+    }
+}
+
+mod convert_to_bytes {
+    use super::*;
+
+    #[test]
+    fn managements_canister_converts_to_empty_slice() {
+        assert_eq!(
+            Principal::management_canister().as_slice(),
+            &MANAGEMENT_CANISTER_BYTES
+        );
+    }
+
+    #[test]
+    fn anonymouse_converts_to_single_byte_04() {
+        assert_eq!(Principal::anonymous().as_slice(), &ANONYMOUS_CANISTER_BYTES);
+    }
+
+    #[test]
+    fn test_case_to_bytes_correct() {
+        assert_eq!(
+            Principal::from_text(TEST_CASE_TEXT).unwrap().as_slice(),
+            &TEST_CASE_BYTES
+        );
+    }
+}
+
+mod convert_to_text {
+    use super::*;
+
+    #[test]
+    fn managements_canister_to_text_correct() {
+        assert_eq!(
+            Principal::management_canister().to_text(),
+            MANAGEMENT_CANISTER_TEXT.to_string()
+        );
+    }
+
+    #[test]
+    fn anonymous_to_text_correct() {
+        assert_eq!(
+            Principal::anonymous().to_text(),
+            ANONYMOUS_CANISTER_TEXT.to_string()
+        );
+    }
+
+    #[test]
+    fn test_case_to_text_correct() {
+        assert_eq!(
+            Principal::try_from_slice(&TEST_CASE_BYTES)
+                .unwrap()
+                .to_text(),
+            TEST_CASE_TEXT.to_string()
+        );
+    }
+}
+
+mod ser_de {
+    use super::*;
+    use serde_test::{assert_tokens, Configure, Token};
+
+    #[test]
+    fn management_canister_serde_match() {
+        let p = Principal::management_canister();
+        assert_tokens(&p.compact(), &[Token::Bytes(&MANAGEMENT_CANISTER_BYTES)]);
+        assert_tokens(&p.readable(), &[Token::Str(MANAGEMENT_CANISTER_TEXT)]);
+    }
+
+    #[test]
+    fn test_case_serde_match() {
+        let p = Principal::try_from_slice(&TEST_CASE_BYTES).unwrap();
+        assert_tokens(&p.compact(), &[Token::Bytes(&TEST_CASE_BYTES)]);
+        assert_tokens(&p.readable(), &[Token::Str(TEST_CASE_TEXT)]);
+    }
+}
+
+#[test]
+fn impl_traits() {
+    use serde::{Deserialize, Serialize};
+    use std::convert::TryFrom;
+    use std::fmt::{Debug, Display};
+    use std::hash::Hash;
+    use std::str::FromStr;
+
+    assert!(impls::impls!(
+        Principal: Debug & Display & Clone & Copy & Eq & PartialOrd & Ord & Hash
+    ));
+
+    assert!(
+        impls::impls!(Principal: FromStr & TryFrom<&'static str> & TryFrom<Vec<u8>> & TryFrom<&'static Vec<u8>> & TryFrom<&'static [u8]> & AsRef<[u8]>)
+    );
+
+    assert!(impls::impls!(Principal: Serialize & Deserialize<'static>));
+}
+
+#[test]
+fn long_blobs_ending_04_is_valid_principal() {
+    let blob: [u8; 18] = [
+        10, 116, 105, 100, 0, 0, 0, 0, 0, 144, 0, 51, 1, 1, 0, 0, 0, 4,
+    ];
+    assert!(Principal::try_from_slice(&blob).is_ok());
+}
+
+#[test]
+fn self_authenticating_ok() {
+    // self_authenticating doesn't verify the input bytes
+    // this test checks:
+    // 1. Sha224 hash is used
+    // 2. 0x02 was added in the end
+    // 3. total length is 29
+    let p1 = Principal::self_authenticating(&[]);
+    let p2 = Principal::try_from_slice(&[
+        209, 74, 2, 140, 42, 58, 43, 201, 71, 97, 2, 187, 40, 130, 52, 196, 21, 162, 176, 31, 130,
+        142, 166, 42, 197, 179, 228, 47, 2,
+    ])
+    .unwrap();
+    assert_eq!(p1, p2);
+}

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid_derive"
-version = "0.4.5"
+version = "0.5.0"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Macros implementation of #[derive(CandidType)] for the Candid."
@@ -23,6 +23,3 @@ quote = "1.0.7"
 syn = { version = "1.0.38", features = ["visit", "full"] }
 proc-macro2 = "1.0.19"
 lazy_static = "1.4.0"
-
-[features]
-cdk = []

--- a/rust/candid_derive/src/lib.rs
+++ b/rust/candid_derive/src/lib.rs
@@ -36,17 +36,6 @@ pub(crate) fn idl_hash(id: &str) -> u32 {
     s
 }
 
-#[cfg(feature = "cdk")]
-pub(crate) fn candid_path(
-    custom_candid_path: &Option<proc_macro2::TokenStream>,
-) -> proc_macro2::TokenStream {
-    match custom_candid_path {
-        Some(custom_candid_path_value) => custom_candid_path_value.clone(),
-        None => quote::quote! { ::ic_cdk::export::candid },
-    }
-}
-
-#[cfg(not(feature = "cdk"))]
 pub(crate) fn candid_path(
     custom_candid_path: &Option<proc_macro2::TokenStream>,
 ) -> proc_macro2::TokenStream {


### PR DESCRIPTION
**Overview**
Re-export `ic-types` often caused build issues in downstream projects.
We believe moving `Principal` implementation to `candid` crate makes more sense.

Also include some other minor changes:
* Remove the cdk feature which is not used by `ic-cdk` anymore. `candid_derive` also needs a major release.
* Update dependencies 

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
This **IS** a breaking change. `candid::types::ic_types` is removed.

We need to publish:
*`candid` v0.8.0
*`candid_derive` v0.5.0