### PR TITLE
fix: add missing typescript export for init args

### DIFF
--- a/rust/candid_parser/src/bindings/typescript.rs
+++ b/rust/candid_parser/src/bindings/typescript.rs
@@ -192,7 +192,9 @@ import type { IDL } from '@dfinity/candid';
         None => RcDoc::nil(),
         Some(actor) => pp_actor(env, actor)
             .append(RcDoc::line())
-            .append("export declare const idlFactory: IDL.InterfaceFactory;"),
+            .append("export declare const idlFactory: IDL.InterfaceFactory;")
+            .append(RcDoc::line())
+            .append("export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];"),
     };
     let doc = RcDoc::text(header)
         .append(RcDoc::line())

--- a/rust/candid_parser/tests/assets/ok/actor.d.ts
+++ b/rust/candid_parser/tests/assets/ok/actor.d.ts
@@ -13,3 +13,4 @@ export interface _SERVICE {
   'o' : ActorMethod<[o], o>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/class.d.ts
+++ b/rust/candid_parser/tests/assets/ok/class.d.ts
@@ -8,3 +8,4 @@ export interface _SERVICE {
   'set' : ActorMethod<[List], List>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/cyclic.d.ts
+++ b/rust/candid_parser/tests/assets/ok/cyclic.d.ts
@@ -10,3 +10,4 @@ export type Y = Z;
 export type Z = A;
 export interface _SERVICE { 'f' : ActorMethod<[A, B, C, X, Y, Z], undefined> }
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/empty.d.ts
+++ b/rust/candid_parser/tests/assets/ok/empty.d.ts
@@ -9,3 +9,4 @@ export interface _SERVICE {
   'h' : ActorMethod<[[T, never]], { 'a' : T } | { 'b' : {} }>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/escape.d.ts
+++ b/rust/candid_parser/tests/assets/ok/escape.d.ts
@@ -10,3 +10,4 @@ export interface t {
 }
 export interface _SERVICE { '\n\'\"\'\'\"\"\r\t' : ActorMethod<[t], undefined> }
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/example.d.ts
+++ b/rust/candid_parser/tests/assets/ok/example.d.ts
@@ -51,3 +51,4 @@ export interface _SERVICE {
   'x' : ActorMethod<[a, b], [[] | [a], [] | [b]]>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/fieldnat.d.ts
+++ b/rust/candid_parser/tests/assets/ok/fieldnat.d.ts
@@ -14,3 +14,4 @@ export interface _SERVICE {
   'foo' : ActorMethod<[{ _2_ : bigint }], { _2_ : bigint, '_2' : bigint }>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/keyword.d.ts
+++ b/rust/candid_parser/tests/assets/ok/keyword.d.ts
@@ -32,3 +32,4 @@ export interface _SERVICE {
   >,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/management.d.ts
+++ b/rust/candid_parser/tests/assets/ok/management.d.ts
@@ -172,3 +172,4 @@ export interface _SERVICE {
   >,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/recursion.d.ts
+++ b/rust/candid_parser/tests/assets/ok/recursion.d.ts
@@ -15,3 +15,4 @@ export type tree = {
   { 'leaf' : bigint };
 export interface _SERVICE extends s {}
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/recursive_class.d.ts
+++ b/rust/candid_parser/tests/assets/ok/recursive_class.d.ts
@@ -5,3 +5,4 @@ import type { IDL } from '@dfinity/candid';
 export interface s { 'next' : ActorMethod<[], Principal> }
 export interface _SERVICE extends s {}
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/service.d.ts
+++ b/rust/candid_parser/tests/assets/ok/service.d.ts
@@ -19,3 +19,4 @@ export interface _SERVICE {
   >,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/unicode.d.ts
+++ b/rust/candid_parser/tests/assets/ok/unicode.d.ts
@@ -19,3 +19,4 @@ export interface _SERVICE {
   '👀' : ActorMethod<[bigint], bigint>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];


### PR DESCRIPTION
**Overview**
The JavaScript bindings generated by Candid [include an `init`](https://github.com/dfinity/candid/blob/a6cc9e6dff2b93435186424e3a530ae2d661672f/rust/candid_parser/src/bindings/javascript.rs#L262) function that can prepare the IDL object necessary to encode init args. There is no corresponding export on the TypeScript bindings so TypeScript will complain when trying to import this function.

**Requirements**
The TypeScript bindings should match the JavaScript bindings and export the `init` function.

**Considered Solutions**
This can be worked around on the developer side by adding a custom declaration file.

**Recommended Solution**
I recommend to add this to Candid's declaration generation so it's not necessary to workaround on the developer side.

**Considerations**
This will have no impact on security or performance.
It is not a breaking change because it's only adding a new exported type.
Maintenance cost should be minimal on this.
