### PR TITLE
feat: add infinite type test

### DIFF
--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -25,6 +25,15 @@ fn test_error() {
         "Trailing value after finishing deserialization",
     );
     check_error(|| test_decode(b"DIDL\0\x01\x7e", &true), "io error");
+    check_error(
+        || {
+            test_decode(
+                b"DIDL\x01\x6c\x02\x07\x78\x08\x00\x01\x00\x2a\x00\x00\x00\x00\x00\x00\x00",
+                &true,
+            )
+        },
+        "Cannot decode empty type",
+    );
     // Out of bounds type index
     check_error(
         || test_decode(b"DIDL\0\x01\0\x01", &42),


### PR DESCRIPTION
This PR adds an infinite type test corresponding to this didc invokation:
```
$ didc decode 4449444c016c020778080001002a00000000000000
Error: Fail to decode argument 0 from table0 to unknown

Caused by:
    0: input: 4449444c016c02077808000100_2a00000000000000
       table: type table0 = empty
       wire_type: empty, expect_type: empty
    1: Subtyping error: Cannot decode empty type
```