### PR TITLE
make the field `zero_sized_values` in `candid::de::Config` public

### DIFF
--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -108,7 +108,7 @@ impl<'de> IDLDeserialize<'de> {
 }
 
 pub struct Config {
-    zero_sized_values: usize,
+    pub zero_sized_values: usize,
 }
 
 macro_rules! assert {


### PR DESCRIPTION
This PR makes the field `zero_sized_values` in `candid::de::Config` public so that its value can actually be set when creating a `Config` to be used in `IDLDeserialize::new_with_config`.