### PR TITLE
Read didc data from stdin

### DIFF
--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -6,8 +6,9 @@ use candid::{
     Error, IDLArgs, TypeEnv,
 };
 use clap::Parser;
+use std::collections::HashSet;
+use std::io;
 use std::path::PathBuf;
-use std::{collections::HashSet, io};
 
 #[derive(Parser)]
 #[clap(version, author)]

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -6,8 +6,8 @@ use candid::{
     Error, IDLArgs, TypeEnv,
 };
 use clap::Parser;
-use std::{collections::HashSet, io};
 use std::path::PathBuf;
+use std::{collections::HashSet, io};
 
 #[derive(Parser)]
 #[clap(version, author)]
@@ -209,10 +209,13 @@ fn main() -> Result<()> {
             format,
             annotate,
         } => {
-            let args = args.unwrap_or_else(|| {
-                let text = io::read_to_string(io::stdin()).expect("Failed to read stdin");
-                parse_args(&text).expect("Failed to parse stdin.")
-            });
+            let args = match args {
+                Some(idl_args) => idl_args,
+                None => {
+                    let text = io::read_to_string(io::stdin())?;
+                    parse_args(&text)?
+                }
+            };
             let bytes = if annotate.is_empty() {
                 args.to_bytes()?
             } else {
@@ -238,9 +241,10 @@ fn main() -> Result<()> {
             format,
             annotate,
         } => {
-            let blob = blob.unwrap_or_else(|| {
-                io::read_to_string(io::stdin()).expect("Failed to read stdin")
-            });
+            let blob = match blob {
+                Some(blob) => blob,
+                None => io::read_to_string(io::stdin())?,
+            };
             let bytes = match format.as_str() {
                 "hex" => hex::decode(&blob)?,
                 "blob" => {

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -242,7 +242,7 @@ fn main() -> Result<()> {
                 io::read_to_string(io::stdin()).expect("Failed to read stdin")
             });
             let bytes = match format.as_str() {
-                "hex" => hex::decode(&blob)?,
+                "hex" => hex::decode(&blob.chars().filter(|c| !c.is_whitespace()).collect::<String>())?,
                 "blob" => {
                     use candid::types::value::IDLValue;
                     match pretty_parse::<IDLValue>("blob", &blob)? {

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -242,7 +242,7 @@ fn main() -> Result<()> {
                 io::read_to_string(io::stdin()).expect("Failed to read stdin")
             });
             let bytes = match format.as_str() {
-                "hex" => hex::decode(&blob.chars().filter(|c| !c.is_whitespace()).collect::<String>())?,
+                "hex" => hex::decode(&blob)?,
                 "blob" => {
                     use candid::types::value::IDLValue;
                     match pretty_parse::<IDLValue>("blob", &blob)? {

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -246,7 +246,12 @@ fn main() -> Result<()> {
                 None => io::read_to_string(io::stdin())?,
             };
             let bytes = match format.as_str() {
-                "hex" => hex::decode(&blob)?,
+                "hex" => hex::decode(
+                    &blob
+                        .chars()
+                        .filter(|c| !c.is_whitespace())
+                        .collect::<String>(),
+                )?,
                 "blob" => {
                     use candid::types::value::IDLValue;
                     match pretty_parse::<IDLValue>("blob", &blob)? {

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -248,8 +248,7 @@ fn main() -> Result<()> {
             };
             let bytes = match format.as_str() {
                 "hex" => hex::decode(
-                    &blob
-                        .chars()
+                    blob.chars()
                         .filter(|c| !c.is_whitespace())
                         .collect::<String>(),
                 )?,


### PR DESCRIPTION
**Overview**
`didc` fails to encode or decode large blobs because the hex is too large to pass as a command line argument.

Example:
```
$ didc decode "$(cat payload.hex)"
bash: /home/max/bin/didc: Argument list too long
$ ls -lh payload.hex 
-rw-rw-r-- 1 max max 5,7M Mai 17 11:32 payload.hex
```

**Requirements**
didc should be able to encode or decode large files.

**Considered Solutions**
The hex needs to be passed to the program but not as a command line argument.  This suggests reading input from a file.  I considered:
* Reading the data from stdin
* Reading the data from a named file

**Recommended Solution**
Read data from stdin.  Both methods work, but reading from a named file places a greater burden on a user reading from stdin, than reading from stdin for a user who wants to read from a named file.

If data is in a file, it can be read from stdin trivially:
```
didc decode < payload.hex
```
However if the input is from stdin and we are forced to read from a  named file, we have a choice of bad options:

Option 1:
```
some_pipeline | didc decode --file /dev/stdin
``` 
which is not portable across platforms.  E.g. OSX doesn't have `/dev/stdin`.

Option 2: 
```
tmpfile="$(mktemp)"
some_pipeline > "$tmpfile"
didc decode --file "$tmpfile"
rm "$tmpfile"
```
This is quite verbose and shortcuts, such as not creating a dynamic tmpfile, invite errors.

**Considerations**
I see no negative impacts.

On the positive side, didc will become more convenient to use.  Our code is full of cases where a file is catted just to pass it as an argument:
```
didc encode "$(cat "$didfile")"
```