### PR TITLE
Macros for reference types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "candid"
-version = "0.9.0-beta.0"
+version = "0.9.0-beta.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,12 @@
 * Deprecate `ToDoc` trait for pretty printing `IDLProg`, use `candid::bindings::candid` module instead
 * Deprecate `candid::codegen`, use `candid::bindings` instead
 
+### Non-breaking changes:
+
+* Macros for constructing type AST nodes: `service!`, `func!` and `field!`
+* Support future types
+* `Nat` serialization for JSON and CBOR
+
 ## 2022-11-17 (Rust 0.8.3 -- 0.8.4)
 
 * Bug fix in TS bindings

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,13 +1,14 @@
 
 # Changelog
 
-## Rust 0.9.0-beta.0
+## Rust 0.9.0-beta
 
 ### Breaking changes:
 
-* The old `candid::Type` is now `candid::TypeInner`, and `Type` is a newtype of `Rc<TypeInner>`. This change significantly improves deserialization performance
 * Deserializer only checks subtyping for reference types, fully conforming to Candid spec 1.4
-* `candid::parser` module is only available under feature flag `"parser"`
+* The old `candid::Type` is now `candid::TypeInner`, and `Type` is a newtype of `Rc<TypeInner>`. This change significantly improves deserialization performance (25% -- 50% improvements)
+* `candid::parser` module is only available under feature flag `"parser"`. This significantly cut down compilation time and Wasm binary size
+* Disable the use of `candid::Func` and `candid::Service` to avoid footguns. Use `define_function!` and `define_service!` macro instead
 * `candid::parser::typing::TypeEnv` moved to `candid::types::TypeEnv`. Use of `candid::TypeEnv` is not affected
 * `candid::parser::types::FuncMode` moved to `candid::types::FuncMode`
 * `candid::parser::value` moved to `candid::types::value`

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -81,10 +81,17 @@ name = "parse_type"
 path = "tests/parse_type.rs"
 required-features = ["parser"]
 
-
 [features]
 configs = ["serde_dhall"]
-random = ["configs", "arbitrary", "fake", "rand"]
+random = ["parser", "configs", "arbitrary", "fake", "rand"]
 parser = ["lalrpop", "lalrpop-util", "logos"]
-all = ["parser", "random"]
+all = ["random"]
 mute_warnings = []
+
+# docs.rs-specific configuration
+# To test locally: RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
+[package.metadata.docs.rs]
+# document all features
+all-features = true
+# defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.9.0-beta.0"
+version = "0.9.0-beta.1"
 edition = "2018"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."

--- a/rust/candid/src/bindings/mod.rs
+++ b/rust/candid/src/bindings/mod.rs
@@ -3,13 +3,18 @@
 
 pub mod candid;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 pub mod analysis;
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 pub mod javascript;
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 pub mod motoko;
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 pub mod rust;
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 pub mod typescript;

--- a/rust/candid/src/error.rs
+++ b/rust/candid/src/error.rs
@@ -18,6 +18,7 @@ pub type Result<T = ()> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
     #[cfg(feature = "parser")]
     #[error("Candid parser error: {0}")]
     Parse(#[from] token::ParserError),
@@ -39,6 +40,7 @@ impl Error {
     pub fn subtype<T: ToString>(msg: T) -> Self {
         Error::Subtype(msg.to_string())
     }
+    #[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
     #[cfg(feature = "parser")]
     pub fn report(&self) -> Diagnostic<()> {
         match self {
@@ -121,6 +123,7 @@ fn get_binread_labels(e: &binread::Error) -> Vec<Label<()>> {
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 fn report_expected(expected: &[String]) -> Vec<String> {
     if expected.is_empty() {
@@ -166,13 +169,14 @@ impl From<binread::Error> for Error {
         Error::Binread(get_binread_labels(&e))
     }
 }
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 impl From<ReportError> for Error {
     fn from(e: ReportError) -> Error {
         Error::msg(e)
     }
 }
-
+#[cfg_attr(docsrs, doc(cfg(feature = "random")))]
 #[cfg(feature = "random")]
 impl From<arbitrary::Error> for Error {
     fn from(e: arbitrary::Error) -> Error {
@@ -180,6 +184,7 @@ impl From<arbitrary::Error> for Error {
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "configs")))]
 #[cfg(feature = "configs")]
 impl From<serde_dhall::Error> for Error {
     fn from(e: serde_dhall::Error) -> Error {
@@ -187,6 +192,7 @@ impl From<serde_dhall::Error> for Error {
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 pub fn pretty_parse<T>(name: &str, str: &str) -> Result<T>
 where
@@ -200,7 +206,7 @@ where
         Err(e)
     })
 }
-
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 pub fn pretty_read<T>(reader: &mut std::io::Cursor<&[u8]>) -> Result<T>
 where

--- a/rust/candid/src/lib.rs
+++ b/rust/candid/src/lib.rs
@@ -126,6 +126,30 @@
 //! # Ok::<(), candid::Error>(())
 //! ```
 //!
+//! ## Operating on reference types
+//! The type of function and service references cannot be derived automatically. We provide
+//! two macros [`define_function!`](macro.define_function.html) and [`define_service!`](macro.define_service.html) to help defining the reference types.
+//!
+//! ```
+//! use candid::{define_function, define_service, func, service, Func, Service, Encode, Decode, Principal, CandidType, Deserialize, types::TypeInner};
+//! let principal = Principal::from_text("aaaaa-aa").unwrap();
+//!
+//! define_function!(pub CustomFunc : func!(() -> (TypeInner::Nat.into())));
+//! let func = CustomFunc(Func {
+//!    principal,
+//!    method: "create_canister".to_string()
+//! });
+//! assert_eq!(func, Decode!(&Encode!(&func)?, CustomFunc)?);
+//!
+//! define_service!(MyService : service! {
+//!   "f": CustomFunc::ty();
+//!   "g": func!(() -> () query)
+//! });
+//! let serv = MyService(Service { principal });
+//! assert_eq!(serv, Decode!(&Encode!(&serv)?, MyService)?);
+//! # Ok::<(), candid::Error>(())
+//! ```
+//!
 //! ## Operating on untyped Candid values
 //! Any valid Candid value can be manipulated in an recursive enum representation [`candid::parser::value::IDLValue`](parser/value/enum.IDLValue.html).
 //! We use `ser.value_arg(v)` and `de.get_value::<IDLValue>()` for encoding and decoding the value.

--- a/rust/candid/src/lib.rs
+++ b/rust/candid/src/lib.rs
@@ -155,7 +155,9 @@
 //! and use `to_bytes()` and `from_bytes()` to encode and decode Candid messages.
 //! We also provide a parser to parse Candid values in text format.
 //!
-//! ```#[cfg(feature = "parser")]
+//! ```
+//! #[cfg(feature = "parser")]
+//! # fn f() -> Result<(), candid::Error> {
 //! use candid::{IDLArgs, TypeEnv};
 //! // Candid values represented in text format
 //! let text_value = r#"
@@ -176,7 +178,8 @@
 //! let parsed_args: IDLArgs = output.parse()?;
 //! let annotated_args = args.annotate_types(true, &TypeEnv::new(), &parsed_args.get_types())?;
 //! assert_eq!(annotated_args, parsed_args);
-//! # Ok::<(), candid::Error>(())
+//! # Ok(())
+//! # }
 //! ```
 //! Note that when parsing Candid values, we assume the number literals are always of type `Int`.
 //! This can be changed by providing the type of the method arguments, which can usually be obtained
@@ -185,7 +188,9 @@
 //! ## Operating on Candid AST
 //! We provide a parser and type checker for Candid files specifying the service interface.
 //!
-//! ```#[cfg(feature = "parser")]
+//! ```
+//! #[cfg(feature = "parser")]
+//! # fn f() -> Result<(), candid::Error> {
 //! use candid::{IDLProg, TypeEnv, check_prog, types::{Type, TypeInner}};
 //! let did_file = r#"
 //!     type List = opt record { head: int; tail: List };
@@ -199,9 +204,6 @@
 //! // Parse did file into an AST
 //! let ast: IDLProg = did_file.parse()?;
 //!
-//! // Pretty-print AST
-//! let pretty: String = candid::parser::types::to_pretty(&ast, 80);
-//!
 //! // Type checking a given .did file
 //! // let (env, opt_actor) = check_file("a.did")?;
 //! // Or alternatively, use check_prog to check in-memory did file
@@ -212,7 +214,8 @@
 //! let method = env.get_method(&actor, "g").unwrap();
 //! assert_eq!(method.is_query(), true);
 //! assert_eq!(method.args, vec![TypeInner::Var("List".to_string()).into()]);
-//! # Ok::<(), candid::Error>(())
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Serializing untyped Candid values with type annotations.
@@ -221,7 +224,9 @@
 //! This is useful when serializing different number types and recursive types.
 //! There is no need to use types for deserialization as the types are available in the Candid message.
 //!
-//! ```#[cfg(feature = "parser")]
+//! ```
+//! #[cfg(feature = "parser")]
+//! # fn f() -> Result<(), candid::Error> {
 //! use candid::{IDLArgs, types::value::IDLValue};
 //! # use candid::{IDLProg, TypeEnv, check_prog};
 //! # let did_file = r#"
@@ -247,7 +252,8 @@
 //!             IDLValue::Nat(42.into()),
 //!             IDLValue::Int8(42)
 //!            ]);
-//! # Ok::<(), candid::Error>(())
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Building the library as a JS/Wasm package
@@ -296,6 +302,10 @@
 //!
 //!
 
+// only enables the `doc_cfg` feature when
+// the `docsrs` configuration attribute is defined
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub use candid_derive::{candid_method, export_service, CandidType};
 pub use serde::Deserialize;
 
@@ -324,6 +334,7 @@ pub mod utils;
 pub use utils::{decode_args, decode_one, encode_args, encode_one, write_args};
 pub mod pretty;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 pub mod parser;
 #[cfg(feature = "parser")]

--- a/rust/candid/src/lib.rs
+++ b/rust/candid/src/lib.rs
@@ -131,21 +131,18 @@
 //! two macros [`define_function!`](macro.define_function.html) and [`define_service!`](macro.define_service.html) to help defining the reference types.
 //!
 //! ```
-//! use candid::{define_function, define_service, func, service, Func, Service, Encode, Decode, Principal, CandidType, Deserialize, types::TypeInner};
+//! use candid::{define_function, define_service, func, Encode, Decode, Principal, types::TypeInner};
 //! let principal = Principal::from_text("aaaaa-aa").unwrap();
 //!
-//! define_function!(pub CustomFunc : func!(() -> (TypeInner::Nat.into())));
-//! let func = CustomFunc(Func {
-//!    principal,
-//!    method: "create_canister".to_string()
-//! });
+//! define_function!(pub CustomFunc : () -> (TypeInner::Nat.into()));
+//! let func = CustomFunc::new(principal, "method_name".to_string());
 //! assert_eq!(func, Decode!(&Encode!(&func)?, CustomFunc)?);
 //!
-//! define_service!(MyService : service! {
+//! define_service!(MyService : {
 //!   "f": CustomFunc::ty();
 //!   "g": func!(() -> () query)
 //! });
-//! let serv = MyService(Service { principal });
+//! let serv = MyService::new(principal);
 //! assert_eq!(serv, Decode!(&Encode!(&serv)?, MyService)?);
 //! # Ok::<(), candid::Error>(())
 //! ```

--- a/rust/candid/src/parser/mod.rs
+++ b/rust/candid/src/parser/mod.rs
@@ -9,8 +9,10 @@ pub mod types;
 
 pub mod typing;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "configs")))]
 #[cfg(feature = "configs")]
 pub mod configs;
+#[cfg_attr(docsrs, doc(cfg(feature = "random")))]
 #[cfg(feature = "random")]
 pub mod random;
 pub mod test;

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -381,6 +381,24 @@ impl Function {
         self.modes.contains(&crate::types::FuncMode::Query)
     }
 }
+#[macro_export]
+macro_rules! func {
+    ( ( $($arg:expr),* ) -> ( $($ret:expr),* ) ) => {
+        Into::<$crate::types::Type>::into($crate::types::TypeInner::Func($crate::types::Function { args: vec![$($arg),*], rets: vec![$($ret),*], modes: vec![] }))
+    };
+    ( ( $($arg:expr),* ) -> ( $($ret:expr),* ) query ) => {
+        Into::<$crate::types::Type>::into($crate::types::TypeInner::Func($crate::types::Function { args: vec![$($arg),*], rets: vec![$($ret),*], modes: vec![$crate::types::FuncMode::Query] }))
+    };
+    ( ( $($arg:expr),* ) -> ( $($ret:expr),* ) oneway ) => {
+        Into::<$crate::types::Type>::into($crate::types::TypeInner::Func($crate::types::Function { args: vec![$($arg),*], rets: vec![$($ret),*], modes: vec![$crate::types::FuncMode::Oneway] }))
+    };
+}
+#[macro_export]
+macro_rules! service {
+    { $($meth:tt : $ty:expr);* } => {
+        Into::<$crate::types::Type>::into($crate::types::TypeInner::Service(vec![ $(($meth.to_string(), $ty)),* ]))
+    }
+}
 
 #[derive(Debug, PartialEq, TryFromPrimitive)]
 #[repr(i64)]

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -334,12 +334,12 @@ impl std::hash::Hash for Label {
         self.get_id();
     }
 }
-
 #[derive(Debug, PartialEq, Hash, Eq, Clone)]
 pub struct Field {
     pub id: Rc<Label>,
     pub ty: Type,
 }
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FuncMode {
     Oneway,
@@ -382,6 +382,7 @@ impl Function {
     }
 }
 #[macro_export]
+/// Construct a function type. `func!(() -> () query)` expands to `Type(Rc::new(TypeInner::Func(...)))`
 macro_rules! func {
     ( ( $($arg:expr),* ) -> ( $($ret:expr),* ) ) => {
         Into::<$crate::types::Type>::into($crate::types::TypeInner::Func($crate::types::Function { args: vec![$($arg),*], rets: vec![$($ret),*], modes: vec![] }))
@@ -394,6 +395,7 @@ macro_rules! func {
     };
 }
 #[macro_export]
+/// Construct a service type. `service!{ "f": func!((HttpRequest::ty()) -> ()) }` expands to `Type(Rc::new(TypeInner::Service(...)))`
 macro_rules! service {
     { $($meth:tt : $ty:expr);* } => {
         Into::<$crate::types::Type>::into($crate::types::TypeInner::Service(vec![ $(($meth.to_string(), $ty)),* ]))

--- a/rust/candid/src/types/reference.rs
+++ b/rust/candid/src/types/reference.rs
@@ -21,7 +21,8 @@ pub struct Service {
 
 #[macro_export]
 /// Define a function reference type.
-/// Example: `define_function!(FuncReference : () -> () query);`
+///
+/// `define_function!(pub MyFunc : () -> () query)` expands to `pub struct MyFunc(Func)`, which implements `CandidType` with the provided type and `MyFunc::new(principal, method)`.
 macro_rules! define_function {
     ( $vis:vis $func:ident : $($ty:tt)+ ) => {
         #[derive($crate::Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -44,7 +45,8 @@ macro_rules! define_function {
 }
 #[macro_export]
 /// Define a service reference type.
-/// Example: `define_service!(MyService : { "f": func!(() -> () query) });`
+///
+/// `define_service!(MyService : { "f": func!(() -> () query) })` expands to `struct MyService(Service)`, which implements `CandidType` with the provided type and `MyService::new(principal)`.
 macro_rules! define_service {
     ( $vis:vis $serv:ident : { $($ty:tt)* } ) => {
         #[derive($crate::Deserialize, PartialEq, Eq, Debug, Clone)]

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -10,11 +10,13 @@ use crate::{pretty_parse, types::Type, Error, TypeEnv};
 #[cfg(feature = "parser")]
 use std::path::Path;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 pub enum CandidSource<'a> {
     File(&'a Path),
     Text(&'a str),
 }
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 impl<'a> CandidSource<'a> {
     pub fn load(&self) -> Result<(TypeEnv, Option<Type>)> {
@@ -30,6 +32,7 @@ impl<'a> CandidSource<'a> {
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 /// Check compatibility of two service types
 pub fn service_compatible(new: CandidSource, old: CandidSource) -> Result<()> {

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -133,39 +133,25 @@ fn test_reserved() {
 #[test]
 fn test_reference() {
     use candid::{
-        types::{Function, Type, TypeInner},
-        Func, Principal, Service,
+        define_function, define_service, func, service, types::TypeInner, Func, Principal, Service,
     };
     let principal = Principal::from_text("w7x7r-cok77-xa").unwrap();
     all_check(principal, "4449444c0001680103caffee");
-    all_check(Service { principal }, "4449444c01690001000103caffee");
+    define_function!(CustomFunc: func!(() -> (TypeInner::Nat.into())));
     all_check(
-        Func {
+        CustomFunc(Func {
             principal,
             method: "method".to_owned(),
-        },
-        "4449444c016a0000000100010103caffee066d6574686f64",
+        }),
+        "4449444c016a00017d000100010103caffee066d6574686f64",
     );
-    #[derive(Deserialize, PartialEq, Debug)]
-    struct CustomFunc(Func);
-    impl CandidType for CustomFunc {
-        fn _ty() -> Type {
-            TypeInner::Func(Function {
-                args: vec![],
-                rets: vec![TypeInner::Nat.into()],
-                modes: vec![],
-            })
-            .into()
-        }
-        fn idl_serialize<S: candid::types::Serializer>(
-            &self,
-            _serializer: S,
-        ) -> Result<(), S::Error> {
-            unimplemented!()
-        }
-    }
     let bytes = hex("4449444c016a00017f000100010100016d");
     test_decode(&bytes, &None::<CustomFunc>);
+    define_service!(MyService: service! { "f": CustomFunc::ty(); "g": func!(() -> () query) });
+    all_check(
+        MyService(Service { principal }),
+        "4449444c0369020166010167026a00017d006a0000010101000103caffee",
+    );
 }
 
 #[test]

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -132,24 +132,19 @@ fn test_reserved() {
 
 #[test]
 fn test_reference() {
-    use candid::{
-        define_function, define_service, func, service, types::TypeInner, Func, Principal, Service,
-    };
+    use candid::{define_function, define_service, func, types::TypeInner, Principal};
     let principal = Principal::from_text("w7x7r-cok77-xa").unwrap();
     all_check(principal, "4449444c0001680103caffee");
-    define_function!(CustomFunc: func!(() -> (TypeInner::Nat.into())));
+    define_function!(CustomFunc: () -> (TypeInner::Nat.into()));
     all_check(
-        CustomFunc(Func {
-            principal,
-            method: "method".to_owned(),
-        }),
+        CustomFunc::new(principal, "method".to_owned()),
         "4449444c016a00017d000100010103caffee066d6574686f64",
     );
     let bytes = hex("4449444c016a00017f000100010100016d");
     test_decode(&bytes, &None::<CustomFunc>);
-    define_service!(MyService: service! { "f": CustomFunc::ty(); "g": func!(() -> () query) });
+    define_service!(MyService: { "f": CustomFunc::ty(); "g": func!(() -> () query) });
     all_check(
-        MyService(Service { principal }),
+        MyService::new(principal),
         "4449444c0369020166010167026a00017d006a0000010101000103caffee",
     );
 }

--- a/rust/candid/tests/types.rs
+++ b/rust/candid/tests/types.rs
@@ -3,10 +3,10 @@
 use std::fmt::Debug;
 
 use candid::{
-    candid_method,
+    candid_method, field,
     ser::IDLBuilder,
     types::value::{IDLValue, IDLValueVisitor},
-    types::{get_type, Label, Serializer, Type, TypeInner},
+    types::{get_type, Serializer, Type, TypeInner},
     CandidType, Decode, Deserialize, Encode, Int,
 };
 use serde::de::DeserializeOwned;
@@ -111,8 +111,8 @@ fn test_struct() {
     assert_eq!(
         A::ty(),
         TypeInner::Record(vec![
-            field("bar", TypeInner::Bool.into()),
-            field("foo", TypeInner::Int.into())
+            field! {bar: TypeInner::Bool.into()},
+            field! {foo: TypeInner::Int.into()}
         ])
         .into()
     );
@@ -126,8 +126,8 @@ fn test_struct() {
     assert_eq!(
         get_type(&res),
         TypeInner::Record(vec![
-            field("g1", TypeInner::Int32.into()),
-            field("g2", TypeInner::Bool.into())
+            field! {g1: TypeInner::Int32.into()},
+            field! {g2: TypeInner::Bool.into()}
         ])
         .into()
     );
@@ -140,11 +140,8 @@ fn test_struct() {
     assert_eq!(
         List::ty(),
         TypeInner::Record(vec![
-            field("head", TypeInner::Int32.into()),
-            field(
-                "tail",
-                TypeInner::Opt(TypeInner::Knot(candid::types::TypeId::of::<List>()).into()).into()
-            )
+            field!{head: TypeInner::Int32.into()},
+            field!{tail: TypeInner::Opt(TypeInner::Knot(candid::types::TypeId::of::<List>()).into()).into()}
         ])
         .into()
     );
@@ -165,24 +162,23 @@ fn test_variant() {
     assert_eq!(
         get_type(&v),
         TypeInner::Variant(vec![
-            field(
-                "Bar",
+            field! {Bar:
                 TypeInner::Record(vec![
-                    unnamed_field(0, TypeInner::Bool.into()),
-                    unnamed_field(1, TypeInner::Int32.into())
+                    field!{0: TypeInner::Bool.into()},
+                    field!{1: TypeInner::Int32.into()}
                 ])
                 .into()
-            ),
-            field(
-                "Baz",
+            },
+            field! {
+                Baz:
                 TypeInner::Record(vec![
-                    field("a", TypeInner::Int32.into()),
-                    field("b", TypeInner::Nat32.into())
+                    field!{a: TypeInner::Int32.into()},
+                    field!{b: TypeInner::Nat32.into()}
                 ])
                 .into()
-            ),
-            field("Foo", TypeInner::Null.into()),
-            field("Newtype", TypeInner::Bool.into()),
+            },
+            field! {Foo: TypeInner::Null.into()},
+            field! {Newtype: TypeInner::Bool.into()},
         ])
         .into()
     );
@@ -295,18 +291,4 @@ fn test_counter() {
     candid::export_service!();
     let expected = "service : { inc : () -> (); read : () -> (nat64) query }";
     assert_eq!(expected, __export_service());
-}
-
-fn field(id: &str, ty: Type) -> candid::types::Field {
-    candid::types::Field {
-        id: Label::Named(id.to_string()).into(),
-        ty,
-    }
-}
-
-fn unnamed_field(id: u32, ty: Type) -> candid::types::Field {
-    candid::types::Field {
-        id: Label::Id(id).into(),
-        ty,
-    }
 }


### PR DESCRIPTION
* Provide macros `define_function!`, `define_service!` for defining reference types. This fixes #273 
* Macros for constructing AST nodes: `service!`, `func!` and `field!`
* Add feature flags for `docs.rs`