### PR TITLE
Add MSRV 1.70.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,6 @@ jobs:
     - name: fmt
       run: cargo fmt -v -- --check
     - name: lint
-      run: cargo clippy --features all --tests -- -D clippy::all
+      run: cargo clippy --features all --tests -- -D warnings
     - name: doc
       run: cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.70.0"
+
 [workspace.dependencies]
 hex = "0.4.3"
 num-bigint = { version = "0.4", features = ["serde"] }

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -2,6 +2,7 @@
 name = "candid"
 version = "0.10.2"
 edition = "2021"
+rust-version.workspace = true
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer."
 homepage = "https://internetcomputer.org/docs/current/developer-docs/build/candid/candid-concepts"

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "candid_derive"
 version = "0.6.5"
 edition = "2021"
+rust-version.workspace = true
 authors = ["DFINITY Team"]
 description = "Macros implementation of #[derive(CandidType)] for the Candid."
 homepage = "https://docs.rs/candid_derive"

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -2,6 +2,7 @@
 name = "candid_parser"
 version = "0.1.2"
 edition = "2021"
+rust-version.workspace = true
 authors = ["DFINITY Team"]
 description = "Candid is an interface description language (IDL) for interacting with canisters running on the Internet Computer. This crate contains the parser and the binding generator for Candid."
 homepage = "https://internetcomputer.org/docs/current/developer-docs/build/candid/candid-concepts"

--- a/rust/ic_principal/Cargo.toml
+++ b/rust/ic_principal/Cargo.toml
@@ -3,6 +3,7 @@ name = "ic_principal"
 version = "0.1.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
+rust-version.workspace = true
 description = "Principal type used on the Internet Computer."
 homepage = "https://internetcomputer.org/docs/current/references/id-encoding-spec"
 documentation = "https://docs.rs/ic_principal"


### PR DESCRIPTION
This adds a MSRV field to the library manifests, and a rust-toolchain.toml to ensure it is checked in CI. 

I also took the opportunity to correct the clippy command in CI - `clippy::all` is a particular set of clippy lints, so `-Dclippy::all` won't flag rustc lints or manually `#[warn]`ed clippy lints.