### PR TITLE
Add missing idlFactory export in TypeScript declarations

### DIFF
--- a/rust/candid/src/bindings/typescript.rs
+++ b/rust/candid/src/bindings/typescript.rs
@@ -178,12 +178,15 @@ fn pp_actor<'a>(env: &'a TypeEnv, ty: &'a Type) -> RcDoc<'a> {
 pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {
     let header = r#"import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 "#;
     let def_list: Vec<_> = env.0.iter().map(|pair| pair.0.as_ref()).collect();
     let defs = pp_defs(env, &def_list);
     let actor = match actor {
         None => RcDoc::nil(),
-        Some(actor) => pp_actor(env, actor),
+        Some(actor) => pp_actor(env, actor)
+            .append(RcDoc::line())
+            .append("export declare const idlFactory: IDL.InterfaceFactory;"),
     };
     let doc = RcDoc::text(header)
         .append(RcDoc::line())

--- a/rust/candid/tests/assets/ok/actor.d.ts
+++ b/rust/candid/tests/assets/ok/actor.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export type f = ActorMethod<[number], number>;
 export type g = f;
@@ -11,3 +12,4 @@ export interface _SERVICE {
   'h' : g,
   'o' : ActorMethod<[o], o>,
 }
+export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid/tests/assets/ok/class.d.ts
+++ b/rust/candid/tests/assets/ok/class.d.ts
@@ -1,8 +1,10 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export type List = [] | [[bigint, List]];
 export interface _SERVICE {
   'get' : ActorMethod<[], List>,
   'set' : ActorMethod<[List], List>,
 }
+export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid/tests/assets/ok/comment.d.ts
+++ b/rust/candid/tests/assets/ok/comment.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export type id = number;
 

--- a/rust/candid/tests/assets/ok/cyclic.d.ts
+++ b/rust/candid/tests/assets/ok/cyclic.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export type A = [] | [B];
 export type B = [] | [C];
@@ -8,3 +9,4 @@ export type X = Y;
 export type Y = Z;
 export type Z = A;
 export interface _SERVICE { 'f' : ActorMethod<[A, B, C, X, Y, Z], undefined> }
+export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid/tests/assets/ok/escape.d.ts
+++ b/rust/candid/tests/assets/ok/escape.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export interface t {
   '\"' : bigint,
@@ -8,3 +9,4 @@ export interface t {
   '\\\n\'\"' : bigint,
 }
 export interface _SERVICE { '\n\'\"\'\'\"\"\r\t' : ActorMethod<[t], undefined> }
+export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid/tests/assets/ok/example.d.ts
+++ b/rust/candid/tests/assets/ok/example.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export type A = B;
 export type B = [] | [A];
@@ -46,3 +47,4 @@ export interface _SERVICE {
   'i' : f,
   'x' : ActorMethod<[a, b], [[] | [a], [] | [b]]>,
 }
+export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid/tests/assets/ok/fieldnat.d.ts
+++ b/rust/candid/tests/assets/ok/fieldnat.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export interface non_tuple { _1_ : string, _2_ : string }
 export type tuple = [string, string];
@@ -12,3 +13,4 @@ export interface _SERVICE {
   'bib' : ActorMethod<[[bigint]], { _0_ : bigint }>,
   'foo' : ActorMethod<[{ _2_ : bigint }], { _2_ : bigint, '_2' : bigint }>,
 }
+export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid/tests/assets/ok/keyword.d.ts
+++ b/rust/candid/tests/assets/ok/keyword.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export type if_ = {
     'branch' : { 'val' : bigint, 'left' : if_, 'right' : if_ }
@@ -30,3 +31,4 @@ export interface _SERVICE {
     undefined
   >,
 }
+export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid/tests/assets/ok/management.d.ts
+++ b/rust/candid/tests/assets/ok/management.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export type bitcoin_address = string;
 export type bitcoin_network = { 'mainnet' : null } |
@@ -170,3 +171,4 @@ export interface _SERVICE {
     undefined
   >,
 }
+export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid/tests/assets/ok/recursion.d.ts
+++ b/rust/candid/tests/assets/ok/recursion.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export type A = B;
 export type B = [] | [A];
@@ -13,3 +14,4 @@ export type tree = {
   } |
   { 'leaf' : bigint };
 export interface _SERVICE extends s {}
+export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid/tests/assets/ok/recursive_class.d.ts
+++ b/rust/candid/tests/assets/ok/recursive_class.d.ts
@@ -1,5 +1,7 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export interface s { 'next' : ActorMethod<[], Principal> }
 export interface _SERVICE extends s {}
+export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid/tests/assets/ok/service.d.ts
+++ b/rust/candid/tests/assets/ok/service.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export type Func = ActorMethod<[], Principal>;
 export interface Service { 'f' : Func }
@@ -17,3 +18,4 @@ export interface _SERVICE {
       { 'b' : { 'f' : [] | [[Principal, string]] } }
   >,
 }
+export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid/tests/assets/ok/unicode.d.ts
+++ b/rust/candid/tests/assets/ok/unicode.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export interface A {
   '\u{e000}' : bigint,
@@ -17,3 +18,4 @@ export interface _SERVICE {
   '函数名' : ActorMethod<[A], B>,
   '👀' : ActorMethod<[bigint], bigint>,
 }
+export declare const idlFactory: IDL.InterfaceFactory;


### PR DESCRIPTION
**Overview**
When generating types from Candid for JavaScript an `idlFactory` is created, for example:
```js
export const idlFactory = ({ IDL }) => {
  const Time = IDL.Int;
  return IDL.Service({ 'get' : IDL.Func([], [Time], ['query']) });
};
export const init = ({ IDL }) => { return []; };
```

There is no corresponding `idlFactory` in the TypeScript output though:
```ts
import type { Principal } from '@dfinity/principal';
import type { ActorMethod } from '@dfinity/agent';

export type Time = bigint;
export interface _SERVICE { 'get' : ActorMethod<[], Time> }
```

This prevents TypeScript clients from importing the `idlFactory` in a type-safe way.

**Requirements**
TypeScript clients can import `idlFactory` in a type-safe way.

**Considered Solutions**
I have been creating my own "shim" files like this:
```ts
import { IDL } from '@dfinity/candid';

export { _SERVICE } from '../../declarations/clock.did';
export declare const idlFactory: IDL.InterfaceFactory;
```

This works fine, but it would be nice to have this integrated into `didc` and eventually `dfx` so that these shims are no longer necessary.

**Recommended Solution**
I recommend integrating my suggested change on this PR so that workarounds are not necessary in developer projects.

**Considerations**
This change should not have any impact on security or performance. The changes are backwards compatible so nothing will break for end users and there should be minimal maintenance costs for this change.