### PR TITLE
limit size of vec null/reserved

### DIFF
--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -170,6 +170,7 @@ struct Deserializer<'de> {
     // Indicates whether to deserialize with IDLValue.
     // It only affects the field id generation in enum type.
     is_untyped: bool,
+    zero_sized_values: usize,
     #[cfg(not(target_arch = "wasm32"))]
     recursion_depth: u16,
 }
@@ -188,6 +189,7 @@ impl<'de> Deserializer<'de> {
             gamma: Gamma::default(),
             field_name: None,
             is_untyped: false,
+            zero_sized_values: 2 * 1048576,
             #[cfg(not(target_arch = "wasm32"))]
             recursion_depth: 0,
         })
@@ -252,6 +254,16 @@ impl<'de> Deserializer<'de> {
             self.wire_type = self.table.trace_type(&self.wire_type)?;
         }
         Ok(())
+    }
+    fn is_zero_sized_type(&self, t: &Type) -> bool {
+        match t.as_ref() {
+            TypeInner::Null | TypeInner::Reserved => true,
+            TypeInner::Record(fs) => fs.iter().all(|f| {
+                let t = self.table.trace_type(&f.ty).unwrap();
+                self.is_zero_sized_type(&t)
+            }),
+            _ => false,
+        }
     }
     // Should always call set_field_name to set the field_name. After deserialize_identifier
     // processed the field_name, field_name will be reset to None.
@@ -634,10 +646,11 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 let expect = e.clone();
                 let wire = w.clone();
                 let len = Len::read(&mut self.input)?.0;
-                if matches!(self.table.trace_type(w)?.as_ref(), TypeInner::Null | TypeInner::Reserved) {
-                    if len > 2 * 1048576 { // 2M message size limit
-                        return Err(Error::msg("vec null/reserved too large"));
+                if self.is_zero_sized_type(w) {
+                    if self.zero_sized_values < len {
+                        return Err(Error::msg("vec length of zero sized values too large"));
                     }
+                    self.zero_sized_values -= len;
                 }
                 visitor.visit_seq(Compound::new(self, Style::Vector { len, expect, wire }))
             }

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -189,7 +189,7 @@ impl<'de> Deserializer<'de> {
             gamma: Gamma::default(),
             field_name: None,
             is_untyped: false,
-            zero_sized_values: 2 * 1048576,
+            zero_sized_values: 2_000_000,
             #[cfg(not(target_arch = "wasm32"))]
             recursion_depth: 0,
         })

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -258,13 +258,11 @@ impl<'de> Deserializer<'de> {
     fn is_zero_sized_type(&self, t: &Type) -> bool {
         match t.as_ref() {
             TypeInner::Null | TypeInner::Reserved => true,
-            TypeInner::Record(fs) => {
-                fs.is_empty()
-                    || fs.iter().all(|f| {
-                        let t = self.table.trace_type(&f.ty).unwrap();
-                        self.is_zero_sized_type(&t)
-                    })
-            }
+            TypeInner::Record(fs) => fs.iter().all(|f| {
+                let t = self.table.trace_type(&f.ty).unwrap();
+                // recursive records have been replaced with empty already, it's safe to call without memoization.
+                self.is_zero_sized_type(&t)
+            }),
             _ => false,
         }
     }

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -258,10 +258,13 @@ impl<'de> Deserializer<'de> {
     fn is_zero_sized_type(&self, t: &Type) -> bool {
         match t.as_ref() {
             TypeInner::Null | TypeInner::Reserved => true,
-            TypeInner::Record(fs) => fs.iter().all(|f| {
-                let t = self.table.trace_type(&f.ty).unwrap();
-                self.is_zero_sized_type(&t)
-            }),
+            TypeInner::Record(fs) => {
+                fs.is_empty()
+                    || fs.iter().all(|f| {
+                        let t = self.table.trace_type(&f.ty).unwrap();
+                        self.is_zero_sized_type(&t)
+                    })
+            }
             _ => false,
         }
     }

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1229,7 +1229,7 @@ M(_ : reserved) = .
 M : <val> -> <constype> -> i8*
 M(null : opt <datatype>) = i8(0)
 M(?v   : opt <datatype>) = i8(1) M(v : <datatype>)
-M(v^N  : vec <datatype>) = leb128(N) M(v : <datatype>)^N
+M(v^N  : vec <datatype>) = leb128(N) M(v : <datatype>)^N  // N < 2097152 if <datatype> == null or reserved
 M(kv*  : record {<fieldtype>*}) = M(kv : <fieldtype>)*
 M(kv   : variant {<fieldtype>*}) = leb128(i) M(kv : <fieldtype>*[i])
 
@@ -1247,6 +1247,9 @@ M(ref(r) : principal) = i8(0)
 M(id(v*) : principal) = i8(1) M(v* : vec nat8)
 ```
 
+Note:
+
+* Since `null` and `reserved` values take no space, to prevent unbounded sized message, we limit the length of `vec null` and `vec reserved` to be less than 2MiB.
 
 #### References
 

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1249,7 +1249,7 @@ M(id(v*) : principal) = i8(1) M(v* : vec nat8)
 
 Note:
 
-* Since `null` and `reserved` values, and records of such values, take no space, to prevent unbounded sized message, we limit the total vector length of such zero-sized values in a message to be 2MiB.
+* Since `null`, `reserved`, `record {}`, and records of such values, take no space, to prevent unbounded sized message, we limit the total vector length of such zero-sized values in a message to be 2MiB.
 
 #### References
 

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1249,7 +1249,7 @@ M(id(v*) : principal) = i8(1) M(v* : vec nat8)
 
 Note:
 
-* Since `null`, `reserved`, `record {}`, and records of such values, take no space, to prevent unbounded sized message, we limit the total vector length of such zero-sized values in a message to be 2MiB. For example, if there are both `vec null` and `vec record {}` in a message, the length of both vectors combined cannot exceed 2MiB.
+* Since `null`, `reserved`, `record {}`, and records of such values, take no space, to prevent unbounded sized message, we limit the total vector length of such zero-sized values in a message to be 2,000,000 elements. For example, if a message contains two vectors, one at type `vec null` and one at type `vec record {}`, then the length of both vectors combined cannot exceed 2,000,000 elements.
 
 #### References
 

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1229,7 +1229,7 @@ M(_ : reserved) = .
 M : <val> -> <constype> -> i8*
 M(null : opt <datatype>) = i8(0)
 M(?v   : opt <datatype>) = i8(1) M(v : <datatype>)
-M(v^N  : vec <datatype>) = leb128(N) M(v : <datatype>)^N  // N < 2097152 if <datatype> == null or reserved
+M(v^N  : vec <datatype>) = leb128(N) M(v : <datatype>)^N
 M(kv*  : record {<fieldtype>*}) = M(kv : <fieldtype>)*
 M(kv   : variant {<fieldtype>*}) = leb128(i) M(kv : <fieldtype>*[i])
 
@@ -1249,7 +1249,7 @@ M(id(v*) : principal) = i8(1) M(v* : vec nat8)
 
 Note:
 
-* Since `null` and `reserved` values take no space, to prevent unbounded sized message, we limit the length of `vec null` and `vec reserved` to be less than 2MiB.
+* Since `null` and `reserved` values, and records of such values, take no space, to prevent unbounded sized message, we limit the total vector length of such zero-sized values in a message to be 2MiB.
 
 #### References
 

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1249,7 +1249,7 @@ M(id(v*) : principal) = i8(1) M(v* : vec nat8)
 
 Note:
 
-* Since `null`, `reserved`, `record {}`, and records of such values, take no space, to prevent unbounded sized message, we limit the total vector length of such zero-sized values in a message to be 2MiB.
+* Since `null`, `reserved`, `record {}`, and records of such values, take no space, to prevent unbounded sized message, we limit the total vector length of such zero-sized values in a message to be 2MiB. For example, if there are both `vec null` and `vec record {}` in a message, the length of both vectors combined cannot exceed 2MiB.
 
 #### References
 

--- a/test/construct.test.did
+++ b/test/construct.test.did
@@ -63,6 +63,8 @@ assert blob "DIDL\01\6d\00\01\00\02\00\00" == "(vec { vec {}; vec {} })"    : (v
 assert blob "DIDL\01\6d\7f\01\00\e8\07"                                     : (vec null) "vec null";
 assert blob "DIDL\01\6d\7f\01\00\80\94\eb\dc\03"                           !: (vec opt nat) "space bomb: vec null <: vec opt nat";
 assert blob "DIDL\01\6d\70\01\00\80\94\eb\dc\03"                           !: (opt nat) "space bomb: send vec reserved to opt nat";
+assert blob "DIDL\04\6c\03\01\7f\02\01\03\02\6c\01\01\70\6c\00\6d\00\01\03\80\94\eb\dc\03" !: (vec record {null;record{reserved};record{}}) "space bomb: zero-sized record";
+assert blob "DIDL\02\6d\01\6d\7f\01\00\05\ff\ff\7f\ff\ff\7f\ff\ff\7f\ff\ff\7f\ff\ff\7f"    !: (vec vec null) "space bomb: vec vec null";
 assert "(vec { 1; -1 })"                                                   !: (vec nat) "vec: type mismatch";
 assert blob "DIDL\01\6d\7c\01\00"                                          !: (vec int) "vec: too short";
 assert blob "DIDL\01\6d\7c\01\00\02\01"                                    !: (vec int) "vec: too short";

--- a/test/construct.test.did
+++ b/test/construct.test.did
@@ -60,7 +60,9 @@ assert blob "DIDL\01\6d\7b\01\00\02\01\02" == "(blob \"\\01\\02\")"         : (v
 assert blob "DIDL\01\6d\00\01\00\00" == "(vec {})"                          : (Vec) "vec: recursive vector";
 assert blob "DIDL\01\6d\00\01\00\02\00\00" == "(vec { vec {}; vec {} })"    : (Vec) "vec: tree";
 assert blob "DIDL\01\6d\00\01\00\02\00\00" == "(vec { vec {}; vec {} })"    : (vec vec opt empty) "vec: non-recursive tree";
-assert blob "DIDL\01\6d\7f\01\00\e8\07"                                     : (vec null) "vec: space bomb";
+assert blob "DIDL\01\6d\7f\01\00\e8\07"                                     : (vec null) "vec null";
+assert blob "DIDL\01\6d\7f\01\00\80\94\eb\dc\03"                           !: (vec opt nat) "space bomb: vec null <: vec opt nat";
+assert blob "DIDL\01\6d\70\01\00\80\94\eb\dc\03"                           !: (opt nat) "space bomb: send vec reserved to opt nat";
 assert "(vec { 1; -1 })"                                                   !: (vec nat) "vec: type mismatch";
 assert blob "DIDL\01\6d\7c\01\00"                                          !: (vec int) "vec: too short";
 assert blob "DIDL\01\6d\7c\01\00\02\01"                                    !: (vec int) "vec: too short";

--- a/test/construct.test.did
+++ b/test/construct.test.did
@@ -64,7 +64,7 @@ assert blob "DIDL\01\6d\7f\01\00\e8\07"                                     : (v
 assert blob "DIDL\01\6d\7f\01\00\80\94\eb\dc\03"                           !: (vec opt nat) "space bomb: vec null <: vec opt nat";
 assert blob "DIDL\01\6d\70\01\00\80\94\eb\dc\03"                           !: (opt nat) "space bomb: send vec reserved to opt nat";
 assert blob "DIDL\04\6c\03\01\7f\02\01\03\02\6c\01\01\70\6c\00\6d\00\01\03\80\94\eb\dc\03" !: (vec record {null;record{reserved};record{}}) "space bomb: zero-sized record";
-assert blob "DIDL\02\6d\01\6d\7f\01\00\05\ff\ff\7f\ff\ff\7f\ff\ff\7f\ff\ff\7f\ff\ff\7f"    !: (vec vec null) "space bomb: vec vec null";
+assert blob "DIDL\02\6d\01\6d\7f\01\00\05\ff\ff\3f\ff\ff\3f\ff\ff\3f\ff\ff\3f\ff\ff\3f"    !: (vec vec null) "space bomb: vec vec null";
 assert "(vec { 1; -1 })"                                                   !: (vec nat) "vec: type mismatch";
 assert blob "DIDL\01\6d\7c\01\00"                                          !: (vec int) "vec: too short";
 assert blob "DIDL\01\6d\7c\01\00\02\01"                                    !: (vec int) "vec: too short";


### PR DESCRIPTION
Fix #294 

Limit the total size of vec null/reserved. If null took 1 byte, the largest `vec null` we can send on the IC is 2MiB. This is probably the least breaking change we can make to the spec.