### PR TITLE
fix: typescript interface for func and service should match javascript

### DIFF
--- a/rust/candid_parser/src/bindings/typescript.rs
+++ b/rust/candid_parser/src/bindings/typescript.rs
@@ -23,18 +23,7 @@ fn pp_ty<'a>(env: &'a TypeEnv, ty: &'a Type, is_ref: bool) -> RcDoc<'a> {
         Text => str("string"),
         Reserved => str("any"),
         Empty => str("never"),
-        Var(ref id) => {
-            if is_ref {
-                let ty = env.rec_find_type(id).unwrap();
-                if matches!(ty.as_ref(), Service(_) | Func(_)) {
-                    pp_ty(env, ty, false)
-                } else {
-                    ident(id)
-                }
-            } else {
-                ident(id)
-            }
-        }
+        Var(ref id) => ident(id),
         Principal => str("Principal"),
         Opt(ref t) => str("[] | ").append(enclose("[", pp_ty(env, t, is_ref), "]")),
         Vec(ref t) => {
@@ -85,8 +74,8 @@ fn pp_ty<'a>(env: &'a TypeEnv, ty: &'a Type, is_ref: bool) -> RcDoc<'a> {
                 .nest(INDENT_SPACE)
             }
         }
-        Func(_) => str("[Principal, string]"),
-        Service(_) => str("Principal"),
+        Func(ref func) => pp_function(env, func),
+        Service(ref serv) => pp_service(env, serv),
         Class(_, _) => unreachable!(),
         Knot(_) | Unknown | Future => unreachable!(),
     }

--- a/rust/candid_parser/tests/assets/ok/actor.d.ts
+++ b/rust/candid_parser/tests/assets/ok/actor.d.ts
@@ -4,10 +4,10 @@ import type { IDL } from '@dfinity/candid';
 
 export type f = ActorMethod<[number], number>;
 export type g = f;
-export type h = ActorMethod<[[Principal, string]], [Principal, string]>;
+export type h = ActorMethod<[f], f>;
 export type o = [] | [o];
 export interface _SERVICE {
-  'f' : ActorMethod<[bigint], [Principal, string]>,
+  'f' : ActorMethod<[bigint], h>,
   'g' : f,
   'h' : g,
   'o' : ActorMethod<[o], o>,

--- a/rust/candid_parser/tests/assets/ok/example.d.ts
+++ b/rust/candid_parser/tests/assets/ok/example.d.ts
@@ -8,8 +8,16 @@ export type List = [] | [{ 'head' : bigint, 'tail' : List }];
 export type a = { 'a' : null } |
   { 'b' : b };
 export type b = [bigint, bigint];
-export interface broker { 'find' : ActorMethod<[string], Principal> }
-export type f = ActorMethod<[List, [Principal, string]], [[] | [List], res]>;
+export interface broker {
+  'find' : ActorMethod<
+    [string],
+    { 'current' : ActorMethod<[], number>, 'up' : ActorMethod<[], undefined> }
+  >,
+}
+export type f = ActorMethod<
+  [List, ActorMethod<[number], bigint>],
+  [[] | [List], res]
+>;
 export type list = [] | [node];
 export type my_type = Principal;
 export interface nested {
@@ -30,8 +38,10 @@ export interface node { 'head' : bigint, 'tail' : list }
 export type res = { 'Ok' : [bigint, bigint] } |
   { 'Err' : { 'error' : string } };
 export interface s { 'f' : t, 'g' : ActorMethod<[list], [B, tree, stream]> }
-export type stream = [] | [{ 'head' : bigint, 'next' : [Principal, string] }];
-export type t = ActorMethod<[Principal], undefined>;
+export type stream = [] | [
+  { 'head' : bigint, 'next' : ActorMethod<[], stream> }
+];
+export type t = ActorMethod<[s], undefined>;
 export type tree = {
     'branch' : { 'val' : bigint, 'left' : tree, 'right' : tree }
   } |
@@ -43,7 +53,7 @@ export interface _SERVICE {
   'g' : ActorMethod<[list], [B, tree, stream]>,
   'g1' : ActorMethod<
     [my_type, List, [] | [List], nested],
-    [bigint, Principal, nested_res]
+    [bigint, broker, nested_res]
   >,
   'h' : ActorMethod<
     [

--- a/rust/candid_parser/tests/assets/ok/keyword.d.ts
+++ b/rust/candid_parser/tests/assets/ok/keyword.d.ts
@@ -10,8 +10,10 @@ export type list = [] | [node];
 export interface node { 'head' : bigint, 'tail' : list }
 export type o = [] | [o];
 export interface return_ { 'f' : t, 'g' : ActorMethod<[list], [if_, stream]> }
-export type stream = [] | [{ 'head' : bigint, 'next' : [Principal, string] }];
-export type t = ActorMethod<[Principal], undefined>;
+export type stream = [] | [
+  { 'head' : bigint, 'next' : ActorMethod<[], stream> }
+];
+export type t = ActorMethod<[return_], undefined>;
 export interface _SERVICE {
   'Oneway' : ActorMethod<[], undefined>,
   'f_' : ActorMethod<[o], o>,

--- a/rust/candid_parser/tests/assets/ok/management.d.ts
+++ b/rust/candid_parser/tests/assets/ok/management.d.ts
@@ -116,7 +116,15 @@ export interface _SERVICE {
         'body' : [] | [Uint8Array | number[]],
         'transform' : [] | [
           {
-            'function' : [Principal, string],
+            'function' : ActorMethod<
+              [
+                {
+                  'context' : Uint8Array | number[],
+                  'response' : http_response,
+                },
+              ],
+              http_response
+            >,
             'context' : Uint8Array | number[],
           }
         ],

--- a/rust/candid_parser/tests/assets/ok/recursion.d.ts
+++ b/rust/candid_parser/tests/assets/ok/recursion.d.ts
@@ -7,8 +7,10 @@ export type B = [] | [A];
 export type list = [] | [node];
 export interface node { 'head' : bigint, 'tail' : list }
 export interface s { 'f' : t, 'g' : ActorMethod<[list], [B, tree, stream]> }
-export type stream = [] | [{ 'head' : bigint, 'next' : [Principal, string] }];
-export type t = ActorMethod<[Principal], undefined>;
+export type stream = [] | [
+  { 'head' : bigint, 'next' : ActorMethod<[], stream> }
+];
+export type t = ActorMethod<[s], undefined>;
 export type tree = {
     'branch' : { 'val' : bigint, 'left' : tree, 'right' : tree }
   } |

--- a/rust/candid_parser/tests/assets/ok/recursive_class.d.ts
+++ b/rust/candid_parser/tests/assets/ok/recursive_class.d.ts
@@ -2,7 +2,7 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
-export interface s { 'next' : ActorMethod<[], Principal> }
+export interface s { 'next' : ActorMethod<[], s> }
 export interface _SERVICE extends s {}
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/service.d.ts
+++ b/rust/candid_parser/tests/assets/ok/service.d.ts
@@ -2,20 +2,17 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
-export type Func = ActorMethod<[], Principal>;
+export type Func = ActorMethod<[], Service>;
 export interface Service { 'f' : Func }
 export type Service2 = Service;
 export interface _SERVICE {
-  'asArray' : ActorMethod<[], [Array<Principal>, Array<[Principal, string]>]>,
-  'asPrincipal' : ActorMethod<[], [Principal, [Principal, string]]>,
-  'asRecord' : ActorMethod<
-    [],
-    [Principal, [] | [Principal], [Principal, string]]
-  >,
+  'asArray' : ActorMethod<[], [Array<Service2>, Array<Func>]>,
+  'asPrincipal' : ActorMethod<[], [Service2, Func]>,
+  'asRecord' : ActorMethod<[], [Service2, [] | [Service], Func]>,
   'asVariant' : ActorMethod<
     [],
-    { 'a' : Principal } |
-      { 'b' : { 'f' : [] | [[Principal, string]] } }
+    { 'a' : Service2 } |
+      { 'b' : { 'f' : [] | [Func] } }
   >,
 }
 export declare const idlFactory: IDL.InterfaceFactory;


### PR DESCRIPTION
There is a mismatch between the IDL defined in javascript and the types defined in typescript. There are some hardcoded conversion that always map a func and a service to something containing principal.
```
 Func(_) => str("[Principal, string]"),
 Service(_) => str("Principal"), 
```
Suppose we have the following candid definition
```
type f = func (int8) -> (int8);
type g = f;
type h = func (f) -> (f);
type o = opt o;
service : { f : (nat) -> (h); g : f; h : g; o : (o) -> (o) }
```
Given the above candid this is incorrect to me
`export type h = ActorMethod<[[Principal, string]], [Principal, string]>;`
Correct
`export type h = ActorMethod<[f], f>;`