### PR TITLE
Bump agent-js and remove workaround for Candid UI

### DIFF
--- a/tools/ui/package-lock.json
+++ b/tools/ui/package-lock.json
@@ -8,11 +8,11 @@
       "name": "ui",
       "version": "0.1.0",
       "devDependencies": {
-        "@dfinity/agent": "0.20.2",
-        "@dfinity/auth-client": "0.20.2",
-        "@dfinity/candid": "0.20.2",
-        "@dfinity/identity": "0.20.2",
-        "@dfinity/principal": "0.20.2",
+        "@dfinity/agent": "0.21.2",
+        "@dfinity/auth-client": "0.21.2",
+        "@dfinity/candid": "0.21.2",
+        "@dfinity/identity": "0.21.2",
+        "@dfinity/principal": "0.21.2",
         "buffer": "6.0.3",
         "copy-webpack-plugin": "^9.0.1",
         "css-loader": "^6.8.1",
@@ -26,10 +26,13 @@
         "webpack-cli": "4.5.0"
       }
     },
+    "../agent-js/packages/agent": {
+      "extraneous": true
+    },
     "node_modules/@dfinity/agent": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.20.2.tgz",
-      "integrity": "sha512-xy90wXH4jn3KOi1vyeZ5ji8gnUUY4Iy8k8Juk8/P/IftTDUPmgWL5uLpL3wVV1qnna418Pms1kXSFtbf8OFM0Q==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.21.2.tgz",
+      "integrity": "sha512-Ght+vXD+Uq/Z2qeskzmIMFDbBusrDCaUqaiC6Ak6YBThM3uY8m9biZ8xDCsWho5ia8HTR1o6f9wQ12ChBqsYVA==",
       "dev": true,
       "dependencies": {
         "@noble/curves": "^1.2.0",
@@ -40,37 +43,37 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.20.2",
-        "@dfinity/principal": "^0.20.2"
+        "@dfinity/candid": "^0.21.2",
+        "@dfinity/principal": "^0.21.2"
       }
     },
     "node_modules/@dfinity/auth-client": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.20.2.tgz",
-      "integrity": "sha512-HP1vTktFldkuQtv5JBQ3/IsnzV5UK3ma405jpCGYNq95kqgFEx746Ja3FrPw4x9dbAulOtu/Zc4zK9lcLv87mw==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.21.2.tgz",
+      "integrity": "sha512-t42Utd9OEEyoOLFr0/jGDD6gJzS19UNqe027AlHXhG1kZrThjBp4IHoCYDEYDX3/955TQ2/6/Oq3BMtR8mIcBQ==",
       "dev": true,
       "dependencies": {
         "idb": "^7.0.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.20.2",
-        "@dfinity/identity": "^0.20.2",
-        "@dfinity/principal": "^0.20.2"
+        "@dfinity/agent": "^0.21.2",
+        "@dfinity/identity": "^0.21.2",
+        "@dfinity/principal": "^0.21.2"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.20.2.tgz",
-      "integrity": "sha512-pBKk7J+IzX6mnyU8T35751DjDxU2c+roMyrN5UU6fhems1ciITcOm29bPhGzQEe3f8hz/K4arlVMqWTYwOrdEg==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.21.2.tgz",
+      "integrity": "sha512-/KCubIOtB8mDTxciMbzexahji5zT7sPLIS4wSlsjOiKmDnurk4ZG0EobkNYJTELy3aXaXDkKNzsbptFVqgpUMw==",
       "dev": true,
       "peerDependencies": {
-        "@dfinity/principal": "^0.20.2"
+        "@dfinity/principal": "^0.21.2"
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.20.2.tgz",
-      "integrity": "sha512-0mrbJPSva8wei8KYpybFGVD2tWfx0Jd9EJDrAuWiW++JDtZTYql2e2/8Vg5vcrGuqWLP3qMP2YC1dziJqgcUdA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.21.2.tgz",
+      "integrity": "sha512-TIRMq1Ox0Kf1d+w+41hyb+EpLPf5/rBqlKQy0LdXyumssgLDjM1Frl4vLbL9MxCw5Z39lnUQ/6b82N9AjmCIRA==",
       "dev": true,
       "dependencies": {
         "@noble/curves": "^1.2.0",
@@ -78,15 +81,15 @@
         "borc": "^2.1.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.20.2",
-        "@dfinity/principal": "^0.20.2",
+        "@dfinity/agent": "^0.21.2",
+        "@dfinity/principal": "^0.21.2",
         "@peculiar/webcrypto": "^1.4.0"
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.20.2.tgz",
-      "integrity": "sha512-xNysODrIxepNjo0ytBrpdCZOkoFCeD5zATyPDXT8tshpBeeQQlgSekDvfHqq7+DeGq9NkGfwTr8IPOmLpltKcg==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.21.2.tgz",
+      "integrity": "sha512-vOEwSkyNrDNeXy4TCHsUOk4H98yFj1DCvRuK1Hmi/dMUZ8GB5vjrQWqQhFjCO84NA6GkrDbPmuInra42kUpGtA==",
       "dev": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1"
@@ -217,17 +220,17 @@
       }
     },
     "node_modules/@peculiar/webcrypto": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
-      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.5.tgz",
+      "integrity": "sha512-oDk93QCDGdxFRM8382Zdminzs44dg3M2+E5Np+JWkpqLDyJC9DviMh8F8mEJkYuUcUOGA5jHO5AJJ10MFWdbZw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-schema": "^2.3.8",
         "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.5.0",
-        "webcrypto-core": "^1.7.7"
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2",
+        "webcrypto-core": "^1.7.8"
       },
       "engines": {
         "node": ">=10.12.0"
@@ -2712,17 +2715,17 @@
       }
     },
     "node_modules/webcrypto-core": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
-      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.8.tgz",
+      "integrity": "sha512-eBR98r9nQXTqXt/yDRtInszPMjTaSAMJAFDg2AHsgrnczawT1asx9YNBX6k5p+MekbPF4+s/UJJrr88zsTqkSg==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-schema": "^2.3.8",
         "@peculiar/json-schema": "^1.1.12",
         "asn1js": "^3.0.1",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/webpack": {
@@ -2929,9 +2932,9 @@
   },
   "dependencies": {
     "@dfinity/agent": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.20.2.tgz",
-      "integrity": "sha512-xy90wXH4jn3KOi1vyeZ5ji8gnUUY4Iy8k8Juk8/P/IftTDUPmgWL5uLpL3wVV1qnna418Pms1kXSFtbf8OFM0Q==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.21.2.tgz",
+      "integrity": "sha512-Ght+vXD+Uq/Z2qeskzmIMFDbBusrDCaUqaiC6Ak6YBThM3uY8m9biZ8xDCsWho5ia8HTR1o6f9wQ12ChBqsYVA==",
       "dev": true,
       "requires": {
         "@noble/curves": "^1.2.0",
@@ -2943,25 +2946,25 @@
       }
     },
     "@dfinity/auth-client": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.20.2.tgz",
-      "integrity": "sha512-HP1vTktFldkuQtv5JBQ3/IsnzV5UK3ma405jpCGYNq95kqgFEx746Ja3FrPw4x9dbAulOtu/Zc4zK9lcLv87mw==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.21.2.tgz",
+      "integrity": "sha512-t42Utd9OEEyoOLFr0/jGDD6gJzS19UNqe027AlHXhG1kZrThjBp4IHoCYDEYDX3/955TQ2/6/Oq3BMtR8mIcBQ==",
       "dev": true,
       "requires": {
         "idb": "^7.0.2"
       }
     },
     "@dfinity/candid": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.20.2.tgz",
-      "integrity": "sha512-pBKk7J+IzX6mnyU8T35751DjDxU2c+roMyrN5UU6fhems1ciITcOm29bPhGzQEe3f8hz/K4arlVMqWTYwOrdEg==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.21.2.tgz",
+      "integrity": "sha512-/KCubIOtB8mDTxciMbzexahji5zT7sPLIS4wSlsjOiKmDnurk4ZG0EobkNYJTELy3aXaXDkKNzsbptFVqgpUMw==",
       "dev": true,
       "requires": {}
     },
     "@dfinity/identity": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.20.2.tgz",
-      "integrity": "sha512-0mrbJPSva8wei8KYpybFGVD2tWfx0Jd9EJDrAuWiW++JDtZTYql2e2/8Vg5vcrGuqWLP3qMP2YC1dziJqgcUdA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.21.2.tgz",
+      "integrity": "sha512-TIRMq1Ox0Kf1d+w+41hyb+EpLPf5/rBqlKQy0LdXyumssgLDjM1Frl4vLbL9MxCw5Z39lnUQ/6b82N9AjmCIRA==",
       "dev": true,
       "requires": {
         "@noble/curves": "^1.2.0",
@@ -2970,9 +2973,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.20.2.tgz",
-      "integrity": "sha512-xNysODrIxepNjo0ytBrpdCZOkoFCeD5zATyPDXT8tshpBeeQQlgSekDvfHqq7+DeGq9NkGfwTr8IPOmLpltKcg==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.21.2.tgz",
+      "integrity": "sha512-vOEwSkyNrDNeXy4TCHsUOk4H98yFj1DCvRuK1Hmi/dMUZ8GB5vjrQWqQhFjCO84NA6GkrDbPmuInra42kUpGtA==",
       "dev": true,
       "requires": {
         "@noble/hashes": "^1.3.1"
@@ -3076,17 +3079,17 @@
       }
     },
     "@peculiar/webcrypto": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
-      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.5.tgz",
+      "integrity": "sha512-oDk93QCDGdxFRM8382Zdminzs44dg3M2+E5Np+JWkpqLDyJC9DviMh8F8mEJkYuUcUOGA5jHO5AJJ10MFWdbZw==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-schema": "^2.3.8",
         "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.5.0",
-        "webcrypto-core": "^1.7.7"
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2",
+        "webcrypto-core": "^1.7.8"
       }
     },
     "@types/eslint": {
@@ -4898,17 +4901,17 @@
       }
     },
     "webcrypto-core": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
-      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.8.tgz",
+      "integrity": "sha512-eBR98r9nQXTqXt/yDRtInszPMjTaSAMJAFDg2AHsgrnczawT1asx9YNBX6k5p+MekbPF4+s/UJJrr88zsTqkSg==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-schema": "^2.3.8",
         "@peculiar/json-schema": "^1.1.12",
         "asn1js": "^3.0.1",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
       }
     },
     "webpack": {

--- a/tools/ui/package-lock.json
+++ b/tools/ui/package-lock.json
@@ -8,11 +8,11 @@
       "name": "ui",
       "version": "0.1.0",
       "devDependencies": {
-        "@dfinity/agent": "0.21.2",
-        "@dfinity/auth-client": "0.21.2",
-        "@dfinity/candid": "0.21.2",
-        "@dfinity/identity": "0.21.2",
-        "@dfinity/principal": "0.21.2",
+        "@dfinity/agent": "0.21.4",
+        "@dfinity/auth-client": "0.21.4",
+        "@dfinity/candid": "0.21.4",
+        "@dfinity/identity": "0.21.4",
+        "@dfinity/principal": "0.21.4",
         "buffer": "6.0.3",
         "copy-webpack-plugin": "^9.0.1",
         "css-loader": "^6.8.1",
@@ -30,9 +30,9 @@
       "extraneous": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.21.2.tgz",
-      "integrity": "sha512-Ght+vXD+Uq/Z2qeskzmIMFDbBusrDCaUqaiC6Ak6YBThM3uY8m9biZ8xDCsWho5ia8HTR1o6f9wQ12ChBqsYVA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.21.4.tgz",
+      "integrity": "sha512-k5k8v1BmDE8RStC22FtuqbFzMLaQAQL3cE/wF45ZMKP4WmBBmCPss75RDgIVGiFwLGEKKKXE1muHQDy9g+m5yQ==",
       "dev": true,
       "dependencies": {
         "@noble/curves": "^1.2.0",
@@ -43,37 +43,37 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.21.2",
-        "@dfinity/principal": "^0.21.2"
+        "@dfinity/candid": "^0.21.4",
+        "@dfinity/principal": "^0.21.4"
       }
     },
     "node_modules/@dfinity/auth-client": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.21.2.tgz",
-      "integrity": "sha512-t42Utd9OEEyoOLFr0/jGDD6gJzS19UNqe027AlHXhG1kZrThjBp4IHoCYDEYDX3/955TQ2/6/Oq3BMtR8mIcBQ==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.21.4.tgz",
+      "integrity": "sha512-FF5UrFEURj7/1vcaFsR7bHFJQXXoyXH+epIYCSNno8PwbEoxpfE0kpTmE0LWXudRbOE/bajP6OoGsv33d1Nmxg==",
       "dev": true,
       "dependencies": {
         "idb": "^7.0.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.21.2",
-        "@dfinity/identity": "^0.21.2",
-        "@dfinity/principal": "^0.21.2"
+        "@dfinity/agent": "^0.21.4",
+        "@dfinity/identity": "^0.21.4",
+        "@dfinity/principal": "^0.21.4"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.21.2.tgz",
-      "integrity": "sha512-/KCubIOtB8mDTxciMbzexahji5zT7sPLIS4wSlsjOiKmDnurk4ZG0EobkNYJTELy3aXaXDkKNzsbptFVqgpUMw==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.21.4.tgz",
+      "integrity": "sha512-BRdgLQjPbqEZDRIR985jpy92uwhdBn4mN2D8StMKyOXQLmR6hKSD0p/P2b632Sh7zPUY8HuiA8njpMZ67JEyAg==",
       "dev": true,
       "peerDependencies": {
-        "@dfinity/principal": "^0.21.2"
+        "@dfinity/principal": "^0.21.4"
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.21.2.tgz",
-      "integrity": "sha512-TIRMq1Ox0Kf1d+w+41hyb+EpLPf5/rBqlKQy0LdXyumssgLDjM1Frl4vLbL9MxCw5Z39lnUQ/6b82N9AjmCIRA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.21.4.tgz",
+      "integrity": "sha512-+lTcr5+/RYwDSM7sGAKbt+kbpIWYDNpMmGi7D9iPWNJWYdWtTX6TDIJDx9dMCRN83/1lKLXF0p7F18ROZdjdUA==",
       "dev": true,
       "dependencies": {
         "@noble/curves": "^1.2.0",
@@ -81,15 +81,15 @@
         "borc": "^2.1.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.21.2",
-        "@dfinity/principal": "^0.21.2",
+        "@dfinity/agent": "^0.21.4",
+        "@dfinity/principal": "^0.21.4",
         "@peculiar/webcrypto": "^1.4.0"
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.21.2.tgz",
-      "integrity": "sha512-vOEwSkyNrDNeXy4TCHsUOk4H98yFj1DCvRuK1Hmi/dMUZ8GB5vjrQWqQhFjCO84NA6GkrDbPmuInra42kUpGtA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.21.4.tgz",
+      "integrity": "sha512-r9d+9BYZdFMzrq1+zcdIg6q6tlWeZ9SKnakVdhQ21qUJ6iDe0yxDlah6k9QKEh6fVsg2yv95nID++nqEosvt1Q==",
       "dev": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1"
@@ -2932,9 +2932,9 @@
   },
   "dependencies": {
     "@dfinity/agent": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.21.2.tgz",
-      "integrity": "sha512-Ght+vXD+Uq/Z2qeskzmIMFDbBusrDCaUqaiC6Ak6YBThM3uY8m9biZ8xDCsWho5ia8HTR1o6f9wQ12ChBqsYVA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.21.4.tgz",
+      "integrity": "sha512-k5k8v1BmDE8RStC22FtuqbFzMLaQAQL3cE/wF45ZMKP4WmBBmCPss75RDgIVGiFwLGEKKKXE1muHQDy9g+m5yQ==",
       "dev": true,
       "requires": {
         "@noble/curves": "^1.2.0",
@@ -2946,25 +2946,25 @@
       }
     },
     "@dfinity/auth-client": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.21.2.tgz",
-      "integrity": "sha512-t42Utd9OEEyoOLFr0/jGDD6gJzS19UNqe027AlHXhG1kZrThjBp4IHoCYDEYDX3/955TQ2/6/Oq3BMtR8mIcBQ==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.21.4.tgz",
+      "integrity": "sha512-FF5UrFEURj7/1vcaFsR7bHFJQXXoyXH+epIYCSNno8PwbEoxpfE0kpTmE0LWXudRbOE/bajP6OoGsv33d1Nmxg==",
       "dev": true,
       "requires": {
         "idb": "^7.0.2"
       }
     },
     "@dfinity/candid": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.21.2.tgz",
-      "integrity": "sha512-/KCubIOtB8mDTxciMbzexahji5zT7sPLIS4wSlsjOiKmDnurk4ZG0EobkNYJTELy3aXaXDkKNzsbptFVqgpUMw==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.21.4.tgz",
+      "integrity": "sha512-BRdgLQjPbqEZDRIR985jpy92uwhdBn4mN2D8StMKyOXQLmR6hKSD0p/P2b632Sh7zPUY8HuiA8njpMZ67JEyAg==",
       "dev": true,
       "requires": {}
     },
     "@dfinity/identity": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.21.2.tgz",
-      "integrity": "sha512-TIRMq1Ox0Kf1d+w+41hyb+EpLPf5/rBqlKQy0LdXyumssgLDjM1Frl4vLbL9MxCw5Z39lnUQ/6b82N9AjmCIRA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.21.4.tgz",
+      "integrity": "sha512-+lTcr5+/RYwDSM7sGAKbt+kbpIWYDNpMmGi7D9iPWNJWYdWtTX6TDIJDx9dMCRN83/1lKLXF0p7F18ROZdjdUA==",
       "dev": true,
       "requires": {
         "@noble/curves": "^1.2.0",
@@ -2973,9 +2973,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.21.2.tgz",
-      "integrity": "sha512-vOEwSkyNrDNeXy4TCHsUOk4H98yFj1DCvRuK1Hmi/dMUZ8GB5vjrQWqQhFjCO84NA6GkrDbPmuInra42kUpGtA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.21.4.tgz",
+      "integrity": "sha512-r9d+9BYZdFMzrq1+zcdIg6q6tlWeZ9SKnakVdhQ21qUJ6iDe0yxDlah6k9QKEh6fVsg2yv95nID++nqEosvt1Q==",
       "dev": true,
       "requires": {
         "@noble/hashes": "^1.3.1"

--- a/tools/ui/package.json
+++ b/tools/ui/package.json
@@ -7,11 +7,11 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "@dfinity/agent": "0.21.2",
-    "@dfinity/candid": "0.21.2",
-    "@dfinity/auth-client": "0.21.2",
-    "@dfinity/identity": "0.21.2",
-    "@dfinity/principal": "0.21.2",
+    "@dfinity/agent": "0.21.4",
+    "@dfinity/candid": "0.21.4",
+    "@dfinity/auth-client": "0.21.4",
+    "@dfinity/identity": "0.21.4",
+    "@dfinity/principal": "0.21.4",
     "buffer": "6.0.3",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.8.1",

--- a/tools/ui/package.json
+++ b/tools/ui/package.json
@@ -7,11 +7,11 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "@dfinity/agent": "0.20.2",
-    "@dfinity/candid": "0.20.2",
-    "@dfinity/auth-client": "0.20.2",
-    "@dfinity/identity": "0.20.2",
-    "@dfinity/principal": "0.20.2",
+    "@dfinity/agent": "0.21.2",
+    "@dfinity/candid": "0.21.2",
+    "@dfinity/auth-client": "0.21.2",
+    "@dfinity/identity": "0.21.2",
+    "@dfinity/principal": "0.21.2",
     "buffer": "6.0.3",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.8.1",

--- a/tools/ui/src/candid.ts
+++ b/tools/ui/src/candid.ts
@@ -20,9 +20,7 @@ function isKnownMainnet(agent: HttpAgent) {
 
 export let authClient: AuthClient | undefined;
 
-const agent = new HttpAgent({
-  host: window.location.host.replace(/^(localhost)(:\d+)?$/, '127.0.0.1$2')
-});
+const agent = new HttpAgent();
 if (!isKnownMainnet(agent)) {
   agent.fetchRootKey();
 }


### PR DESCRIPTION
Updates agent-js to the latest version and removes a hotfix used for the latest dfx release. 

Pending the next release of `@dfinity/agent`.
