### PR TITLE
fix: trailing comma in TypeScript bindings

### DIFF
--- a/rust/candid/src/bindings/typescript.rs
+++ b/rust/candid/src/bindings/typescript.rs
@@ -117,7 +117,7 @@ fn pp_function<'a>(env: &'a TypeEnv, func: &'a Function) -> RcDoc<'a> {
     };
     enclose(
         "ActorMethod<",
-        concat([args, rets].iter().cloned(), ","),
+        strict_concat([args, rets].iter().cloned(), ","),
         ">",
     )
 }

--- a/rust/candid/src/pretty.rs
+++ b/rust/candid/src/pretty.rs
@@ -44,7 +44,7 @@ pub fn enclose_space<'a>(left: &'a str, doc: RcDoc<'a>, right: &'a str) -> RcDoc
     }
 }
 
-#[allow(dead_code)]
+/// Intersperse the separator between each item in `docs`.
 pub fn strict_concat<'a, D>(docs: D, sep: &'a str) -> RcDoc<'a>
 where
     D: Iterator<Item = RcDoc<'a>>,
@@ -52,7 +52,7 @@ where
     RcDoc::intersperse(docs, RcDoc::text(sep).append(RcDoc::line()))
 }
 
-/// Append the separator to each docs items. If it is displayed in a single line, omit the last separator.
+/// Append the separator to each item in `docs`. If it is displayed in a single line, omit the last separator.
 pub fn concat<'a, D>(docs: D, sep: &'a str) -> RcDoc<'a>
 where
     D: Iterator<Item = RcDoc<'a>> + Clone,

--- a/rust/candid/tests/assets/ok/example.d.ts
+++ b/rust/candid/tests/assets/ok/example.d.ts
@@ -41,7 +41,7 @@ export interface _SERVICE {
         { 'B' : [] | [string] },
       [] | [List],
     ],
-    { _42_ : {}, 'id' : bigint },
+    { _42_ : {}, 'id' : bigint }
   >,
   'i' : f,
   'x' : ActorMethod<[a, b], [[] | [a], [] | [b]]>,

--- a/rust/candid/tests/assets/ok/keyword.d.ts
+++ b/rust/candid/tests/assets/ok/keyword.d.ts
@@ -24,6 +24,6 @@ export interface _SERVICE {
   'tuple' : ActorMethod<[[bigint, Uint8Array, string]], [bigint, number]>,
   'variant' : ActorMethod<
     [{ 'A' : null } | { 'B' : null } | { 'C' : null } | { 'D' : number }],
-    undefined,
+    undefined
   >,
 }

--- a/rust/candid/tests/assets/ok/service.d.ts
+++ b/rust/candid/tests/assets/ok/service.d.ts
@@ -9,11 +9,11 @@ export interface _SERVICE {
   'asPrincipal' : ActorMethod<[], [Principal, [Principal, string]]>,
   'asRecord' : ActorMethod<
     [],
-    [Principal, [] | [Principal], [Principal, string]],
+    [Principal, [] | [Principal], [Principal, string]]
   >,
   'asVariant' : ActorMethod<
     [],
     { 'a' : Principal } |
-      { 'b' : { 'f' : [] | [[Principal, string]] } },
+      { 'b' : { 'f' : [] | [[Principal, string]] } }
   >,
 }


### PR DESCRIPTION
Removes trailing commas from generated TS type parameters (https://github.com/microsoft/TypeScript/issues/21984).
