### PR TITLE
chore: elide needless lifetimes for rust 1.83.0 update to stable

### DIFF
--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -636,7 +636,7 @@ macro_rules! primitive_impl {
     };
 }
 
-impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
+impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
     type Error = Error;
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
@@ -1086,7 +1086,7 @@ impl<'a, 'de> Compound<'a, 'de> {
     }
 }
 
-impl<'de, 'a> de::SeqAccess<'de> for Compound<'a, 'de> {
+impl<'de> de::SeqAccess<'de> for Compound<'_, 'de> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
@@ -1138,7 +1138,7 @@ impl<'de, 'a> de::SeqAccess<'de> for Compound<'a, 'de> {
     }
 }
 
-impl<'de, 'a> de::MapAccess<'de> for Compound<'a, 'de> {
+impl<'de> de::MapAccess<'de> for Compound<'_, 'de> {
     type Error = Error;
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
     where
@@ -1239,7 +1239,7 @@ impl<'de, 'a> de::MapAccess<'de> for Compound<'a, 'de> {
     }
 }
 
-impl<'de, 'a> de::EnumAccess<'de> for Compound<'a, 'de> {
+impl<'de> de::EnumAccess<'de> for Compound<'_, 'de> {
     type Error = Error;
     type Variant = Self;
 
@@ -1273,7 +1273,7 @@ impl<'de, 'a> de::EnumAccess<'de> for Compound<'a, 'de> {
     }
 }
 
-impl<'de, 'a> de::VariantAccess<'de> for Compound<'a, 'de> {
+impl<'de> de::VariantAccess<'de> for Compound<'_, 'de> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -205,7 +205,7 @@ impl<'a> types::Serializer for &'a mut ValueSerializer {
 pub struct Compound<'a> {
     ser: &'a mut ValueSerializer,
 }
-impl<'a> types::Compound for Compound<'a> {
+impl types::Compound for Compound<'_> {
     type Error = Error;
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where

--- a/rust/candid/src/types/impls.rs
+++ b/rust/candid/src/types/impls.rs
@@ -331,7 +331,7 @@ where
     }
 }
 
-impl<'a, T> CandidType for &'a T
+impl<T> CandidType for &T
 where
     T: ?Sized + CandidType,
 {
@@ -348,7 +348,7 @@ where
         (**self).idl_serialize(serializer)
     }
 }
-impl<'a, T> CandidType for &'a mut T
+impl<T> CandidType for &mut T
 where
     T: ?Sized + CandidType,
 {
@@ -366,7 +366,7 @@ where
     }
 }
 
-impl<'a, T> CandidType for std::borrow::Cow<'a, T>
+impl<T> CandidType for std::borrow::Cow<'_, T>
 where
     T: ?Sized + CandidType + ToOwned,
 {

--- a/rust/candid/src/types/number.rs
+++ b/rust/candid/src/types/number.rs
@@ -126,7 +126,7 @@ impl<'de> Deserialize<'de> for Int {
         D: serde::Deserializer<'de>,
     {
         struct IntVisitor;
-        impl<'de> Visitor<'de> for IntVisitor {
+        impl Visitor<'_> for IntVisitor {
             type Value = Int;
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("Int value")

--- a/rust/candid/src/types/reference.rs
+++ b/rust/candid/src/types/reference.rs
@@ -104,7 +104,7 @@ impl CandidType for Service {
 /// A [`Visitor`] to extract [`Func`]s.
 pub struct FuncVisitor;
 
-impl<'de> Visitor<'de> for FuncVisitor {
+impl Visitor<'_> for FuncVisitor {
     type Value = Func;
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("Func value")
@@ -138,7 +138,7 @@ impl<'de> Deserialize<'de> for Service {
         D: serde::Deserializer<'de>,
     {
         struct ServVisitor;
-        impl<'de> Visitor<'de> for ServVisitor {
+        impl Visitor<'_> for ServVisitor {
             type Value = Service;
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("Service value")

--- a/rust/candid/src/types/reserved.rs
+++ b/rust/candid/src/types/reserved.rs
@@ -50,7 +50,7 @@ impl<'de> Deserialize<'de> for Empty {
         D: serde::Deserializer<'de>,
     {
         struct EmptyVisitor;
-        impl<'de> Visitor<'de> for EmptyVisitor {
+        impl Visitor<'_> for EmptyVisitor {
             type Value = Empty;
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("Cannot decode empty value")

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -789,7 +789,7 @@ fn path_to_var(path: &[TypePath]) -> String {
 struct NominalState<'a> {
     state: crate::configs::State<'a, BindingConfig>,
 }
-impl<'a> NominalState<'a> {
+impl NominalState<'_> {
     // Convert structural typing to nominal typing to fit Rust's type system
     fn nominalize(&mut self, env: &mut TypeEnv, path: &mut Vec<TypePath>, t: &Type) -> Type {
         let elem = StateElem::Type(t);

--- a/rust/candid_parser/src/configs.rs
+++ b/rust/candid_parser/src/configs.rs
@@ -319,7 +319,7 @@ impl std::str::FromStr for Configs {
         Ok(Configs(v))
     }
 }
-impl<'a> std::fmt::Display for StateElem<'a> {
+impl std::fmt::Display for StateElem<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             StateElem::Type(t) => write!(f, "{}", path_name(t)),

--- a/rust/candid_parser/src/random.rs
+++ b/rust/candid_parser/src/random.rs
@@ -111,7 +111,7 @@ impl ConfigState for GenConfig {
 }
 
 pub struct RandState<'a>(State<'a, GenConfig>);
-impl<'a> RandState<'a> {
+impl RandState<'_> {
     pub fn any(&mut self, u: &mut Unstructured, ty: &Type) -> Result<IDLValue> {
         let old_config = self.0.push_state(&StateElem::Type(ty));
         if let Some(vec) = &self.0.config.value {

--- a/rust/candid_parser/src/token.rs
+++ b/rust/candid_parser/src/token.rs
@@ -169,7 +169,7 @@ pub fn error2<E: ToString>(err: E, span: Span) -> ParserError {
     }
 }
 
-impl<'input> Iterator for Tokenizer<'input> {
+impl Iterator for Tokenizer<'_> {
     type Item = Result<(usize, Token, usize), LexicalError>;
     fn next(&mut self) -> Option<Self::Item> {
         let token = self.lex.next()?;

--- a/rust/candid_parser/src/utils.rs
+++ b/rust/candid_parser/src/utils.rs
@@ -8,7 +8,7 @@ pub enum CandidSource<'a> {
     Text(&'a str),
 }
 
-impl<'a> CandidSource<'a> {
+impl CandidSource<'_> {
     pub fn load(&self) -> Result<(TypeEnv, Option<Type>)> {
         Ok(match self {
             CandidSource::File(path) => pretty_check_file(path)?,

--- a/rust/ic_principal/src/lib.rs
+++ b/rust/ic_principal/src/lib.rs
@@ -340,7 +340,7 @@ mod deserialize {
     // as there's no need for it.
     pub(super) struct PrincipalVisitor;
 
-    impl<'de> serde::de::Visitor<'de> for PrincipalVisitor {
+    impl serde::de::Visitor<'_> for PrincipalVisitor {
         type Value = super::Principal;
 
         fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
This is intended to fix build errors seen on other PRs, for example https://github.com/dfinity/candid/actions/runs/12254878563/job/34186747992?pr=586