### PR TITLE
Add a test regarding structs with a new Option field

### DIFF
--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -194,6 +194,56 @@ fn test_option() {
 }
 
 #[test]
+fn test_struct_with_option() {
+    #[derive(CandidType, Deserialize, PartialEq, Debug)]
+    struct Old {
+        field: i32,
+    }
+
+    #[derive(CandidType, Deserialize, PartialEq, Debug)]
+    struct New {
+        field: i32,
+        new_field: Option<i32>,
+    }
+
+    let old_bytes = encode(&Old { field: 1 });
+    let new_bytes_with_none = encode(&New {
+        field: 2,
+        new_field: None,
+    });
+    let new_bytes_with_some = encode(&New {
+        field: 3,
+        new_field: Some(4),
+    });
+
+    test_decode(&old_bytes, &Old { field: 1 });
+    test_decode(&new_bytes_with_none, &Old { field: 2 });
+    test_decode(&new_bytes_with_some, &Old { field: 3 });
+
+    test_decode(
+        &old_bytes,
+        &New {
+            field: 1,
+            new_field: None,
+        },
+    );
+    test_decode(
+        &new_bytes_with_none,
+        &New {
+            field: 2,
+            new_field: None,
+        },
+    );
+    test_decode(
+        &new_bytes_with_some,
+        &New {
+            field: 3,
+            new_field: Some(4),
+        },
+    );
+}
+
+#[test]
 fn test_struct() {
     #[derive(PartialEq, Debug, Deserialize, CandidType)]
     struct A1 {


### PR DESCRIPTION
This checks that adding an Option field to a struct has the expected behavior, where

* For an old writer and new reader, the struct deserializes with a field of None
* For a new writer and an old reader, the struct deserializes with the value of the Option ignored.

**Overview**
This PR just adds a test. Within the crypto team we were not sure if this situation (adding an `Option` to a Candid struct) worked as we expected (CRP-2642). This test is to confirm our understanding. But it also seems like a nice test to have for the future.