### PR TITLE
makes typescript bindings accurately permissive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "candid"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "didc"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "candid",

--- a/rust/candid/src/bindings/typescript.rs
+++ b/rust/candid/src/bindings/typescript.rs
@@ -54,14 +54,14 @@ fn pp_ty<'a>(env: &'a TypeEnv, ty: &'a Type, is_ref: bool) -> RcDoc<'a> {
                 _ => t,
             };
             match *ty {
-                Nat8 => str("Uint8Array"),
-                Nat16 => str("Uint16Array"),
-                Nat32 => str("Uint32Array"),
-                Nat64 => str("BigUint64Array"),
-                Int8 => str("Int8Array"),
-                Int16 => str("Int16Array"),
-                Int32 => str("Int32Array"),
-                Int64 => str("BigInt64Array"),
+                Nat8 => str("Uint8Array | number[]"),
+                Nat16 => str("Uint16Array | number[]"),
+                Nat32 => str("Uint32Array | number[]"),
+                Nat64 => str("BigUint64Array | bigint[]"),
+                Int8 => str("Int8Array | number[]"),
+                Int16 => str("Int16Array | number[]"),
+                Int32 => str("Int32Array | number[]"),
+                Int64 => str("BigInt64Array | bigint[]"),
                 _ => str("Array").append(enclose("<", pp_ty(env, t, is_ref), ">")),
             }
         }

--- a/rust/candid/tests/assets/ok/example.d.ts
+++ b/rust/candid/tests/assets/ok/example.d.ts
@@ -32,7 +32,7 @@ export type tree = {
   } |
   { 'leaf' : bigint };
 export interface _SERVICE {
-  'f' : ActorMethod<[list, Uint8Array, [] | [boolean]], undefined>,
+  'f' : ActorMethod<[list, Uint8Array | number[], [] | [boolean]], undefined>,
   'g' : ActorMethod<[my_type, List, [] | [List], nested], [bigint, Principal]>,
   'h' : ActorMethod<
     [

--- a/rust/candid/tests/assets/ok/keyword.d.ts
+++ b/rust/candid/tests/assets/ok/keyword.d.ts
@@ -18,10 +18,13 @@ export interface _SERVICE {
   'fieldnat' : ActorMethod<[{ _2_ : bigint, '2' : bigint }], [bigint]>,
   'oneway' : ActorMethod<[number], undefined>,
   'oneway_' : ActorMethod<[number], undefined>,
-  'query' : ActorMethod<[Uint8Array], Uint8Array>,
+  'query' : ActorMethod<[Uint8Array | number[]], Uint8Array | number[]>,
   'return' : ActorMethod<[o], o>,
   'service' : t,
-  'tuple' : ActorMethod<[[bigint, Uint8Array, string]], [bigint, number]>,
+  'tuple' : ActorMethod<
+    [[bigint, Uint8Array | number[], string]],
+    [bigint, number]
+  >,
   'variant' : ActorMethod<
     [{ 'A' : null } | { 'B' : null } | { 'C' : null } | { 'D' : number }],
     undefined


### PR DESCRIPTION
for Nat and Int arrays

**Overview**
There are a few justifications for this change:
* The browser support for BigInt64Array is less than `bigint[]`
* Some old TS code is unnecessarily broken in the shift away from `number[]` and `bigint[]` typing
* the JS agent accepts these types

**Recommended Solution**
I simply recommend adopting this change

**Considerations**
This should not affect anyone currently using BigInt64Array or the like
