### PR TITLE
chore: fix quirks mode warning on Firefox

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,7 +6,7 @@ jobs:
     name: run benchmark
     runs-on: ubuntu-latest
     env:
-      RUSTC_VERSION: 1.79.0
+      RUSTC_VERSION: 1.81.0
     steps:
     - uses: actions/checkout@v4
     - name: Checkout base branch

--- a/tools/ui/Cargo.lock
+++ b/tools/ui/Cargo.lock
@@ -123,7 +123,7 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "candid"
-version = "0.10.10"
+version = "0.10.13"
 dependencies = [
  "anyhow",
  "binread",

--- a/tools/ui/src/candid.html
+++ b/tools/ui/src/candid.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION
Our frontend tests found a warning about quirks mode in Firefox in https://github.com/dfinity/sdk/pull/4131. This removes the need for the warning