### PR TITLE
use btreemap for type_map and release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "candid"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,15 @@
 
 # Changelog
 
+## 2024-04-11
+
+### Candid 0.10.7 -- 0.10.5
+
+* Switch `HashMap` to `BTreeMap` in serialization and `T::ty()`. This leads to around 20% perf improvement for serializing complicated types.
+* Disable memoization for unrolled types in serialization to save cycle cost. In some cases, type table can get slightly larger, but it's worth the trade off.
+* Fix bug in `text_size`
+* Fix decoding cost calculation overflow
+
 ## 2024-02-27
 
 ### Candid 0.10.4

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.10.6"
+version = "0.10.7"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -262,12 +262,12 @@ impl TypeSerialize {
         // from the type table.
         // Someone should implement Pottier's O(nlogn) algorithm
         // http://gallium.inria.fr/~fpottier/publis/gauthier-fpottier-icfp04.pdf
-        let unrolled = types::internal::unroll(t);
+        /*let unrolled = types::internal::unroll(t);
         if let Some(idx) = self.type_map.get(&unrolled) {
             let idx = *idx;
             self.type_map.insert(t.clone(), idx);
             return Ok(());
-        }
+        }*/
 
         let idx = self.type_table.len();
         self.type_map.insert(t.clone(), idx as i32);

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -262,12 +262,13 @@ impl TypeSerialize {
         // from the type table.
         // Someone should implement Pottier's O(nlogn) algorithm
         // http://gallium.inria.fr/~fpottier/publis/gauthier-fpottier-icfp04.pdf
-        /*let unrolled = types::internal::unroll(t);
-        if let Some(idx) = self.type_map.get(&unrolled) {
-            let idx = *idx;
-            self.type_map.insert(t.clone(), idx);
-            return Ok(());
-        }*/
+        // Disable this "optimization", as unroll is expensive and has to be called on every recursion.
+        // let unrolled = types::internal::unroll(t);
+        // if let Some(idx) = self.type_map.get(&unrolled) {
+        //    let idx = *idx;
+        //    self.type_map.insert(t.clone(), idx);
+        //    return Ok(());
+        // }
 
         let idx = self.type_table.len();
         self.type_map.insert(t.clone(), idx as i32);

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -7,7 +7,7 @@ use super::types::value::IDLValue;
 use super::types::{internal::Opcode, Field, Type, TypeEnv, TypeInner};
 use byteorder::{LittleEndian, WriteBytesExt};
 use leb128::write::{signed as sleb128_encode, unsigned as leb128_encode};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io;
 use std::vec::Vec;
 
@@ -224,7 +224,7 @@ impl<'a> types::Compound for Compound<'a> {
 #[derive(Default)]
 pub struct TypeSerialize {
     type_table: Vec<Vec<u8>>,
-    type_map: HashMap<Type, i32>,
+    type_map: BTreeMap<Type, i32>,
     env: TypeEnv,
     args: Vec<Type>,
     result: Vec<u8>,
@@ -235,7 +235,7 @@ impl TypeSerialize {
     pub fn new() -> Self {
         TypeSerialize {
             type_table: Vec::new(),
-            type_map: HashMap::new(),
+            type_map: BTreeMap::new(),
             env: TypeEnv::new(),
             args: Vec::new(),
             result: Vec::new(),

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -7,7 +7,7 @@ use std::fmt;
 // This is a re-implementation of std::any::TypeId to get rid of 'static constraint.
 // The current TypeId doesn't consider lifetime while computing the hash, which is
 // totally fine for Candid type, as we don't care about lifetime at all.
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Ord, PartialOrd)]
 pub struct TypeId {
     id: usize,
     pub name: &'static str,
@@ -164,10 +164,10 @@ impl TypeContainer {
     }
 }
 
-#[derive(Debug, PartialEq, Hash, Eq, Clone)]
+#[derive(Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub struct Type(pub std::rc::Rc<TypeInner>);
 
-#[derive(Debug, PartialEq, Hash, Eq, Clone)]
+#[derive(Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeInner {
     Null,
     Bool,
@@ -382,7 +382,7 @@ pub fn text_size(t: &Type, limit: i32) -> Result<i32, ()> {
     }
 }
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Eq, Clone, PartialOrd, Ord)]
 pub enum Label {
     Id(u32),
     Named(String),
@@ -423,7 +423,7 @@ impl std::hash::Hash for Label {
 
 pub type SharedLabel = std::rc::Rc<Label>;
 
-#[derive(Debug, PartialEq, Hash, Eq, Clone)]
+#[derive(Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub struct Field {
     pub id: SharedLabel,
     pub ty: Type,
@@ -486,13 +486,13 @@ macro_rules! variant {
     }}
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum FuncMode {
     Oneway,
     Query,
     CompositeQuery,
 }
-#[derive(Debug, PartialEq, Hash, Eq, Clone)]
+#[derive(Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub struct Function {
     pub modes: Vec<FuncMode>,
     pub args: Vec<Type>,

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -1,7 +1,7 @@
 use super::CandidType;
 use crate::idl_hash;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 
 // This is a re-implementation of std::any::TypeId to get rid of 'static constraint.
@@ -33,8 +33,8 @@ pub fn type_of<T>(_: &T) -> TypeId {
 
 #[derive(Default)]
 struct TypeName {
-    type_name: HashMap<TypeId, String>,
-    name_index: HashMap<String, usize>,
+    type_name: BTreeMap<TypeId, String>,
+    name_index: BTreeMap<String, usize>,
 }
 impl TypeName {
     fn get(&mut self, id: &TypeId) -> String {
@@ -626,9 +626,9 @@ pub fn unroll(t: &Type) -> Type {
 }
 
 thread_local! {
-    static ENV: RefCell<HashMap<TypeId, Type>> = RefCell::new(HashMap::new());
+    static ENV: RefCell<BTreeMap<TypeId, Type>> = RefCell::new(BTreeMap::new());
     // only used for TypeContainer
-    static ID: RefCell<HashMap<Type, TypeId>> = RefCell::new(HashMap::new());
+    static ID: RefCell<BTreeMap<Type, TypeId>> = RefCell::new(BTreeMap::new());
     static NAME: RefCell<TypeName> = RefCell::new(TypeName::default());
 }
 

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -7,7 +7,7 @@ use std::fmt;
 // This is a re-implementation of std::any::TypeId to get rid of 'static constraint.
 // The current TypeId doesn't consider lifetime while computing the hash, which is
 // totally fine for Candid type, as we don't care about lifetime at all.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Ord, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
 pub struct TypeId {
     id: usize,
     pub name: &'static str,

--- a/rust/candid/src/types/internal.rs
+++ b/rust/candid/src/types/internal.rs
@@ -626,9 +626,9 @@ pub fn unroll(t: &Type) -> Type {
 }
 
 thread_local! {
-    static ENV: RefCell<BTreeMap<TypeId, Type>> = RefCell::new(BTreeMap::new());
+    static ENV: RefCell<BTreeMap<TypeId, Type>> = const { RefCell::new(BTreeMap::new()) };
     // only used for TypeContainer
-    static ID: RefCell<BTreeMap<Type, TypeId>> = RefCell::new(BTreeMap::new());
+    static ID: RefCell<BTreeMap<Type, TypeId>> = const { RefCell::new(BTreeMap::new()) };
     static NAME: RefCell<TypeName> = RefCell::new(TypeName::default());
 }
 

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -260,8 +260,9 @@ fn test_struct() {
     );
 
     let list: Option<List> = None;
-    // without memoization on the unrolled type, type table will have 3 entries.
-    all_check(list, "4449444c026e016c02a0d2aca8047c90eddae70400010000");
+    // with memoization on the unrolled type, type table will have 2 entries.
+    // all_check(list, "4449444c026e016c02a0d2aca8047c90eddae70400010000");
+    all_check(list, "4449444c036e016c02a0d2aca8047c90eddae704026e01010000");
 }
 
 #[test]


### PR DESCRIPTION
Looking from the encoding flamegraph, with a large type table, the encoder spends a lot of time in `hashbrown::raw::RawTable::reserve_rehash`. Changing the data structure from `HashMap` to `BTreeMap` significantly improves the performance. Another reason for the improvement is that comparing the type AST is usually cheaper than hashing the type AST.

This PR also disables the memoization to unroll types. Type table can now be slightly larger, but saves a lot of time in encoding.

For `list_proposal` benchmark, encoding cost comes down from 19M to 10M. Further down to 6M after disabling type unrolling. 