### PR TITLE
feat(didjs): skip asset certification in Candid UI canister

### DIFF
--- a/tools/ui/Cargo.lock
+++ b/tools/ui/Cargo.lock
@@ -116,16 +116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,11 +255,10 @@ dependencies = [
  "base64",
  "candid",
  "candid_parser",
- "ic-asset-certification",
  "ic-cdk",
  "ic-certification",
  "ic-http-certification",
- "include_dir",
+ "ic-representation-independent-hash",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -361,25 +350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "globset"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax 0.8.2",
-]
-
-[[package]]
 name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,17 +376,6 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
-]
-
-[[package]]
-name = "ic-asset-certification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
-dependencies = [
- "globset",
- "ic-certification",
- "ic-http-certification",
- "thiserror",
 ]
 
 [[package]]
@@ -496,26 +455,6 @@ dependencies = [
  "serde",
  "sha2",
  "thiserror",
-]
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "glob",
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
 ]
 
 [[package]]

--- a/tools/ui/Cargo.lock
+++ b/tools/ui/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,14 +116,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+
+[[package]]
 name = "candid"
-version = "0.10.4"
+version = "0.10.10"
 dependencies = [
  "anyhow",
  "binread",
@@ -240,11 +262,17 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 name = "didjs"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "candid",
  "candid_parser",
+ "ic-asset-certification",
  "ic-cdk",
+ "ic-certification",
+ "ic-http-certification",
+ "include_dir",
  "serde",
  "serde_bytes",
+ "serde_cbor",
 ]
 
 [[package]]
@@ -333,6 +361,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +396,28 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "ic-asset-certification"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
+dependencies = [
+ "globset",
+ "ic-certification",
+ "ic-http-certification",
+ "thiserror",
+]
 
 [[package]]
 name = "ic-cdk"
@@ -372,6 +447,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-certification"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_bytes",
+ "sha2",
+]
+
+[[package]]
+name = "ic-http-certification"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
+dependencies = [
+ "candid",
+ "http",
+ "ic-certification",
+ "ic-representation-independent-hash",
+ "serde",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "ic-representation-independent-hash"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
+dependencies = [
+ "leb128",
+ "sha2",
+]
+
+[[package]]
 name = "ic0"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +496,26 @@ dependencies = [
  "serde",
  "sha2",
  "thiserror",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "glob",
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -407,6 +536,12 @@ checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "lalrpop"
@@ -757,6 +892,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +1078,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "version_check"

--- a/tools/ui/src/didjs/Cargo.toml
+++ b/tools/ui/src/didjs/Cargo.toml
@@ -8,9 +8,14 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-ic-cdk = "0.13"
+base64 = "0.22.1"
 candid = "0.10"
 candid_parser = "0.1"
+ic-asset-certification = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
+ic-cdk = "0.13"
+ic-certification = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
+ic-http-certification = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
+include_dir = { version = "0.7", features = ["glob"] }
 serde = "1.0"
 serde_bytes = "0.11"
-
+serde_cbor = "0.11.2"

--- a/tools/ui/src/didjs/Cargo.toml
+++ b/tools/ui/src/didjs/Cargo.toml
@@ -11,11 +11,10 @@ crate-type = ["cdylib"]
 base64 = "0.22.1"
 candid = "0.10"
 candid_parser = "0.1"
-ic-asset-certification = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
 ic-cdk = "0.13"
 ic-certification = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
 ic-http-certification = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
-include_dir = { version = "0.7", features = ["glob"] }
+ic-representation-independent-hash = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
 serde = "1.0"
 serde_bytes = "0.11"
 serde_cbor = "0.11.2"

--- a/tools/ui/src/didjs/lib.rs
+++ b/tools/ui/src/didjs/lib.rs
@@ -1,25 +1,31 @@
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
 use candid::types::{subtype, Type, TypeInner};
-use candid_parser::{check_prog, CandidType, Deserialize, IDLProg, TypeEnv};
+use candid_parser::{check_prog, IDLProg, TypeEnv};
+use ic_asset_certification::{
+    Asset, AssetConfig, AssetEncoding, AssetFallbackConfig, AssetRedirectKind, AssetRouter,
+};
+use ic_cdk::{
+    api::{data_certificate, set_certified_data},
+    *,
+};
+use ic_certification::HashTree;
+use ic_http_certification::{HeaderField, HttpCertificationTree, HttpRequest, HttpResponse};
+use include_dir::{include_dir, Dir};
+use serde::Serialize;
+use std::{cell::RefCell, rc::Rc};
 
-#[derive(CandidType, Deserialize)]
-pub struct HeaderField(pub String, pub String);
+thread_local! {
+    static HTTP_TREE: Rc<RefCell<HttpCertificationTree>> = Default::default();
 
-#[derive(CandidType, Deserialize)]
-pub struct HttpRequest {
-    pub method: String,
-    pub url: String,
-    pub headers: Vec<HeaderField>,
-    #[serde(with = "serde_bytes")]
-    pub body: Vec<u8>,
+    // initializing the asset router with an HTTP certification tree is optional.
+    // if direct access to the HTTP certification tree is not needed for certifying
+    // requests and responses outside of the asset router, then this step can be skipped.
+    static ASSET_ROUTER: RefCell<AssetRouter<'static>> = RefCell::new(AssetRouter::with_tree(HTTP_TREE.with(|tree| tree.clone())));
 }
 
-#[derive(CandidType, Deserialize)]
-pub struct HttpResponse {
-    pub status_code: u16,
-    pub headers: Vec<HeaderField>,
-    #[serde(with = "serde_bytes")]
-    pub body: Vec<u8>,
-}
+static ASSETS_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../dist/didjs/");
+const IMMUTABLE_ASSET_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
 
 #[ic_cdk::query]
 fn did_to_js(prog: String) -> Option<String> {
@@ -74,46 +80,172 @@ fn subtype(new: String, old: String) -> Result<(), String> {
     subtype::subtype(&mut gamma, &new_env, &new_actor, &old_actor).map_err(|e| e.to_string())
 }
 
-fn retrieve(path: &str) -> Option<(&str, &'static [u8])> {
-    match path {
-        "/index.html" | "/" => Some(("text/html", include_bytes!("../../dist/didjs/index.html"))),
-        "/favicon.ico" => Some((
-            "image/x-icon",
-            include_bytes!("../../dist/didjs/favicon.ico"),
-        )),
-        "/index.js" => Some((
-            "application/javascript",
-            include_bytes!("../../dist/didjs/index.js"),
-        )),
-        _ => None,
+#[init]
+fn init() {
+    certify_all_assets();
+}
+
+#[post_upgrade]
+fn post_upgrade() {
+    init();
+}
+
+#[query]
+fn http_request(req: HttpRequest) -> HttpResponse {
+    serve_asset(&req)
+}
+
+/// Rescursively collect all assets from the provided directory
+fn collect_assets<'content, 'path>(
+    dir: &'content Dir<'path>,
+    assets: &mut Vec<Asset<'content, 'path>>,
+) {
+    for file in dir.files() {
+        assets.push(Asset::new(file.path().to_string_lossy(), file.contents()));
+    }
+
+    for dir in dir.dirs() {
+        collect_assets(dir, assets);
     }
 }
 
-fn get_path(url: &str) -> Option<&str> {
-    url.split('?').next()
+// Certification
+fn certify_all_assets() {
+    // 1. Define the asset certification configurations.
+    let encodings = vec![
+        AssetEncoding::Brotli.default_config(),
+        AssetEncoding::Gzip.default_config(),
+    ];
+
+    let asset_configs = vec![
+        AssetConfig::File {
+            path: "index.html".to_string(),
+            content_type: Some("text/html".to_string()),
+            headers: get_asset_headers(vec![(
+                "cache-control".to_string(),
+                "public, no-cache, no-store".to_string(),
+            )]),
+            fallback_for: vec![AssetFallbackConfig {
+                scope: "/".to_string(),
+            }],
+            aliased_by: vec!["/".to_string()],
+            encodings: encodings.clone(),
+        },
+        AssetConfig::Pattern {
+            pattern: "**/*.js".to_string(),
+            content_type: Some("text/javascript".to_string()),
+            headers: get_asset_headers(vec![(
+                "cache-control".to_string(),
+                IMMUTABLE_ASSET_CACHE_CONTROL.to_string(),
+            )]),
+            encodings: encodings.clone(),
+        },
+        AssetConfig::Pattern {
+            pattern: "**/*.css".to_string(),
+            content_type: Some("text/css".to_string()),
+            headers: get_asset_headers(vec![(
+                "cache-control".to_string(),
+                IMMUTABLE_ASSET_CACHE_CONTROL.to_string(),
+            )]),
+            encodings,
+        },
+        AssetConfig::Pattern {
+            pattern: "**/*.ico".to_string(),
+            content_type: Some("image/x-icon".to_string()),
+            headers: get_asset_headers(vec![(
+                "cache-control".to_string(),
+                IMMUTABLE_ASSET_CACHE_CONTROL.to_string(),
+            )]),
+            encodings: vec![],
+        },
+        AssetConfig::Pattern {
+            pattern: "**/*.svg".to_string(),
+            content_type: Some("image/svg+xml".to_string()),
+            headers: get_asset_headers(vec![(
+                "cache-control".to_string(),
+                IMMUTABLE_ASSET_CACHE_CONTROL.to_string(),
+            )]),
+            encodings: vec![],
+        },
+        AssetConfig::Redirect {
+            from: "/old-url".to_string(),
+            to: "/".to_string(),
+            kind: AssetRedirectKind::Permanent,
+        },
+    ];
+
+    // 2. Collect all assets from the frontend build directory.
+    let mut assets = Vec::new();
+    collect_assets(&ASSETS_DIR, &mut assets);
+
+    ASSET_ROUTER.with_borrow_mut(|asset_router| {
+        // 3. Certify the assets using the `certify_assets` function from the `ic-asset-certification` crate.
+        if let Err(err) = asset_router.certify_assets(assets, asset_configs) {
+            ic_cdk::trap(&format!("Failed to certify assets: {}", err));
+        }
+
+        // 4. Set the canister's certified data.
+        set_certified_data(&asset_router.root_hash());
+    });
 }
 
-#[ic_cdk::query]
-fn http_request(request: HttpRequest) -> HttpResponse {
-    //TODO add /canister_id/ as endpoint when ICQC is available.
-    let path = get_path(request.url.as_str()).unwrap_or("/");
-    if let Some((content_type, bytes)) = retrieve(path) {
-        HttpResponse {
-            status_code: 200,
-            headers: vec![
-                HeaderField("Content-Type".to_string(), content_type.to_string()),
-                HeaderField("Content-Length".to_string(), format!("{}", bytes.len())),
-                HeaderField("Cache-Control".to_string(), format!("max-age={}", 600)),
-            ],
-            body: bytes.to_vec(),
+// Handlers
+fn serve_asset(req: &HttpRequest) -> HttpResponse {
+    ASSET_ROUTER.with_borrow(|asset_router| {
+        if let Ok((mut response, witness, expr_path)) = asset_router.serve_asset(req) {
+            add_certificate_header(&mut response, &witness, &expr_path);
+
+            response
+        } else {
+            ic_cdk::trap("Failed to serve asset");
         }
-    } else {
-        HttpResponse {
-            status_code: 404,
-            headers: Vec::new(),
-            body: path.as_bytes().to_vec(),
-        }
-    }
+    })
+}
+
+fn get_asset_headers(additional_headers: Vec<HeaderField>) -> Vec<HeaderField> {
+    // set up the default headers and include additional headers provided by the caller
+    let mut headers = vec![
+        ("strict-transport-security".to_string(), "max-age=31536000; includeSubDomains".to_string()),
+        ("x-frame-options".to_string(), "DENY".to_string()),
+        ("x-content-type-options".to_string(), "nosniff".to_string()),
+        ("content-security-policy".to_string(), "default-src 'self'; form-action 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content".to_string()),
+        ("referrer-policy".to_string(), "no-referrer".to_string()),
+        ("permissions-policy".to_string(), "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),layout-animations=(self),legacy-image-formats=(self),magnetometer=(),microphone=(),midi=(),oversized-images=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=(),sync-xhr=(self),unoptimized-images=(self),unsized-media=(self),usb=(),screen-wake-lock=(),web-share=(),xr-spatial-tracking=()".to_string()),
+        ("cross-origin-embedder-policy".to_string(), "require-corp".to_string()),
+        ("cross-origin-opener-policy".to_string(), "same-origin".to_string()),
+    ];
+    headers.extend(additional_headers);
+
+    headers
+}
+
+const IC_CERTIFICATE_HEADER: &str = "IC-Certificate";
+fn add_certificate_header(response: &mut HttpResponse, witness: &HashTree, expr_path: &[String]) {
+    let certified_data = data_certificate().expect("No data certificate available");
+    let witness = cbor_encode(witness);
+    let expr_path = cbor_encode(&expr_path);
+
+    response.headers.push((
+        IC_CERTIFICATE_HEADER.to_string(),
+        format!(
+            "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
+            BASE64.encode(certified_data),
+            BASE64.encode(witness),
+            BASE64.encode(expr_path)
+        ),
+    ));
+}
+
+// Encoding
+fn cbor_encode(value: &impl Serialize) -> Vec<u8> {
+    let mut serializer = serde_cbor::Serializer::new(Vec::new());
+    serializer
+        .self_describe()
+        .expect("Failed to self describe CBOR");
+    value
+        .serialize(&mut serializer)
+        .expect("Failed to serialize value");
+    serializer.into_inner()
 }
 
 ic_cdk::export_candid!();


### PR DESCRIPTION
This PR certifies that asset certification is skipped in the Candid UI canister so that the canister can be accessed without using the `raw` endpoint.