### PR TITLE
fix typescript export for init args func

### DIFF
--- a/rust/candid_parser/src/bindings/typescript.rs
+++ b/rust/candid_parser/src/bindings/typescript.rs
@@ -194,7 +194,7 @@ import type { IDL } from '@dfinity/candid';
             .append(RcDoc::line())
             .append("export declare const idlFactory: IDL.InterfaceFactory;")
             .append(RcDoc::line())
-            .append("export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];"),
+            .append("export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];"),
     };
     let doc = RcDoc::text(header)
         .append(RcDoc::line())

--- a/rust/candid_parser/tests/assets/ok/actor.d.ts
+++ b/rust/candid_parser/tests/assets/ok/actor.d.ts
@@ -13,4 +13,4 @@ export interface _SERVICE {
   'o' : ActorMethod<[o], o>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/class.d.ts
+++ b/rust/candid_parser/tests/assets/ok/class.d.ts
@@ -8,4 +8,4 @@ export interface _SERVICE {
   'set' : ActorMethod<[List], List>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/cyclic.d.ts
+++ b/rust/candid_parser/tests/assets/ok/cyclic.d.ts
@@ -10,4 +10,4 @@ export type Y = Z;
 export type Z = A;
 export interface _SERVICE { 'f' : ActorMethod<[A, B, C, X, Y, Z], undefined> }
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/empty.d.ts
+++ b/rust/candid_parser/tests/assets/ok/empty.d.ts
@@ -9,4 +9,4 @@ export interface _SERVICE {
   'h' : ActorMethod<[[T, never]], { 'a' : T } | { 'b' : {} }>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/escape.d.ts
+++ b/rust/candid_parser/tests/assets/ok/escape.d.ts
@@ -10,4 +10,4 @@ export interface t {
 }
 export interface _SERVICE { '\n\'\"\'\'\"\"\r\t' : ActorMethod<[t], undefined> }
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/example.d.ts
+++ b/rust/candid_parser/tests/assets/ok/example.d.ts
@@ -51,4 +51,4 @@ export interface _SERVICE {
   'x' : ActorMethod<[a, b], [[] | [a], [] | [b]]>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/fieldnat.d.ts
+++ b/rust/candid_parser/tests/assets/ok/fieldnat.d.ts
@@ -14,4 +14,4 @@ export interface _SERVICE {
   'foo' : ActorMethod<[{ _2_ : bigint }], { _2_ : bigint, '_2' : bigint }>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/keyword.d.ts
+++ b/rust/candid_parser/tests/assets/ok/keyword.d.ts
@@ -32,4 +32,4 @@ export interface _SERVICE {
   >,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/management.d.ts
+++ b/rust/candid_parser/tests/assets/ok/management.d.ts
@@ -172,4 +172,4 @@ export interface _SERVICE {
   >,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/recursion.d.ts
+++ b/rust/candid_parser/tests/assets/ok/recursion.d.ts
@@ -15,4 +15,4 @@ export type tree = {
   { 'leaf' : bigint };
 export interface _SERVICE extends s {}
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/recursive_class.d.ts
+++ b/rust/candid_parser/tests/assets/ok/recursive_class.d.ts
@@ -5,4 +5,4 @@ import type { IDL } from '@dfinity/candid';
 export interface s { 'next' : ActorMethod<[], Principal> }
 export interface _SERVICE extends s {}
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/service.d.ts
+++ b/rust/candid_parser/tests/assets/ok/service.d.ts
@@ -19,4 +19,4 @@ export interface _SERVICE {
   >,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/unicode.d.ts
+++ b/rust/candid_parser/tests/assets/ok/unicode.d.ts
@@ -19,4 +19,4 @@ export interface _SERVICE {
   '👀' : ActorMethod<[bigint], bigint>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
-export declare const init: ({ IDL }: { IDL: IDL }) => IDL.Type[];
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];


### PR DESCRIPTION
**Overview**
This fixes a feature I added in https://github.com/dfinity/candid/pull/510.

The feature I added only works in TypeScript projects that use the `tsconfig` option to `skipLibCheck` and the generated types are not directly included in the TypeScript compilation via the `include` option in `tsconfig`, but are instead indirectly included via `import` statements. This working setup should be the default for most projects so that's why it wasn't noticed until now.

This [forum post](https://forum.dfinity.org/t/didc-ts2709-cannot-use-namespace-idl-as-a-type/27723/3) helped identify the scenario where it's not working.
