### PR TITLE
[Rust] adding more util functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,25 +1019,34 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "logos"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+checksum = "c000ca4d908ff18ac99b93a062cb8958d331c3220719c52e77cb19cc6ac5d2c1"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
-name = "logos-derive"
-version = "0.12.1"
+name = "logos-codegen"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+checksum = "dc487311295e0002e452025d6b580b77bb17286de87b57138f3b5db711cded68"
 dependencies = [
  "beef",
  "fnv",
  "proc-macro2 1.0.63",
  "quote 1.0.29",
  "regex-syntax 0.6.29",
- "syn 1.0.109",
+ "syn 2.0.22",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
+dependencies = [
+ "logos-codegen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
  "num-traits",
  "num_enum",
  "paste",
- "pretty 0.10.0",
+ "pretty 0.12.1",
  "rand",
  "serde",
  "serde_bytes",
@@ -1120,23 +1120,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 1.0.109",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1331,22 +1331,23 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9940b913ee56ddd94aec2d3cd179dd47068236f42a1a6415ccf9d880ce2a61"
-dependencies = [
- "arrayvec",
- "typed-arena",
-]
-
-[[package]]
-name = "pretty"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83f3aa1e3ca87d3b124db7461265ac176b40c277f37e503eaa29c9c75c037846"
 dependencies = [
  "arrayvec",
  "log",
+ "typed-arena",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "pretty"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563c9d701c3a31dfffaaf9ce23507ba09cbe0b9125ba176d15e629b0235e9acc"
+dependencies = [
+ "arrayvec",
  "typed-arena",
  "unicode-segmentation",
 ]

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -23,14 +23,14 @@ byteorder = "1.4.3"
 candid_derive = { path = "../candid_derive", version = "=0.6.1" }
 codespan-reporting = "0.11"
 crc32fast = "1.3.0"
-data-encoding = "2.3.2"
+data-encoding = "2.4.0"
 hex = "0.4.2"
 leb128 = "0.2.4"
-num_enum = "0.5.1"
+num_enum = "0.6.1"
 num-bigint = { version = "0.4.2", features = ["serde"] }
 num-traits = "0.2.12"
 paste = "1.0.0"
-pretty = "0.10.0"
+pretty = "0.12.0"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_bytes = "0.11"
 sha2 = "0.10.1"

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -39,7 +39,7 @@ anyhow = "1.0"
 binread = { version = "2.1", features = ["debug_template"] }
 
 lalrpop-util = { version = "0.20.0", optional = true }
-logos = { version = "0.12", optional = true }
+logos = { version = "0.13", optional = true }
 
 arbitrary = { version = "1.0", optional = true }
 # Don't upgrade serde_dhall. It will introduce dependency with invalid license.

--- a/rust/candid/src/bindings/candid.rs
+++ b/rust/candid/src/bindings/candid.rs
@@ -132,7 +132,7 @@ pub fn pp_label(id: &SharedLabel) -> RcDoc {
     }
 }
 
-fn pp_field(field: &Field, is_variant: bool) -> RcDoc {
+pub(crate) fn pp_field(field: &Field, is_variant: bool) -> RcDoc {
     let ty_doc = if is_variant && *field.ty == TypeInner::Null {
         RcDoc::nil()
     } else {
@@ -156,7 +156,7 @@ pub fn pp_function(func: &Function) -> RcDoc {
         .nest(INDENT_SPACE)
 }
 
-fn pp_args(args: &[Type]) -> RcDoc {
+pub fn pp_args(args: &[Type]) -> RcDoc {
     let doc = concat(args.iter().map(pp_ty), ",");
     enclose("(", doc, ")")
 }

--- a/rust/candid/src/parser/token.rs
+++ b/rust/candid/src/parser/token.rs
@@ -89,6 +89,7 @@ enum Comment {
 }
 
 #[derive(Logos, Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
 enum Text {
     #[regex(r#"[^\\"]+"#)]
     Text,

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -357,6 +357,15 @@ pub struct Field {
     pub id: SharedLabel,
     pub ty: Type,
 }
+impl fmt::Display for Field {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            crate::bindings::candid::pp_field(self, false).pretty(80)
+        )
+    }
+}
 #[macro_export]
 /// Construct a field type, which can be used in `TypeInner::Record` and `TypeInner::Variant`.
 ///

--- a/rust/candid/src/types/reference.rs
+++ b/rust/candid/src/types/reference.rs
@@ -36,6 +36,11 @@ macro_rules! define_function {
                 self.0.idl_serialize(serializer)
             }
         }
+        impl From<$crate::types::reference::Func> for $func {
+            fn from(v: $crate::types::reference::Func) -> Self {
+                Self(v)
+            }
+        }
         impl $func {
             pub fn new(principal: $crate::Principal, method: String) -> Self {
                 $func($crate::types::reference::Func { principal, method })
@@ -58,6 +63,11 @@ macro_rules! define_service {
             fn idl_serialize<S: $crate::types::Serializer>(&self, serializer: S) -> Result<(), S::Error>
             {
                 self.0.idl_serialize(serializer)
+            }
+        }
+        impl From<$crate::types::reference::Service> for $serv {
+            fn from(v: $crate::types::reference::Service) -> Self {
+                Self(v)
             }
         }
         impl $serv {

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -68,15 +68,31 @@ pub fn service_compatible(new: CandidSource, old: CandidSource) -> Result<()> {
 #[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 /// Check structural equality of two service types
-pub fn service_equal(new: CandidSource, old: CandidSource) -> Result<()> {
-    let (mut env, t1) = new.load()?;
-    let t1 = t1.ok_or_else(|| Error::msg("new interface has no main service type"))?;
-    let (env2, t2) = old.load()?;
-    let t2 = t2.ok_or_else(|| Error::msg("old interface has no main service type"))?;
+pub fn service_equal(left: CandidSource, right: CandidSource) -> Result<()> {
+    let (mut env, t1) = left.load()?;
+    let t1 = t1.ok_or_else(|| Error::msg("left interface has no main service type"))?;
+    let (env2, t2) = right.load()?;
+    let t2 = t2.ok_or_else(|| Error::msg("right interface has no main service type"))?;
     let mut gamma = std::collections::HashSet::new();
     let t2 = env.merge_type(env2, t2);
     crate::types::subtype::equal(&mut gamma, &env, &t1, &t2)?;
     Ok(())
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
+#[cfg(feature = "parser")]
+/// Take a did file and outputs the init args and the service type (without init args).
+/// If the original did file contains imports, the output flatens the type definitions.
+/// For now, the comments from the original did file is omitted.
+pub fn instantiate_candid(candid: CandidSource) -> Result<(Vec<Type>, (TypeEnv, Type))> {
+    use crate::types::TypeInner;
+    let (env, serv) = candid.load()?;
+    let serv = serv.ok_or_else(|| Error::msg("the Candid interface has no main service type"))?;
+    Ok(match serv.as_ref() {
+        TypeInner::Class(args, ty) => (args.clone(), (env, ty.clone())),
+        TypeInner::Service(_) => (vec![], (env, serv)),
+        _ => unreachable!(),
+    })
 }
 
 /// Encode sequence of Rust values into Candid message of type `candid::Result<Vec<u8>>`.

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -65,6 +65,20 @@ pub fn service_compatible(new: CandidSource, old: CandidSource) -> Result<()> {
     Ok(())
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
+#[cfg(feature = "parser")]
+/// Check structural equality of two service types
+pub fn service_equal(new: CandidSource, old: CandidSource) -> Result<()> {
+    let (mut env, t1) = new.load()?;
+    let t1 = t1.ok_or_else(|| Error::msg("new interface has no main service type"))?;
+    let (env2, t2) = old.load()?;
+    let t2 = t2.ok_or_else(|| Error::msg("old interface has no main service type"))?;
+    let mut gamma = std::collections::HashSet::new();
+    let t2 = env.merge_type(env2, t2);
+    crate::types::subtype::equal(&mut gamma, &env, &t1, &t2)?;
+    Ok(())
+}
+
 /// Encode sequence of Rust values into Candid message of type `candid::Result<Vec<u8>>`.
 #[macro_export]
 macro_rules! Encode {

--- a/rust/candid/tests/assets/ok/comment.mo
+++ b/rust/candid/tests/assets/ok/comment.mo
@@ -3,5 +3,5 @@
 
 module {
   public type id = Nat8;
-  
+
 }

--- a/rust/candid/tests/assets/ok/unicode.did
+++ b/rust/candid/tests/assets/ok/unicode.did
@@ -1,9 +1,4 @@
-type A = record {
-  "\u{e000}" : nat;
-  "📦🍦" : nat;
-  "字段名" : nat;
-  "字 段 名2" : nat;
-};
+type A = record { "\u{e000}" : nat; "📦🍦" : nat; "字段名" : nat; "字 段 名2" : nat };
 type B = variant { ""; "空的"; "  空的  "; "1⃣️2⃣️3⃣️" };
 service : {
   "" : (nat) -> (nat);


### PR DESCRIPTION
* `candid::utils::service_equal`: check if two types are structurally equal under variable renaming
* `impl From<Func/Service>` trait for `define_function/define_service` macro
* `utils::instantiate_candid` generate metadata from did file: separate init args, flatten imports.
* bump dependencies