### PR TITLE
typo: binary format for function annotations

### DIFF
--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -1181,7 +1181,7 @@ T(service {<methtype>*}) =
 T : <methtype> -> i8*
 T(<name>:<datatype>) = leb128(|utf8(<name>)|) i8*(utf8(<name>)) I(<datatype>)
 
-T : <funcann> -> i8*
+T : <funcann> -> i8
 T(query)  = i8(1)
 T(oneway) = i8(2)
 T(composite_query) = i8(3)


### PR DESCRIPTION
I think there's a typo here. Every binary `funcann` occupies 1 byte, not zero or more.

