### PR TITLE
Improve custom `.did` fallback logic in the Candid UI

### DIFF
--- a/tools/ui/src/candid.ts
+++ b/tools/ui/src/candid.ts
@@ -53,13 +53,18 @@ export async function fetchActor(canisterId: Principal): Promise<ActorSubclass> 
   const base64Source = (await EXTERNAL_CONFIG_PROMISE)?.candid || window.history.state?.candid || maybeDid;
   if (base64Source) {
     js = await didToJs(window.atob(base64Source));
-  } else {
+    if (!js) {
+      console.warn('Nothing returned from didjs for base64 input:', base64Source);
+    }
+  }
+  if (!js) {
     js = await getDidJsFromMetadata(canisterId);
     if (!js) {
       try {
         js = await getDidJsFromTmpHack(canisterId);
       } catch(err) {
         if (/no query method/.test(err)) {
+          console.warn(err);
           js = undefined;
         } else {
           throw(err);

--- a/tools/ui/src/index.ts
+++ b/tools/ui/src/index.ts
@@ -22,10 +22,10 @@ async function main() {
         const reader = new FileReader();
         reader.addEventListener("load", () => {
           const encoded = reader.result as string;
-          const hex = encoded.substr(encoded.indexOf(",") + 1);
+          const candid = encoded.substr(encoded.indexOf(",") + 1);
           // update URL with Candid data and refresh
           window.history.pushState({}, "", window.location.search);
-          window.history.pushState({ candid: hex }, "", `?${params}`);
+          window.history.pushState({ candid }, "", `?${params}`);
           window.location.reload();
         });
         reader.readAsDataURL(did.files![0]);


### PR DESCRIPTION
Fixes a corner case when passing a Candid file which cannot be converted to JS. 
