### PR TITLE
Make candid max length public

### DIFF
--- a/rust/ic_principal/src/lib.rs
+++ b/rust/ic_principal/src/lib.rs
@@ -97,7 +97,7 @@ pub struct Principal {
 }
 
 impl Principal {
-    const MAX_LENGTH_IN_BYTES: usize = 29;
+    pub const MAX_LENGTH_IN_BYTES: usize = 29;
     const CRC_LENGTH_IN_BYTES: usize = 4;
 
     const SELF_AUTHENTICATING_TAG: u8 = 2;


### PR DESCRIPTION
I just to hard-code `PRINCIPAL_MAX_LENGTH` in my code for the second time this year. It would be very convenient to have access to this const through the type itself.