### PR TITLE
Remove unnecessary allocation/copy from the string serialization implementation

### DIFF
--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -147,9 +147,9 @@ impl<'a> types::Serializer for &'a mut ValueSerializer {
     serialize_num!(float64, f64, write_f64::<LittleEndian>);
 
     fn serialize_text(self, v: &str) -> Result<()> {
-        let mut buf = Vec::from(v.as_bytes());
+        let buf = v.as_bytes();
         self.write_leb128(buf.len() as u64)?;
-        self.value.append(&mut buf);
+        self.value.extend_from_slice(buf);
         Ok(())
     }
     fn serialize_null(self, _v: ()) -> Result<()> {
@@ -316,9 +316,9 @@ impl TypeSerialize {
                 sleb128_encode(&mut buf, Opcode::Service as i64)?;
                 leb128_encode(&mut buf, ms.len() as u64)?;
                 for (id, ty) in ms {
-                    let mut name = Vec::from(id.as_bytes());
+                    let name = id.as_bytes();
                     leb128_encode(&mut buf, name.len() as u64)?;
-                    buf.append(&mut name);
+                    buf.extend_from_slice(name);
                     self.encode(&mut buf, ty)?;
                 }
             }


### PR DESCRIPTION
Avoid creating an intermediate vector when serializing texts.

Affected benchmarks:

```
Benchmark: text
  total:
    instructions: 38.30 M (improved by 17.97%)
    heap_increase: 99 pages (no change)
    stable_memory_increase: 0 pages (no change)

  1. Encoding (scope):
    instructions: 20.46 M (improved by 29.08%)
    heap_increase: 66 pages (improved by 33.33%)
    stable_memory_increase: 0 pages (no change)

  2. Decoding (scope):
    instructions: 17.84 M (0.00%) (change within noise threshold)
    heap_increase: 33 pages (regressed from 0)
    stable_memory_increase: 0 pages (no change)
```

```
Benchmark: btreemap
  total:
    instructions: 19.75 B (improved by 2.44%)
    heap_increase: 1179 pages (1.29%) (change within noise threshold)
    stable_memory_increase: 0 pages (no change)

  1. Encoding (scope):
    instructions: 4.02 B (improved by 10.70%)
    heap_increase: 159 pages (improved by 38.13%)
    stable_memory_increase: 0 pages (no change)

  2. Decoding (scope):
    instructions: 15.72 B (-0.08%) (change within noise threshold)
    heap_increase: 1020 pages (regressed by 12.46%)
    stable_memory_increase: 0 pages (no change)
```

My assumption is that the heap_increase regression in the decoding phase is due to the fact that heap is not reclaimed after encoding. Since encoding uses less heap after this change, the heap increase for the decoding phase is now higher.