### PR TITLE
Add Candid assist feature in candid_parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
  "codespan-reporting",
  "console",
  "convert_case",
+ "ctrlc",
  "dialoguer",
  "fake",
  "goldenfile",
@@ -565,6 +566,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
+dependencies = [
+ "nix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1104,6 +1115,17 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "nom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "candid"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "candid_parser"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "didc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "candid_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,7 +625,6 @@ dependencies = [
  "shell-words",
  "tempfile",
  "thiserror",
- "zeroize",
 ]
 
 [[package]]
@@ -2279,9 +2278,3 @@ name = "yansi"
 version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
-
-[[package]]
-name = "zeroize"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,9 @@ dependencies = [
  "arbitrary",
  "candid",
  "codespan-reporting",
+ "console",
  "convert_case",
+ "dialoguer",
  "fake",
  "goldenfile",
  "hex",
@@ -450,6 +452,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "unicode-width",
  "windows-sys 0.45.0",
 ]
 
@@ -610,6 +613,19 @@ dependencies = [
  "proc-macro2 1.0.70",
  "quote 1.0.33",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -1650,6 +1666,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "similar"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,3 +2279,9 @@ name = "yansi"
 version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,13 +1,27 @@
 
 # Changelog
 
+## 2023-01-03
+
+### Candid 0.10.2
+
+* Fix display `IDLValue::Blob` to allow "\n\t" in ascii characters.
+
+### candid_parser 0.1.2
+
+* Add an "assist" feature. Given a type, construct Candid value in the terminal with interactive dialogue.
+
+### didc 0.3.6
+
+* Add `didc assist` command.
+* Fix `didc decode --format blob`.
+
 ## 2023-12-15
 
 ### Candid 0.10.1
 
 * Add `candid::types::value::try_from_candid_type` to convert Rust type to `IDLValue`.
 * Display `IDLValue::Blob` in ascii character only when the whole blob are ascii characters.
-
 
 ### candid_parser 0.1.1
 

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -373,11 +373,7 @@ impl<'de> Deserializer<'de> {
         let mut bytes = vec![0u8];
         let int = match self.wire_type.as_ref() {
             TypeInner::Int => Int::decode(&mut self.input).map_err(Error::msg)?,
-            TypeInner::Nat => Int(Nat::decode(&mut self.input)
-                .map_err(Error::msg)?
-                .0
-                .try_into()
-                .map_err(Error::msg)?),
+            TypeInner::Nat => Int(Nat::decode(&mut self.input).map_err(Error::msg)?.0.into()),
             t => return Err(Error::subtype(format!("{t} cannot be deserialized to int"))),
         };
         bytes.extend_from_slice(&int.0.to_signed_bytes_le());

--- a/rust/candid/src/error.rs
+++ b/rust/candid/src/error.rs
@@ -14,7 +14,7 @@ pub struct Label {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("binary parser error: {}", .0.get(0).map_or_else(|| "io error".to_string(), |f| format!("{} at byte offset {}", f.message, f.pos/2)))]
+    #[error("binary parser error: {}", .0.first().map_or_else(|| "io error".to_string(), |f| format!("{} at byte offset {}", f.message, f.pos/2)))]
     Binread(Vec<Label>),
 
     #[error("Subtyping error: {0}")]

--- a/rust/candid/src/pretty/candid.rs
+++ b/rust/candid/src/pretty/candid.rs
@@ -340,7 +340,9 @@ pub mod value {
                 Opt(v) => write!(f, "opt {v:?}"),
                 Blob(b) => {
                     write!(f, "blob \"")?;
-                    let is_ascii = b.iter().all(|c| (0x20u8..=0x7eu8).contains(c));
+                    let is_ascii = b
+                        .iter()
+                        .all(|c| (0x20u8..=0x7eu8).contains(c) || [0x09, 0x0a, 0x0d].contains(c));
                     if is_ascii {
                         for v in b.iter() {
                             write!(f, "{}", pp_char(*v))?;

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -316,7 +316,7 @@ impl fmt::Display for TypeInner {
         write!(f, "{:?}", self)
     }
 }
-pub(crate) fn text_size(t: &Type, limit: i32) -> Result<i32, ()> {
+pub fn text_size(t: &Type, limit: i32) -> Result<i32, ()> {
     use TypeInner::*;
     if limit <= 1 {
         return Err(());

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -316,6 +316,7 @@ impl fmt::Display for TypeInner {
         write!(f, "{:?}", self)
     }
 }
+#[allow(clippy::result_unit_err)]
 pub fn text_size(t: &Type, limit: i32) -> Result<i32, ()> {
     use TypeInner::*;
     if limit <= 1 {

--- a/rust/candid/src/types/subtype.rs
+++ b/rust/candid/src/types/subtype.rs
@@ -110,7 +110,7 @@ fn subtype_(
             Ok(())
         }
         (Service(ms1), Service(ms2)) => {
-            let meths: HashMap<_, _> = ms1.iter().map(|(name, ty)| (name, ty)).collect();
+            let meths: HashMap<_, _> = ms1.iter().cloned().collect();
             for (name, ty2) in ms2 {
                 match meths.get(name) {
                     Some(ty1) => subtype_(report, gamma, env, ty1, ty2).with_context(|| {

--- a/rust/candid_derive/src/func.rs
+++ b/rust/candid_derive/src/func.rs
@@ -50,7 +50,7 @@ pub(crate) fn candid_method(attrs: Vec<Meta>, fun: ItemFn) -> Result<TokenStream
         ));
     }
     if attrs.is_init {
-        match (rets.len(), rets.get(0).map(|x| x.as_str())) {
+        match (rets.len(), rets.first().map(|x| x.as_str())) {
             (0, None) | (1, Some("Self")) => {
                 if let Some(init) = INIT.lock().unwrap().as_mut() {
                     *init = Some(args);

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -39,6 +39,7 @@ num-traits = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 dialoguer = { version = "0.11", default-features = false, features = ["editor", "completion"], optional = true }
 console = { version = "0.15", optional = true }
+ctrlc = { version = "3.4", optional = true }
 
 [dev-dependencies]
 goldenfile = "1.1.0"
@@ -48,7 +49,7 @@ rand.workspace = true
 [features]
 configs = ["serde_dhall"]
 random = ["configs", "arbitrary", "fake", "rand", "num-traits", "serde"]
-assist = ["dep:dialoguer", "dep:console"]
+assist = ["dep:dialoguer", "dep:console", "dep:ctrlc"]
 all = ["random", "assist"]
 
 # docs.rs-specific configuration

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid_parser"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer. This crate contains the parser and the binding generator for Candid."

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -37,7 +37,7 @@ fake = { version = "2.4", optional = true }
 rand = { version = "0.8", optional = true }
 num-traits = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-dialoguer = { version = "0.11", optional = true }
+dialoguer = { version = "0.11", default-features = false, features = ["editor", "completion"], optional = true }
 console = { version = "0.15", optional = true }
 
 [dev-dependencies]

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -37,7 +37,8 @@ fake = { version = "2.4", optional = true }
 rand = { version = "0.8", optional = true }
 num-traits = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-
+dialoguer = { version = "0.11", optional = true }
+console = { version = "0.15", optional = true }
 
 [dev-dependencies]
 goldenfile = "1.1.0"
@@ -47,7 +48,8 @@ rand.workspace = true
 [features]
 configs = ["serde_dhall"]
 random = ["configs", "arbitrary", "fake", "rand", "num-traits", "serde"]
-all = ["random"]
+assist = ["dep:dialoguer", "dep:console"]
+all = ["random", "assist"]
 
 # docs.rs-specific configuration
 # To test locally: RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features all

--- a/rust/candid_parser/src/assist.rs
+++ b/rust/candid_parser/src/assist.rs
@@ -1,0 +1,253 @@
+use anyhow::Result;
+use candid::types::{
+    internal::text_size,
+    value::{IDLField, IDLValue, VariantValue},
+    Type, TypeEnv, TypeInner,
+};
+use candid::{IDLArgs, Int, Nat, Principal};
+use dialoguer::{theme::ColorfulTheme, Confirm, Editor, Input, Select};
+
+fn show_type(ty: &Type) -> String {
+    if text_size(ty, 80).is_ok() {
+        format!(" : {ty}")
+    } else {
+        String::new()
+    }
+}
+
+/// Ask for user input from terminal based on the provided Candid types. A textual version of Candid UI.
+pub fn input_args(env: &TypeEnv, tys: &[Type]) -> Result<IDLArgs> {
+    let len = tys.len();
+    let mut args = Vec::new();
+    for (i, ty) in tys.iter().enumerate() {
+        println!("Enter argument {} of {}:", i + 1, len);
+        let val = input(env, ty)?;
+        args.push(val);
+    }
+    Ok(IDLArgs { args })
+}
+
+/// Ask for user input from terminal based on the provided Candid type. A textual version of Candid UI.
+pub fn input(env: &TypeEnv, ty: &Type) -> Result<IDLValue> {
+    let theme = ColorfulTheme::default();
+    let style = console::Style::new().bright().green();
+    Ok(match ty.as_ref() {
+        TypeInner::Reserved => IDLValue::Reserved,
+        TypeInner::Null => IDLValue::Null,
+        TypeInner::Knot(_) | TypeInner::Unknown | TypeInner::Future | TypeInner::Class(_, _) => {
+            unreachable!()
+        }
+        TypeInner::Empty => unreachable!(),
+        TypeInner::Var(id) => {
+            let t = env.rec_find_type(id)?;
+            println!("Enter a value for {}{}", style.apply_to(id), show_type(t));
+            input(env, t)?
+        }
+        TypeInner::Bool => {
+            let v = Select::with_theme(&theme)
+                .with_prompt("Select a bool")
+                .items(&["false", "true"])
+                .interact()?;
+            IDLValue::Bool(v == 1)
+        }
+        TypeInner::Int => IDLValue::Int(
+            Input::<Int>::with_theme(&theme)
+                .with_prompt("Enter an int")
+                .interact_text()?,
+        ),
+        TypeInner::Nat => IDLValue::Nat(
+            Input::<Nat>::with_theme(&theme)
+                .with_prompt("Enter a nat")
+                .interact_text()?,
+        ),
+        TypeInner::Nat8 => IDLValue::Nat8(
+            Input::<u8>::with_theme(&theme)
+                .with_prompt("Enter a nat8")
+                .interact_text()?,
+        ),
+        TypeInner::Nat16 => IDLValue::Nat16(
+            Input::<u16>::with_theme(&theme)
+                .with_prompt("Enter a nat16")
+                .interact_text()?,
+        ),
+        TypeInner::Nat32 => IDLValue::Nat32(
+            Input::<u32>::with_theme(&theme)
+                .with_prompt("Enter a nat32")
+                .interact_text()?,
+        ),
+        TypeInner::Nat64 => IDLValue::Nat64(
+            Input::<u64>::with_theme(&theme)
+                .with_prompt("Enter a nat64")
+                .interact_text()?,
+        ),
+        TypeInner::Int8 => IDLValue::Int8(
+            Input::<i8>::with_theme(&theme)
+                .with_prompt("Enter an int8")
+                .interact_text()?,
+        ),
+        TypeInner::Int16 => IDLValue::Int16(
+            Input::<i16>::with_theme(&theme)
+                .with_prompt("Enter an int16")
+                .interact_text()?,
+        ),
+        TypeInner::Int32 => IDLValue::Int32(
+            Input::<i32>::with_theme(&theme)
+                .with_prompt("Enter an int32")
+                .interact_text()?,
+        ),
+        TypeInner::Int64 => IDLValue::Int64(
+            Input::<i64>::with_theme(&theme)
+                .with_prompt("Enter an int64")
+                .interact_text()?,
+        ),
+        TypeInner::Float32 => IDLValue::Float32(
+            Input::<f32>::with_theme(&theme)
+                .with_prompt("Enter a float32")
+                .interact_text()?,
+        ),
+        TypeInner::Float64 => IDLValue::Float64(
+            Input::<f64>::with_theme(&theme)
+                .with_prompt("Enter a float64")
+                .interact_text()?,
+        ),
+        TypeInner::Text => {
+            let text = Input::<String>::with_theme(&theme)
+                .allow_empty(true)
+                .with_prompt("Enter a text (type :editor to use editor)")
+                .interact()?;
+            let text = if text == ":editor" {
+                if let Some(rv) = Editor::new().edit("Enter your text")? {
+                    rv
+                } else {
+                    String::new()
+                }
+            } else {
+                text
+            };
+            IDLValue::Text(text)
+        }
+        TypeInner::Opt(ty) => {
+            let yes = Confirm::with_theme(&theme)
+                .with_prompt("Do you want to enter an optional value?")
+                .interact()?;
+            if yes {
+                let val = input(env, ty)?;
+                IDLValue::Opt(Box::new(val))
+            } else {
+                IDLValue::None
+            }
+        }
+        TypeInner::Vec(_) if ty.is_blob(env) => {
+            let mode = Select::with_theme(&theme)
+                .with_prompt("Select a way to enter blob")
+                .default(0)
+                .items(&["blob", "hex", "file"])
+                .interact()?;
+            let blob = match mode {
+                0 => {
+                    use crate::parse_idl_value;
+                    let raw = Input::<String>::with_theme(&theme)
+                        .with_prompt("Enter a blob (characters or \\xx)")
+                        .allow_empty(true)
+                        .interact()?;
+                    let raw = format!("blob \"{}\"", raw);
+                    if let IDLValue::Blob(blob) = parse_idl_value(&raw)? {
+                        blob
+                    } else {
+                        Vec::new()
+                    }
+                }
+                1 => {
+                    let blob = Input::<String>::with_theme(&theme)
+                        .with_prompt("Enter hex string")
+                        .allow_empty(true)
+                        .validate_with(|s: &String| {
+                            if s.len() % 2 == 0 && s.chars().all(|c| c.is_ascii_hexdigit()) {
+                                Ok(())
+                            } else {
+                                Err("Invalid hex string")
+                            }
+                        })
+                        .interact_text()?;
+                    hex::decode(blob)?
+                }
+                2 => Input::<String>::with_theme(&theme) // TODO
+                    .with_prompt("Enter a file path")
+                    .interact()?
+                    .into_bytes(),
+                _ => unreachable!(),
+            };
+            IDLValue::Blob(blob)
+        }
+        TypeInner::Vec(ty) => {
+            let mut vals = Vec::new();
+            loop {
+                let yes = Confirm::with_theme(&theme)
+                    .with_prompt("Do you want to enter a new vector element?")
+                    .interact()?;
+                if yes {
+                    let val = input(env, ty)?;
+                    vals.push(val);
+                } else {
+                    break;
+                }
+            }
+            IDLValue::Vec(vals)
+        }
+        TypeInner::Record(fs) => {
+            let mut fields = Vec::new();
+            for f in fs.iter() {
+                let name = style.apply_to(format!("{}", f.id));
+                let val = if let TypeInner::Opt(ty) = f.ty.as_ref() {
+                    let prompt = format!("Enter optional field {name}{}?", show_type(&f.ty));
+                    let yes = Confirm::with_theme(&theme).with_prompt(prompt).interact()?;
+                    if yes {
+                        IDLValue::Opt(Box::new(input(env, ty)?))
+                    } else {
+                        IDLValue::None
+                    }
+                } else {
+                    println!("Enter field {name}{}", show_type(&f.ty));
+                    input(env, &f.ty)?
+                };
+                fields.push(IDLField {
+                    id: (*f.id).clone(),
+                    val,
+                });
+            }
+            IDLValue::Record(fields)
+        }
+        TypeInner::Variant(fs) => {
+            let tags: Vec<_> = fs.iter().map(|f| format!("{}", f.id)).collect();
+            let idx = Select::with_theme(&theme)
+                .with_prompt("Select a variant")
+                .items(&tags)
+                .interact()?;
+            let val = input(env, &fs[idx].ty)?;
+            let field = IDLField {
+                id: (*fs[idx].id).clone(),
+                val,
+            };
+            IDLValue::Variant(VariantValue(Box::new(field), idx as u64))
+        }
+        TypeInner::Principal => IDLValue::Principal(
+            Input::<Principal>::with_theme(&theme)
+                .with_prompt("Enter a principal")
+                .interact()?,
+        ),
+        TypeInner::Service(_) => IDLValue::Service(
+            Input::<Principal>::with_theme(&theme)
+                .with_prompt("Enter a canister id")
+                .interact()?,
+        ),
+        TypeInner::Func(_) => {
+            let id = Input::<Principal>::with_theme(&theme)
+                .with_prompt("Enter a canister id")
+                .interact()?;
+            let method = Input::<String>::with_theme(&theme)
+                .with_prompt("Enter a method name")
+                .interact()?;
+            IDLValue::Func(id, method)
+        }
+    })
+}

--- a/rust/candid_parser/src/assist.rs
+++ b/rust/candid_parser/src/assist.rs
@@ -48,7 +48,7 @@ pub fn input(env: &TypeEnv, ty: &Type) -> Result<IDLValue> {
         TypeInner::Knot(_) | TypeInner::Unknown | TypeInner::Future | TypeInner::Class(_, _) => {
             unreachable!()
         }
-        TypeInner::Empty => unreachable!(),
+        TypeInner::Empty => unreachable!(), // TODO: proactively avoid empty
         TypeInner::Var(id) => {
             let t = env.rec_find_type(id)?;
             println!("Enter a value for {}{}", style.apply_to(id), show_type(t));
@@ -184,7 +184,7 @@ pub fn input(env: &TypeEnv, ty: &Type) -> Result<IDLValue> {
                             if Path::new(s).exists() {
                                 Ok(())
                             } else {
-                                Err("file doesn't exist")
+                                Err("File doesn't exist")
                             }
                         })
                         .interact()?;

--- a/rust/candid_parser/src/assist.rs
+++ b/rust/candid_parser/src/assist.rs
@@ -45,10 +45,10 @@ impl Context {
 /// Ask for user input from terminal based on the provided Candid types. A textual version of Candid UI.
 pub fn input_args(ctx: &Context, tys: &[Type]) -> Result<IDLArgs> {
     // Patch ctrlc untill https://github.com/console-rs/dialoguer/issues/77 is fixed
-    ctrlc::set_handler(move || {
+    let _ = ctrlc::try_set_handler(move || {
         let term = console::Term::stdout();
         let _ = term.show_cursor();
-    })?;
+    });
     let len = tys.len();
     let mut args = Vec::new();
     for (i, ty) in tys.iter().enumerate() {

--- a/rust/candid_parser/src/assist.rs
+++ b/rust/candid_parser/src/assist.rs
@@ -44,6 +44,11 @@ impl Context {
 
 /// Ask for user input from terminal based on the provided Candid types. A textual version of Candid UI.
 pub fn input_args(ctx: &Context, tys: &[Type]) -> Result<IDLArgs> {
+    // Patch ctrlc untill https://github.com/console-rs/dialoguer/issues/77 is fixed
+    ctrlc::set_handler(move || {
+        let term = console::Term::stdout();
+        let _ = term.show_cursor();
+    })?;
     let len = tys.len();
     let mut args = Vec::new();
     for (i, ty) in tys.iter().enumerate() {

--- a/rust/candid_parser/src/lib.rs
+++ b/rust/candid_parser/src/lib.rs
@@ -133,6 +133,9 @@ pub use typing::{check_file, check_prog, pretty_check_file};
 pub use candid;
 pub use candid::*;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "assist")))]
+#[cfg(feature = "assist")]
+pub mod assist;
 #[cfg_attr(docsrs, doc(cfg(feature = "configs")))]
 #[cfg(feature = "configs")]
 pub mod configs;

--- a/tools/didc/Cargo.toml
+++ b/tools/didc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didc"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["DFINITY Team"]
 edition = "2021"
 
@@ -8,6 +8,7 @@ edition = "2021"
 candid_parser = { path = "../../rust/candid_parser", features = ["all"] }
 clap = { version = "4.3", features = ["derive"] }
 pretty-hex = "0.2.1"
-hex = "0.4.2"
-anyhow = "1.0.32"
-rand = "0.8"
+hex.workspace = true
+anyhow.workspace = true
+rand.workspace = true
+

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -66,6 +66,11 @@ enum Command {
         #[clap(flatten)]
         annotate: TypeAnnotation,
     },
+    /// Generate textual Candid values based on a terminal dialog
+    Assist {
+        #[clap(flatten)]
+        annotate: TypeAnnotation,
+    },
     /// Generate random Candid values
     Random {
         #[clap(flatten)]
@@ -230,6 +235,11 @@ fn main() -> Result<()> {
         Command::Hash { input } => {
             println!("{}", candid_parser::idl_hash(&input));
         }
+        Command::Assist { annotate } => {
+            let (env, types) = annotate.get_types(Mode::Encode)?;
+            let args = candid_parser::assist::input_args(&env, &types)?;
+            println!("{args}");
+        }
         Command::Encode {
             args,
             format,
@@ -282,16 +292,7 @@ fn main() -> Result<()> {
                         let _ = pretty_diagnose("blob", &blob, &e);
                         e
                     })? {
-                        IDLValue::Vec(vec) => vec
-                            .iter()
-                            .map(|v| {
-                                if let IDLValue::Nat8(u) = v {
-                                    *u
-                                } else {
-                                    unreachable!()
-                                }
-                            })
-                            .collect(),
+                        IDLValue::Blob(blob) => blob,
                         _ => unreachable!(),
                     }
                 }

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -236,8 +236,10 @@ fn main() -> Result<()> {
             println!("{}", candid_parser::idl_hash(&input));
         }
         Command::Assist { annotate } => {
+            use candid_parser::assist::{input_args, Context};
             let (env, types) = annotate.get_types(Mode::Encode)?;
-            let args = candid_parser::assist::input_args(&env, &types)?;
+            let ctx = Context::new(env);
+            let args = input_args(&ctx, &types)?;
             println!("{args}");
         }
         Command::Encode {


### PR DESCRIPTION
A textual version of Candid UI: given a type, construct candid value in terminal with interactive dialogue. 
![Screenshot 2024-01-03 at 11 09 40 AM](https://github.com/dfinity/candid/assets/48968912/ad416108-1b97-43e8-a9c4-eda23cb25bb1)
