### PR TITLE
feat: release v0.10.14 with Decoding Utility Functions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,8 +5,6 @@ jobs:
   runBenchMark:
     name: run benchmark
     runs-on: ubuntu-latest
-    env:
-      RUSTC_VERSION: 1.81.0
     steps:
     - uses: actions/checkout@v4
     - name: Checkout base branch

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,6 +5,8 @@ jobs:
   runBenchMark:
     name: run benchmark
     runs-on: ubuntu-latest
+    env:
+      RUSTC_VERSION: 1.82.0
     steps:
     - uses: actions/checkout@v4
     - name: Checkout base branch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "bincode",
@@ -280,7 +280,7 @@ version = "0.2.0-beta.4"
 dependencies = [
  "anyhow",
  "arbitrary",
- "candid 0.10.13",
+ "candid 0.10.14",
  "codespan-reporting",
  "console",
  "convert_case",

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## 2025-05-15
+
+### Candid 0.10.14
+
+* Add a series of decoder functions which provide convenience for ic-cdk macros usage.
+
 ## 2025-01-22
 
 ### Candid 0.10.13

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.10.13"
+version = "0.10.14"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]

--- a/rust/candid/src/lib.rs
+++ b/rust/candid/src/lib.rs
@@ -262,11 +262,11 @@ pub mod ser;
 
 pub mod utils;
 pub use utils::{
-    decode_args, decode_args_with_config, decode_args_with_decoding_quota,
-    decode_args_with_skipping_quota, decode_args_with_decoding_and_skipping_quota,
-    decode_one, decode_one_with_config, decode_one_with_decoding_quota,
-    decode_one_with_skipping_quota, decode_one_with_decoding_and_skipping_quota,
-    encode_args, encode_one, write_args,
+    decode_args, decode_args_with_config, decode_args_with_decoding_and_skipping_quota,
+    decode_args_with_decoding_quota, decode_args_with_skipping_quota, decode_one,
+    decode_one_with_config, decode_one_with_decoding_and_skipping_quota,
+    decode_one_with_decoding_quota, decode_one_with_skipping_quota, encode_args, encode_one,
+    write_args,
 };
 
 #[cfg_attr(docsrs, doc(cfg(feature = "value")))]

--- a/rust/candid/src/lib.rs
+++ b/rust/candid/src/lib.rs
@@ -262,8 +262,11 @@ pub mod ser;
 
 pub mod utils;
 pub use utils::{
-    decode_args, decode_args_with_config, decode_one, decode_one_with_config, encode_args,
-    encode_one, write_args,
+    decode_args, decode_args_with_config, decode_args_with_decoding_quota,
+    decode_args_with_skipping_quota, decode_args_with_decoding_and_skipping_quota,
+    decode_one, decode_one_with_config, decode_one_with_decoding_quota,
+    decode_one_with_skipping_quota, decode_one_with_decoding_and_skipping_quota,
+    encode_args, encode_one, write_args,
 };
 
 #[cfg_attr(docsrs, doc(cfg(feature = "value")))]

--- a/rust/candid/src/types/number.rs
+++ b/rust/candid/src/types/number.rs
@@ -317,12 +317,10 @@ macro_rules! define_eq {
     ($f: ty, $($t: ty)*) => ($(
         impl PartialEq<$t> for $f {
             #[inline]
-            #[must_use]
             fn eq(&self, v: &$t) -> bool { self.0.eq(&(*v).into()) }
         }
         impl PartialEq<$f> for $t {
             #[inline]
-            #[must_use]
             fn eq(&self, v: &$f) -> bool { v.0.eq(&(*self).into()) }
         }
     )*)

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -150,9 +150,9 @@ where
 ///
 /// Example:
 ///
-/// ```
+/// ```ignore
 /// #[ic_cdk::query(decode_with = "decode_args_with_decoding_quota::<10000,_>")]
-/// fn count((arg1, arg2): (String, String)) -> u32 {
+/// fn count(arg1: String, arg2: String) -> u32 {
 ///    arg1.len() as u32 + arg2.len() as u32
 /// }
 /// ```
@@ -218,7 +218,7 @@ where
 ///
 /// Example:
 ///
-/// ```
+/// ```ignore
 /// #[ic_cdk::query(decode_with = "decode_one_with_decoding_quota::<10000,_>")]
 /// fn count(arg: String) -> u32 {
 ///    arg.len() as u32

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -151,10 +151,7 @@ where
 /// Example:
 ///
 /// ```
-/// # use ic_cdk::query;
-/// # use candid::utils::decode_args_with_decoding_quota;
-///
-/// #[query(decode_with = "decode_args_with_decoding_quota::<10000,_>")]
+/// #[ic_cdk::query(decode_with = "decode_args_with_decoding_quota::<10000,_>")]
 /// fn count((arg1, arg2): (String, String)) -> u32 {
 ///    arg1.len() as u32 + arg2.len() as u32
 /// }
@@ -222,10 +219,7 @@ where
 /// Example:
 ///
 /// ```
-/// # use ic_cdk::query;
-/// # use candid::utils::decode_one_with_decoding_quota;
-///
-/// #[query(decode_with = "decode_one_with_decoding_quota::<10000,_>")]
+/// #[ic_cdk::query(decode_with = "decode_one_with_decoding_quota::<10000,_>")]
 /// fn count(arg: String) -> u32 {
 ///    arg.len() as u32
 /// }

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -142,6 +142,33 @@ where
     let cost = de.get_config().compute_cost(config);
     Ok((res, cost))
 }
+pub fn decode_args_with_decoding_quota<const N: usize, Tuple>(byte_vec: Vec<u8>) -> Tuple
+where
+    Tuple: for<'a> ArgumentDecoder<'a>,
+{
+    let mut config = DecoderConfig::new();
+    config.set_decoding_quota(N);
+    decode_args_with_config(&byte_vec[..], &config).unwrap()
+}
+pub fn decode_args_with_skipping_quota<const M: usize, Tuple>(byte_vec: Vec<u8>) -> Tuple
+where
+    Tuple: for<'a> ArgumentDecoder<'a>,
+{
+    let mut config = DecoderConfig::new();
+    config.set_skipping_quota(M);
+    decode_args_with_config(&byte_vec[..], &config).unwrap()
+}
+pub fn decode_args_with_decoding_and_skipping_quota<const N: usize, const M: usize, Tuple>(
+    byte_vec: Vec<u8>,
+) -> Tuple
+where
+    Tuple: for<'a> ArgumentDecoder<'a>,
+{
+    let mut config = DecoderConfig::new();
+    config.set_decoding_quota(N);
+    config.set_skipping_quota(M);
+    decode_args_with_config(&byte_vec[..], &config).unwrap()
+}
 
 /// Decode a single argument.
 ///
@@ -169,6 +196,33 @@ where
 {
     let (res,) = decode_args_with_config(bytes, config)?;
     Ok(res)
+}
+pub fn decode_one_with_decoding_quota<const N: usize, T>(byte_vec: Vec<u8>) -> T
+where
+    T: for<'a> Deserialize<'a> + CandidType,
+{
+    let mut config = DecoderConfig::new();
+    config.set_decoding_quota(N);
+    decode_one_with_config(&byte_vec[..], &config).unwrap()
+}
+pub fn decode_one_with_skipping_quota<const M: usize, T>(byte_vec: Vec<u8>) -> T
+where
+    T: for<'a> Deserialize<'a> + CandidType,
+{
+    let mut config = DecoderConfig::new();
+    config.set_skipping_quota(M);
+    decode_one_with_config(&byte_vec[..], &config).unwrap()
+}
+pub fn decode_one_with_decoding_and_skipping_quota<const N: usize, const M: usize, T>(
+    byte_vec: Vec<u8>,
+) -> T
+where
+    T: for<'a> Deserialize<'a> + CandidType,
+{
+    let mut config = DecoderConfig::new();
+    config.set_decoding_quota(N);
+    config.set_skipping_quota(M);
+    decode_one_with_config(&byte_vec[..], &config).unwrap()
 }
 
 /// Serialize an encoding of a tuple and write it to a `Write` buffer.

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -142,6 +142,23 @@ where
     let cost = de.get_config().compute_cost(config);
     Ok((res, cost))
 }
+
+/// Decode a series of arguments, represented as a tuple, with const generic quotas.
+/// There is a maximum of 16 arguments supported.
+///
+/// This function is particularly useful as a decoder in ic-cdk macros.
+///
+/// Example:
+///
+/// ```
+/// # use ic_cdk::query;
+/// # use candid::utils::decode_args_with_decoding_quota;
+///
+/// #[query(decode_with = "decode_args_with_decoding_quota::<10000,_>")]
+/// fn count((arg1, arg2): (String, String)) -> u32 {
+///    arg1.len() as u32 + arg2.len() as u32
+/// }
+/// ```
 pub fn decode_args_with_decoding_quota<const N: usize, Tuple>(byte_vec: Vec<u8>) -> Tuple
 where
     Tuple: for<'a> ArgumentDecoder<'a>,
@@ -197,6 +214,22 @@ where
     let (res,) = decode_args_with_config(bytes, config)?;
     Ok(res)
 }
+
+/// Decode a single argument with const generic quotas.
+///
+/// This function is particularly useful as a decoder in ic-cdk macros.
+///
+/// Example:
+///
+/// ```
+/// # use ic_cdk::query;
+/// # use candid::utils::decode_one_with_decoding_quota;
+///
+/// #[query(decode_with = "decode_one_with_decoding_quota::<10000,_>")]
+/// fn count(arg: String) -> u32 {
+///    arg.len() as u32
+/// }
+/// ```
 pub fn decode_one_with_decoding_quota<const N: usize, T>(byte_vec: Vec<u8>) -> T
 where
     T: for<'a> Deserialize<'a> + CandidType,

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -146,7 +146,7 @@ where
 /// Decode a series of arguments, represented as a tuple, with const generic quotas.
 /// There is a maximum of 16 arguments supported.
 ///
-/// This function is particularly useful as a decoder in ic-cdk macros.
+/// This function is particularly useful as a decoder in ic-cdk macros (version 0.18 and up).
 ///
 /// Example:
 ///
@@ -214,7 +214,7 @@ where
 
 /// Decode a single argument with const generic quotas.
 ///
-/// This function is particularly useful as a decoder in ic-cdk macros.
+/// This function is particularly useful as a decoder in ic-cdk macros (version 0.18 and up).
 ///
 /// Example:
 ///

--- a/rust/candid/src/utils.rs
+++ b/rust/candid/src/utils.rs
@@ -143,8 +143,7 @@ where
     Ok((res, cost))
 }
 
-/// Decode a series of arguments, represented as a tuple, with const generic quotas.
-/// There is a maximum of 16 arguments supported.
+/// Decode a series of arguments, represented as a tuple, with a decoding_quota specified as a const generic number.
 ///
 /// This function is particularly useful as a decoder in ic-cdk macros (version 0.18 and up).
 ///
@@ -164,6 +163,19 @@ where
     config.set_decoding_quota(N);
     decode_args_with_config(&byte_vec[..], &config).unwrap()
 }
+
+/// Decode a series of arguments, represented as a tuple, with a skipping_quota specified as a const generic number.
+///
+/// This function is particularly useful as a decoder in ic-cdk macros (version 0.18 and up).
+///
+/// Example:
+///
+/// ```ignore
+/// #[ic_cdk::query(decode_with = "decode_args_with_skipping_quota::<10000,_>")]
+/// fn count(arg1: String, arg2: String) -> u32 {
+///    arg1.len() as u32 + arg2.len() as u32
+/// }
+/// ```
 pub fn decode_args_with_skipping_quota<const M: usize, Tuple>(byte_vec: Vec<u8>) -> Tuple
 where
     Tuple: for<'a> ArgumentDecoder<'a>,
@@ -172,6 +184,19 @@ where
     config.set_skipping_quota(M);
     decode_args_with_config(&byte_vec[..], &config).unwrap()
 }
+
+/// Decode a series of arguments, represented as a tuple, with decoding_quota and skipping_quota specified as const generic numbers.
+///
+/// This function is particularly useful as a decoder in ic-cdk macros (version 0.18 and up).
+///
+/// Example:
+///
+/// ```ignore
+/// #[ic_cdk::query(decode_with = "decode_args_with_decoding_and_skipping_quota::<10000,10000,_>")]
+/// fn count(arg1: String, arg2: String) -> u32 {
+///    arg1.len() as u32 + arg2.len() as u32
+/// }
+/// ```
 pub fn decode_args_with_decoding_and_skipping_quota<const N: usize, const M: usize, Tuple>(
     byte_vec: Vec<u8>,
 ) -> Tuple
@@ -212,7 +237,7 @@ where
     Ok(res)
 }
 
-/// Decode a single argument with const generic quotas.
+/// Decode a single argument with a decoding_quota specified as a const generic number.
 ///
 /// This function is particularly useful as a decoder in ic-cdk macros (version 0.18 and up).
 ///
@@ -232,6 +257,19 @@ where
     config.set_decoding_quota(N);
     decode_one_with_config(&byte_vec[..], &config).unwrap()
 }
+
+/// Decode a single argument with a skipping_quota specified as a const generic number.
+///
+/// This function is particularly useful as a decoder in ic-cdk macros (version 0.18 and up).
+///
+/// Example:
+///
+/// ```ignore
+/// #[ic_cdk::query(decode_with = "decode_one_with_skipping_quota::<10000,_>")]
+/// fn count(arg: String) -> u32 {
+///    arg.len() as u32
+/// }
+/// ```
 pub fn decode_one_with_skipping_quota<const M: usize, T>(byte_vec: Vec<u8>) -> T
 where
     T: for<'a> Deserialize<'a> + CandidType,
@@ -240,6 +278,19 @@ where
     config.set_skipping_quota(M);
     decode_one_with_config(&byte_vec[..], &config).unwrap()
 }
+
+/// Decode a single argument with decoding_quota and skipping_quota specified as const generic numbers.
+///
+/// This function is particularly useful as a decoder in ic-cdk macros (version 0.18 and up).
+///
+/// Example:
+///
+/// ```ignore
+/// #[ic_cdk::query(decode_with = "decode_one_with_decoding_and_skipping_quota::<10000,10000,_>")]
+/// fn count(arg: String) -> u32 {
+///    arg.len() as u32
+/// }
+/// ```
 pub fn decode_one_with_decoding_and_skipping_quota<const N: usize, const M: usize, T>(
     byte_vec: Vec<u8>,
 ) -> T


### PR DESCRIPTION
In ic-cdk `0.17.1` macros such as query had direct support for `decoding_quota` and `skipping_quota`, for [0.18.0](https://docs.rs/ic-cdk/0.18.0/ic_cdk/attr.query.html) this was dropped and support for a general user supplied decoding function was added instead.

So if you wanted to use candid but with specific value for `decoding_quota`, you are expected to write your own function. Since the argument is a fixed `Vec<u8>`, it's not possible to provide a generic function for different quotas, except through [const generics](https://practice.course.rs/generics-traits/const-generics.html#:~:text=Const%20generics%20are%20generic%20arguments,type%20T%20and%20N%3A%20usize.). Support for this was recently [added to ic-cdk](https://github.com/dfinity/cdk-rs/pull/599).

A frequent use-case with ic-cdk `0.17.1`
```Rust
 #[query(decoding_quota = 10000)]
fn my_query(arg: T) -> U {
   ..
}
```
could be translated with the functions added here as
```Rust
use candid::decode_args_with_decoding_quota as decoding_quota;

#[query(decode_with = "decoding_quota::<10000,_>")]
fn my_query(arg: T) -> U {
   ..
}
```
