### PR TITLE
feat(didc-js): encode and validate specific types and service args

### DIFF
--- a/tools/didc-js/wasm-package/README.md
+++ b/tools/didc-js/wasm-package/README.md
@@ -42,7 +42,7 @@ const methods = getServiceMethods(IDL);
 const encoded = encode({
   idl: IDL,
   input: "(record { number=90; })",
-  withType: { methodParams: "store_number" },
+  withType: { kind: "methodParams", name: "store_number" },
   targetFormat: "hex",
 });
 
@@ -50,7 +50,7 @@ const encoded = encode({
 const encoded = encode({
   idl: IDL,
   input: '(record { field1="Hello"; field2=42 })',
-  withType: { type: "SomeType" },
+  withType: { kind: "type", name: "SomeType" },
   targetFormat: "hex",
 });
 
@@ -58,7 +58,7 @@ const encoded = encode({
 const encoded = encode({
   idl: IDL,
   input: '(record { name="MyCanister" })',
-  withType: { serviceParams: null },
+  withType: { kind: "serviceParams" },
   targetFormat: "hex",
 });
 
@@ -88,10 +88,10 @@ Parameters:
 
 - `idl`: The Candid IDL to encode against
 - `input`: The Candid text value to encode
-- `withType` (optional): Type specifier for encoding:
-  - `{ methodParams: "method_name" }`: Uses the parameters of the specified method
-  - `{ type: "type_name" }`: Uses the specified type
-  - `{ serviceParams: null }`: Uses the service constructor parameters
+- `withType` (optional): Type specifier for encoding (discriminated union):
+  - `{ kind: "methodParams", name: "method_name" }`: Uses the parameters of the specified method
+  - `{ kind: "type", name: "type_name" }`: Uses the specified type
+  - `{ kind: "serviceParams" }`: Uses the service constructor parameters
 - `targetFormat` (optional): Output format, either 'hex' (default) or 'blob'
 
 ### decode(args: DecodeArgs): string

--- a/tools/didc-js/wasm-package/README.md
+++ b/tools/didc-js/wasm-package/README.md
@@ -1,6 +1,6 @@
 # @dfinity/didc
 
-A multi-purpose Candid tool for JavaScript projects, including encoding and decoding Candid values. 
+A multi-purpose Candid tool for JavaScript projects, including encoding and decoding Candid values.
 
 ## Usage
 
@@ -16,7 +16,16 @@ export const IDL = `
     number : nat64;
   };
 
-  service : {
+  type InitArgs = record {
+    name : text;
+  };
+
+  type SomeType = record {
+    field1 : text;
+    field2 : nat64;
+  };
+
+  service : (InitArgs) -> {
     store_number : (input : StoreNumberInput) -> ();
     get_number : () -> (nat64) query;
   };
@@ -33,7 +42,23 @@ const methods = getServiceMethods(IDL);
 const encoded = encode({
   idl: IDL,
   input: "(record { number=90; })",
-  serviceMethod: "store_number",
+  withType: { methodParams: "store_number" },
+  targetFormat: "hex",
+});
+
+// Encodes a specific type - encode values according to a named type
+const encoded = encode({
+  idl: IDL,
+  input: '(record { field1="Hello"; field2=42 })',
+  withType: { type: "SomeType" },
+  targetFormat: "hex",
+});
+
+// Encodes service constructor parameters
+const encoded = encode({
+  idl: IDL,
+  input: '(record { name="MyCanister" })',
+  withType: { serviceParams: null },
   targetFormat: "hex",
 });
 
@@ -48,3 +73,36 @@ const decoded = decode({
   targetFormat: "candid",
 });
 ```
+
+## API Reference
+
+### getServiceMethods(idl: string): string[]
+
+Returns a list of method names available in the service defined in the IDL.
+
+### encode(args: EncodeArgs): string
+
+Encodes Candid text format to hex or blob format.
+
+Parameters:
+
+- `idl`: The Candid IDL to encode against
+- `input`: The Candid text value to encode
+- `withType` (optional): Type specifier for encoding:
+  - `{ methodParams: "method_name" }`: Uses the parameters of the specified method
+  - `{ type: "type_name" }`: Uses the specified type
+  - `{ serviceParams: null }`: Uses the service constructor parameters
+- `targetFormat` (optional): Output format, either 'hex' (default) or 'blob'
+
+### decode(args: DecodeArgs): string
+
+Decodes hex or blob format to Candid text format.
+
+Parameters:
+
+- `idl`: The Candid IDL to decode against
+- `input`: The hex or blob value to decode
+- `serviceMethod` (optional): Method to use for type information
+- `useServiceMethodReturnType` (optional): Whether to use return types (true) or parameter types (false)
+- `inputFormat` (optional): Input format, either 'hex' (default) or 'blob'
+- `targetFormat` (optional): Output format, only 'candid' is supported currently

--- a/tools/didc-js/wasm-package/package.json
+++ b/tools/didc-js/wasm-package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dfinity/didc",
   "description": "Utility tools for candid.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "DFINITY Stiftung",
   "license": "Apache-2.0",
   "repository": "github:dfinity/candid",

--- a/tools/didc-js/wasm-package/package.json
+++ b/tools/didc-js/wasm-package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dfinity/didc",
   "description": "Utility tools for candid.",
-  "version": "0.0.3",
+  "version": "0.0.2",
   "author": "DFINITY Stiftung",
   "license": "Apache-2.0",
   "repository": "github:dfinity/candid",

--- a/tools/didc-js/wasm-package/src/core.rs
+++ b/tools/didc-js/wasm-package/src/core.rs
@@ -54,7 +54,7 @@ pub fn encode(args: EncodeArgs) -> Result<String, LibraryError> {
                     reason: format!("Could not encode args to bytes {}", e),
                 })?
         }
-        (Some(EncodeType::Type(type_name)), Some(_)) => {
+        (Some(EncodeType::Type(type_name)), _) => {
             let type_def =
                 idl.env
                     .find_type(&type_name)

--- a/tools/didc-js/wasm-package/src/core.rs
+++ b/tools/didc-js/wasm-package/src/core.rs
@@ -88,7 +88,7 @@ pub fn encode(args: EncodeArgs) -> Result<String, LibraryError> {
                     }
 
                     idl_args
-                        .to_bytes_with_types(&idl.env, &ctor_args)
+                        .to_bytes_with_types(&idl.env, ctor_args)
                         .map_err(|e| LibraryError::IdlArgsToBytesFailed {
                             reason: format!("Could not encode input to bytes {}", e),
                         })?

--- a/tools/didc-js/wasm-package/src/errors.rs
+++ b/tools/didc-js/wasm-package/src/errors.rs
@@ -9,6 +9,15 @@ pub enum LibraryError {
     /// Service method not found.
     #[error(r#"Service method not found `{method}`."#)]
     IdlMethodNotFound { method: String },
+    /// IDL not specified.
+    #[error(r#"IDL not specified."#)]
+    IdlNotFound,
+    /// Type not found.
+    #[error(r#"Type not found `{type_name}`."#)]
+    TypeNotFound { type_name: String },
+    /// Unexpected service parameters.
+    #[error(r#"Unexpected service parameters."#)]
+    UnexpectedServiceParams,
     /// Failed to parse arguments.
     #[error(r#"Failed to parse arguments `{reason}`."#)]
     IdlArgsParsingFailed { reason: String },

--- a/tools/didc-js/wasm-package/src/validation.rs
+++ b/tools/didc-js/wasm-package/src/validation.rs
@@ -60,7 +60,7 @@ mod tests {
             idl: "test".to_string(),
             target_format: EncodeFormat::Hex,
             input: "test".to_string(),
-            service_method: None,
+            with_type: None,
         };
 
         assert!(args.validate().is_ok());

--- a/tools/didc-js/wasm-tests/src/encode.test.ts
+++ b/tools/didc-js/wasm-tests/src/encode.test.ts
@@ -7,7 +7,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: "(record { number=90; })",
-        withType: { methodParams: "store_number" },
+        withType: { kind: "methodParams", name: "store_number" },
         targetFormat: "hex",
       })
     ).toBe("4449444c016c01c98dea8b0a7801005a00000000000000");
@@ -18,7 +18,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: "(record { number=90; })",
-        withType: { methodParams: "store_number" },
+        withType: { kind: "methodParams", name: "store_number" },
         targetFormat: "blob",
       })
     ).toBe(
@@ -31,7 +31,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: '(record { field1="test"; field2=90; })',
-        withType: { type: "CustomInit" },
+        withType: { kind: "type", name: "CustomInit" },
         targetFormat: "hex",
       })
     ).toBe(
@@ -44,7 +44,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: "(null)",
-        withType: { serviceParams: null },
+        withType: { kind: "serviceParams" },
         targetFormat: "hex",
       })
     ).toBe("4449444c026e016c02b79cba840871b89cba840878010000");
@@ -55,7 +55,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: '(opt record { field1="test"; field2=90; })',
-        withType: { serviceParams: null },
+        withType: { kind: "serviceParams" },
         targetFormat: "hex",
       })
     ).toBe(
@@ -68,7 +68,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: '(record { field1="test"; field2=90; })',
-        withType: { type: "UnknownType" },
+        withType: { kind: "type", name: "UnknownType" },
         targetFormat: "hex",
       });
 
@@ -81,7 +81,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: '(record { field1="test"; unknown_field="bad"; })',
-        withType: { type: "CustomInit" },
+        withType: { kind: "type", name: "CustomInit" },
         targetFormat: "hex",
       });
 
@@ -94,7 +94,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: "(record { number=90; })",
-        withType: { methodParams: "unknown_method" },
+        withType: { kind: "methodParams", name: "unknown_method" },
       });
 
     expect(performEncoding).toThrow(Error);
@@ -108,7 +108,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: "record { number=90; }",
-        withType: { methodParams: "store_number" },
+        withType: { kind: "methodParams", name: "store_number" },
       });
 
     expect(performEncoding).toThrow(Error);

--- a/tools/didc-js/wasm-tests/src/encode.test.ts
+++ b/tools/didc-js/wasm-tests/src/encode.test.ts
@@ -7,7 +7,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: "(record { number=90; })",
-        serviceMethod: "store_number",
+        withType: { methodParams: "store_number" },
         targetFormat: "hex",
       })
     ).toBe("4449444c016c01c98dea8b0a7801005a00000000000000");
@@ -18,7 +18,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: "(record { number=90; })",
-        serviceMethod: "store_number",
+        withType: { methodParams: "store_number" },
         targetFormat: "blob",
       })
     ).toBe(
@@ -26,12 +26,75 @@ describe("encode", () => {
     );
   });
 
+  it("encoding works with arbitrary types", () => {
+    expect(
+      encode({
+        idl: IDL,
+        input: '(record { field1="test"; field2=90; })',
+        withType: { type: "CustomInit" },
+        targetFormat: "hex",
+      })
+    ).toBe(
+      "4449444c016c02b79cba840871b89cba840878010004746573745a00000000000000"
+    );
+  });
+
+  it("encoding works with service parameters (null)", () => {
+    expect(
+      encode({
+        idl: IDL,
+        input: "(null)",
+        withType: { serviceParams: null },
+        targetFormat: "hex",
+      })
+    ).toBe("4449444c026e016c02b79cba840871b89cba840878010000");
+  });
+
+  it("encoding works with service parameters (non-null)", () => {
+    expect(
+      encode({
+        idl: IDL,
+        input: '(opt record { field1="test"; field2=90; })',
+        withType: { serviceParams: null },
+        targetFormat: "hex",
+      })
+    ).toBe(
+      "4449444c026e016c02b79cba840871b89cba84087801000104746573745a00000000000000"
+    );
+  });
+
+  it("encoding throws an error for unknown types", () => {
+    const performEncoding = () =>
+      encode({
+        idl: IDL,
+        input: '(record { field1="test"; field2=90; })',
+        withType: { type: "UnknownType" },
+        targetFormat: "hex",
+      });
+
+    expect(performEncoding).toThrow(Error);
+    expect(performEncoding).toThrow("Type not found `UnknownType`.");
+  });
+
+  it("encoding throws an error for bad values", () => {
+    const performEncoding = () =>
+      encode({
+        idl: IDL,
+        input: '(record { field1="test"; unknown_field="bad"; })',
+        withType: { type: "CustomInit" },
+        targetFormat: "hex",
+      });
+
+    expect(performEncoding).toThrow(Error);
+    expect(performEncoding).toThrow(/field field2 not found/);
+  });
+
   it("encoding with an invalid service method throws", () => {
     const performEncoding = () =>
       encode({
         idl: IDL,
         input: "(record { number=90; })",
-        serviceMethod: "unknown_method",
+        withType: { methodParams: "unknown_method" },
       });
 
     expect(performEncoding).toThrow(Error);
@@ -45,7 +108,7 @@ describe("encode", () => {
       encode({
         idl: IDL,
         input: "record { number=90; }",
-        serviceMethod: "store_number",
+        withType: { methodParams: "store_number" },
       });
 
     expect(performEncoding).toThrow(Error);

--- a/tools/didc-js/wasm-tests/src/test.utils.ts
+++ b/tools/didc-js/wasm-tests/src/test.utils.ts
@@ -13,7 +13,12 @@ export const IDL = `
     B : text;
   };
 
-  service : {
+  type CustomInit = record {
+    field1 : text;
+    field2 : nat64;
+  };
+
+  service : (opt CustomInit) -> {
     store_number : (input : StoreNumberInput) -> ();
     get_number : () -> (nat64) query;
     set_complex_type : (input : CustomType) -> ();


### PR DESCRIPTION
**Overview**
This PR extends the `didc-js` wasm module with capability to encode values of specific types, and values for the service arguments, with the purpose of also validating them against those types. This is useful for JS clients where the user is expected to produce valid candid value for a particular type.

**Requirements**
- the `encode` function can receive type information other than `service_method` such as a type name or instruction to use the service argument types

**Considered Solutions**
I did not find any other solution.

**Recommended Solution**
Since `encode` already has this functionality to encode (and validate) service method arguments, this seems like a good place to extend the functionality.

**Considerations**
