### PR TITLE
docs: fix link to candid intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ the data they exchange, with type safety and extensibility.
 ## Documentation
 
 * The [spec](spec/) directory contains Candid specifications, including the [Candid language specification](spec/Candid.md) and a soundness proof.
-* The [official manual](https://sdk.dfinity.org/docs/candid-guide/candid-intro.html) is hosted by dfinity; see [./docs](docs/) for the source code.
+* The [official manual](https://internetcomputer.org/docs/current/developer-docs/build/candid/candid-intro/) is hosted by dfinity; see [./docs](docs/) for the source code.
 
 ## Implementations
 


### PR DESCRIPTION
The page was moved to https://internetcomputer.org.
