### PR TITLE
feat: Make it easy to convert data to IDLValue and candid text format

### DIFF
--- a/rust/candid/src/types/value.rs
+++ b/rust/candid/src/types/value.rs
@@ -1,6 +1,6 @@
 use crate::types::number::{Int, Nat};
 use crate::types::{Field, Label, Type, TypeEnv, TypeInner};
-use crate::{Error, Result};
+use crate::{CandidType, Decode, Encode, Error, Result};
 use serde::de;
 use serde::de::{Deserialize, Visitor};
 use std::collections::HashMap;
@@ -334,6 +334,32 @@ impl IDLValue {
             }
         }
         .into()
+    }
+
+    /// Converts data that implements [`CandidType`] into an [`IDLValue`].
+    ///
+    /// # Example: Convert data to candid text format
+    /// ```
+    /// # use candid::{CandidType, IDLValue};
+    /// #[derive(CandidType)]
+    /// struct MyStruct {
+    ///    a: u8,
+    ///   b: String,
+    /// }
+    /// let my_struct = MyStruct { a: 42, b: "hello".to_string() };
+    /// let idl_value = IDLValue::try_from_candid_type(&my_struct).unwrap();
+    /// let expected_text = "record { a = 42 : nat8; b = \"hello\" }";
+    /// let actual_text = idl_value.to_string();
+    /// assert_eq!(expected_text, actual_text);
+    /// ```
+    pub fn try_from_candid_type<T>(data: &T) -> Result<Self>
+    where
+        T: CandidType,
+    {
+        let blob = Encode!(data)?;
+        let parsed: IDLValue = Decode!(&blob, IDLValue)?;
+        let annotated: IDLValue = parsed.annotate_type(false, &TypeEnv::default(), &T::ty())?;
+        Ok(annotated)
     }
 }
 

--- a/rust/candid/src/types/value.rs
+++ b/rust/candid/src/types/value.rs
@@ -1,6 +1,6 @@
 use crate::types::number::{Int, Nat};
 use crate::types::{Field, Label, Type, TypeEnv, TypeInner};
-use crate::{CandidType, Decode, Encode, Error, Result};
+use crate::{CandidType, Error, Result};
 use serde::de;
 use serde::de::{Deserialize, Visitor};
 use std::collections::HashMap;
@@ -356,10 +356,10 @@ impl IDLValue {
     where
         T: CandidType,
     {
+        use crate::Encode;
         let blob = Encode!(data)?;
-        let parsed: IDLValue = Decode!(&blob, IDLValue)?;
-        let annotated: IDLValue = parsed.annotate_type(false, &TypeEnv::default(), &T::ty())?;
-        Ok(annotated)
+        let args = IDLArgs::from_bytes_with_types(&blob, &TypeEnv::default(), &[T::ty()])?;
+        Ok(args.args[0].clone())
     }
 }
 


### PR DESCRIPTION
**Overview**
It is not well documented how to convert types that implement `CandidType` into an `IDLValue`.

**Requirements**
It is easy to convert instances of Rust types into `IDLValues` using the best available method.

**Considered Solutions**
- Provide a Candid library method for the conversion. (implemented in this PR)
- Document the current approach.  However the current approach seems inefficient  and can probably be improved.

**Recommended Solution**
Provide a library method for converting data to Candid.

The current method - serializing and parsing - can probably be improved greatly, so it seems preferable to offer a conversion method in the candid library and then improve that method rather than document a method that is sub-optimal and then expect developers to update their code when a better method is documented.

**Considerations**
- I think that this will have no negative influence on performance.
- This makes conversion of data to text-format candid a one-liner:  `IDLValue::try_from_candid_type(data).unwrap().to_string()`