### PR TITLE
feat: IDLBuilder.try_reserve_value_serializer_capacity

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## 2024-12-10
+
+### Candid 0.10.11
+
+* Add `IDLBuilder.try_reserve_value_serializer_capacity()` to reserve capacity before serializing a large amount of data.
+
 ## 2024-05-03
 
 ### Candid 0.10.10

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,7 @@
 
 # Changelog
 
-## 2024-12-10
-
-### Candid 0.10.11
+## [Unreleased]
 
 * Add `IDLBuilder.try_reserve_value_serializer_capacity()` to reserve capacity before serializing a large amount of data.
 

--- a/rust/candid/src/error.rs
+++ b/rust/candid/src/error.rs
@@ -1,6 +1,7 @@
 //! `candid::Result<T> = Result<T, candid::Error>>`
 
 use serde::{de, ser};
+use std::collections::TryReserveError;
 use std::{io, num::ParseIntError};
 use thiserror::Error;
 
@@ -16,6 +17,9 @@ pub struct Label {
 pub enum Error {
     #[error("binary parser error: {}", .0.first().map_or_else(|| "io error".to_string(), |f| format!("{} at byte offset {}", f.message, f.pos/2)))]
     Binread(Vec<Label>),
+
+    #[error(transparent)]
+    Reserve(#[from] TryReserveError),
 
     #[error("Subtyping error: {0}")]
     Subtype(String),

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -7,7 +7,7 @@ use super::types::value::IDLValue;
 use super::types::{internal::Opcode, Field, Type, TypeEnv, TypeInner};
 use byteorder::{LittleEndian, WriteBytesExt};
 use leb128::write::{signed as sleb128_encode, unsigned as leb128_encode};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, TryReserveError};
 use std::io;
 use std::vec::Vec;
 
@@ -71,6 +71,14 @@ impl IDLBuilder {
         self.serialize(&mut vec)?;
         Ok(vec)
     }
+    /// If serializing a large amount of data, you can try to reserve the capacity of the
+    /// value serializer ahead of time to avoid reallocation.
+    pub fn try_reserve_value_serializer_capacity(
+        &mut self,
+        additional: usize,
+    ) -> std::result::Result<(), TryReserveError> {
+        self.value_ser.try_reserve(additional)
+    }
 }
 
 /// A structure for serializing Rust values to IDL.
@@ -98,6 +106,10 @@ impl ValueSerializer {
         use std::io::Write;
         self.value.write_all(bytes)?;
         Ok(())
+    }
+    #[doc(hidden)]
+    pub fn try_reserve(&mut self, additional: usize) -> std::result::Result<(), TryReserveError> {
+        self.value.try_reserve(additional)
     }
 }
 


### PR DESCRIPTION
The asset canister [serializes its stable state](https://github.com/dfinity/sdk/blob/master/src/canisters/frontend/ic-frontend-canister/src/lib.rs#L11) through [stable_save](https://github.com/dfinity/cdk-rs/blob/main/src/ic-cdk/src/storage.rs#L11) in the rust cdk.

When this involves growing the serialization buffer, it can mean needing to store more than 3x the size of the assets: the assets themselves, the current serialization buffer, and the new buffer being grown into. This can result in an AllocError which manifests as a panic in the canister.

This PR adds a mechanism for reserving space in the `value_serializer` before actually serializing the values.