### PR TITLE
Add nat serialization support for json and cbor, and test cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "binread"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +207,7 @@ version = "0.9.0-beta.0"
 dependencies = [
  "anyhow",
  "arbitrary",
+ "bincode",
  "binread",
  "byteorder",
  "candid_derive",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -56,6 +56,7 @@ serde_cbor = "0.11.2"
 serde_json = "1.0.74"
 serde_test = "1.0.137"
 impls = "1"
+bincode = "1.3.3"
 
 [[bench]]
 name = "benchmark"

--- a/rust/candid/src/types/number.rs
+++ b/rust/candid/src/types/number.rs
@@ -589,7 +589,6 @@ mod tests {
             inner: Nat::from(1000u64),
         };
         let serialized = bincode::serialize(&test_struct).unwrap();
-        println!("{:?}", serialized);
         // panicked at 'called `Result::unwrap()` on an `Err` value: DeserializeAnyNotSupported'
         let deserialized = bincode::deserialize(&serialized).unwrap();
         assert_eq!(test_struct, deserialized);
@@ -601,7 +600,6 @@ mod tests {
             inner: Nat::from(1000u64),
         };
         let serialized = serde_json::to_string(&test_struct).unwrap();
-        println!("{:?}", serialized);
         let deserialized = serde_json::from_str(&serialized).unwrap();
         assert_eq!(test_struct, deserialized);
 
@@ -612,10 +610,7 @@ mod tests {
             inner: Nat::parse(b"60000000000000000").unwrap(),
         };
         let serialized = serde_json::to_string(&test_struct).unwrap();
-        assert_eq!(
-            format!("{}", serialized),
-            "{\"inner\":[2659581952,13969838]}"
-        );
+        assert_eq!(serialized, "{\"inner\":[2659581952,13969838]}");
         let deserialized = serde_json::from_str(&serialized).unwrap();
         assert_eq!(test_struct, deserialized);
     }
@@ -626,7 +621,6 @@ mod tests {
             inner: Nat::from(1000u64),
         };
         let serialized = serde_cbor::to_vec(&test_struct).unwrap();
-        println!("serialized {:?}", serialized);
         let deserialized = serde_cbor::from_slice(&serialized).unwrap();
         assert_eq!(test_struct, deserialized);
 
@@ -634,7 +628,6 @@ mod tests {
             inner: Nat::parse(b"60000000000000000").unwrap(),
         };
         let serialized = serde_cbor::to_vec(&test_struct).unwrap();
-        println!("serialized {:?}", serialized);
         let deserialized = serde_cbor::from_slice(&serialized).unwrap();
         assert_eq!(test_struct, deserialized);
     }

--- a/rust/candid/src/types/number.rs
+++ b/rust/candid/src/types/number.rs
@@ -608,7 +608,10 @@ mod tests {
             inner: Nat::parse(b"60000000000000000").unwrap(),
         };
         let serialized = serde_json::to_string(&test_struct).unwrap();
-        assert_eq!(format!("{}", serialized), "{\"inner\":[2659581952,13969838]}");
+        assert_eq!(
+            format!("{}", serialized),
+            "{\"inner\":[2659581952,13969838]}"
+        );
         let deserialized = serde_json::from_str(&serialized).unwrap();
         assert_eq!(test_struct, deserialized);
     }

--- a/rust/candid/src/types/number.rs
+++ b/rust/candid/src/types/number.rs
@@ -4,7 +4,7 @@ use super::{CandidType, Serializer, Type, TypeInner};
 use crate::Error;
 use num_bigint::{BigInt, BigUint};
 use serde::{
-    de::{self, Deserialize, Visitor},
+    de::{self, Deserialize, SeqAccess, Visitor},
     Serialize,
 };
 use std::convert::From;
@@ -206,6 +206,20 @@ impl<'de> Deserialize<'de> for Nat {
                 } else {
                     Err(de::Error::custom("not nat"))
                 }
+            }
+
+            fn visit_seq<S>(self, mut seq: S) -> Result<Nat, S::Error>
+            where
+                S: SeqAccess<'de>,
+            {
+                let len = seq.size_hint().unwrap_or(0);
+                let mut data = Vec::with_capacity(len);
+
+                while let Some(value) = seq.next_element::<u32>()? {
+                    data.push(value);
+                }
+
+                Ok(Nat(BigUint::new(data)))
             }
         }
         deserializer.deserialize_any(NatVisitor)
@@ -554,5 +568,51 @@ impl std::ops::RemAssign<i32> for Nat {
     #[inline]
     fn rem_assign(&mut self, other: i32) {
         self.0 %= other as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Default, Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+    pub struct TestStruct {
+        inner: Nat,
+    }
+
+    #[ignore]
+    #[test]
+    fn test_serde_with_bincode() {
+        let test_struct = TestStruct {
+            inner: Nat::from(1000u64),
+        };
+        let serialized = bincode::serialize(&test_struct).unwrap();
+        println!("{:?}", serialized);
+        // panicked at 'called `Result::unwrap()` on an `Err` value: DeserializeAnyNotSupported'
+        let deserialized = bincode::deserialize(&serialized).unwrap();
+        assert_eq!(test_struct, deserialized);
+    }
+
+    #[test]
+    fn test_serde_with_json() {
+        let test_struct = TestStruct {
+            inner: Nat::from(1000u64),
+        };
+        let serialized = serde_json::to_string(&test_struct).unwrap();
+        println!("{:?}", serialized);
+        let deserialized = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(test_struct, deserialized);
+    }
+
+    #[test]
+    fn test_serde_with_cbor() {
+        let test_struct = TestStruct {
+            inner: Nat::from(1000u64),
+        };
+        let serialized = serde_cbor::to_vec(&test_struct).unwrap();
+        println!("serialized {:?}", serialized);
+        let deserialized = serde_cbor::from_slice(&serialized).unwrap();
+        assert_eq!(test_struct, deserialized);
     }
 }

--- a/rust/candid/src/types/number.rs
+++ b/rust/candid/src/types/number.rs
@@ -584,6 +584,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_serde_with_bincode() {
+        // This ignored/failed test shows that bincode isn't supported.
         let test_struct = TestStruct {
             inner: Nat::from(1000u64),
         };
@@ -604,6 +605,9 @@ mod tests {
         let deserialized = serde_json::from_str(&serialized).unwrap();
         assert_eq!(test_struct, deserialized);
 
+        // Nats serialize as arrays in JSON. The following tests the breakdown
+        // of a big number into an array.
+        // 13969838 * 2^32 + 2659581952 == 60000000000000000
         let test_struct = TestStruct {
             inner: Nat::parse(b"60000000000000000").unwrap(),
         };

--- a/rust/candid/src/types/number.rs
+++ b/rust/candid/src/types/number.rs
@@ -603,12 +603,28 @@ mod tests {
         println!("{:?}", serialized);
         let deserialized = serde_json::from_str(&serialized).unwrap();
         assert_eq!(test_struct, deserialized);
+
+        let test_struct = TestStruct {
+            inner: Nat::parse(b"60000000000000000").unwrap(),
+        };
+        let serialized = serde_json::to_string(&test_struct).unwrap();
+        assert_eq!(format!("{}", serialized), "{\"inner\":[2659581952,13969838]}");
+        let deserialized = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(test_struct, deserialized);
     }
 
     #[test]
     fn test_serde_with_cbor() {
         let test_struct = TestStruct {
             inner: Nat::from(1000u64),
+        };
+        let serialized = serde_cbor::to_vec(&test_struct).unwrap();
+        println!("serialized {:?}", serialized);
+        let deserialized = serde_cbor::from_slice(&serialized).unwrap();
+        assert_eq!(test_struct, deserialized);
+
+        let test_struct = TestStruct {
+            inner: Nat::parse(b"60000000000000000").unwrap(),
         };
         let serialized = serde_cbor::to_vec(&test_struct).unwrap();
         println!("serialized {:?}", serialized);


### PR DESCRIPTION
A partial solution to address #374.

Note that Nat serializes as arrays in JSON and CBOR, which could be counter-intuitive.

Know caveat is that bincode isn't supported because bincode doesn't use deserialize_any.