### PR TITLE
fix: missing impl serde traits for Principal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "candid"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 2022-10-04 (Rust 0.8.1)
+
+* Fix: missing impl serde traits for `Principal`
+
 ## 2022-09-27 (Rust 0.8.0)
 
 * Move `Principal` into this crate, no more re-export `ic-types`

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."

--- a/rust/candid/src/types/principal.rs
+++ b/rust/candid/src/types/principal.rs
@@ -1,12 +1,12 @@
 use super::{CandidType, Serializer, Type, TypeId};
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha224};
 use std::convert::TryFrom;
 use std::fmt::Write;
 use thiserror::Error;
 
 /// An error happened while encoding, decoding or serializing a [`Principal`].
-#[derive(Error, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Error, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PrincipalError {
     #[error("Bytes is longer than 29 bytes.")]
     BytesTooLong(),
@@ -52,8 +52,8 @@ pub enum PrincipalError {
 /// assert_eq!(principal.to_text(), text);
 /// ```
 ///
-/// Serialization is enabled with the "serde" feature. It supports serializing
-/// to a byte bufer for non-human readable serializer, and a string version for human
+/// Similarly, serialization using serde has two versions:
+/// serilizing to a byte bufer for non-human readable serializer, and a string version for human
 /// readable serializers.
 ///
 /// ```


### PR DESCRIPTION
When move `Principal` into this crate, I forgot to remove following line:
```rust
#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
```
That makes `Principal` not have those traits impl.

We need this fix so that the mono-repo can use latest `candid`.