### PR TITLE
feat: support argument names

### DIFF
--- a/rust/candid/src/binary_parser.rs
+++ b/rust/candid/src/binary_parser.rs
@@ -1,4 +1,4 @@
-use crate::types::internal::{Field, Function, Label, Type, TypeInner};
+use crate::types::internal::{ArgType, Field, Function, Label, Type, TypeInner};
 use crate::types::{FuncMode, TypeEnv};
 use anyhow::{anyhow, Context, Result};
 use binread::io::{Read, Seek};
@@ -201,7 +201,10 @@ impl ConsType {
                 let mut args = Vec::new();
                 let mut rets = Vec::new();
                 for arg in &f.args {
-                    args.push(arg.to_type(len)?);
+                    args.push(ArgType {
+                        name: None,
+                        typ: arg.to_type(len)?,
+                    });
                 }
                 for ret in &f.rets {
                     rets.push(ret.to_type(len)?);

--- a/rust/candid/src/pretty/candid.rs
+++ b/rust/candid/src/pretty/candid.rs
@@ -1,5 +1,7 @@
 use crate::pretty::utils::*;
-use crate::types::{Field, FuncMode, Function, Label, SharedLabel, Type, TypeEnv, TypeInner};
+use crate::types::{
+    ArgType, Field, FuncMode, Function, Label, SharedLabel, Type, TypeEnv, TypeInner,
+};
 use pretty::RcDoc;
 
 static KEYWORDS: [&str; 30] = [
@@ -149,7 +151,7 @@ fn pp_fields(fs: &[Field], is_variant: bool) -> RcDoc {
 
 pub fn pp_function(func: &Function) -> RcDoc {
     let args = pp_args(&func.args);
-    let rets = pp_args(&func.rets);
+    let rets = pp_rets(&func.rets);
     let modes = pp_modes(&func.modes);
     args.append(" ->")
         .append(RcDoc::space())
@@ -157,10 +159,22 @@ pub fn pp_function(func: &Function) -> RcDoc {
         .nest(INDENT_SPACE)
 }
 
-pub fn pp_args(args: &[Type]) -> RcDoc {
-    let doc = concat(args.iter().map(pp_ty), ",");
+pub fn pp_args(args: &[ArgType]) -> RcDoc {
+    let doc = concat(
+        args.iter().map(|arg| match &arg.name {
+            Some(name) => pp_text(name).append(kwd(" :")).append(pp_ty(&arg.typ)),
+            None => pp_ty(&arg.typ),
+        }),
+        ",",
+    );
     enclose("(", doc, ")")
 }
+
+pub fn pp_rets(rets: &[Type]) -> RcDoc {
+    let doc = concat(rets.iter().map(pp_ty), ",");
+    enclose("(", doc, ")")
+}
+
 pub fn pp_mode(mode: &FuncMode) -> RcDoc {
     match mode {
         FuncMode::Oneway => RcDoc::text("oneway"),
@@ -205,7 +219,7 @@ fn pp_actor(ty: &Type) -> RcDoc {
     }
 }
 
-pub fn pp_init_args<'a>(env: &'a TypeEnv, args: &'a [Type]) -> RcDoc<'a> {
+pub fn pp_init_args<'a>(env: &'a TypeEnv, args: &'a [ArgType]) -> RcDoc<'a> {
     pp_defs(env).append(pp_args(args))
 }
 pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {

--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -335,13 +335,16 @@ impl TypeSerialize {
                 }
             }
             TypeInner::Func(ref func) => {
-                for ty in func.args.iter().chain(func.rets.iter()) {
+                for ty in &func.args {
+                    self.build_type(&ty.typ)?;
+                }
+                for ty in &func.rets {
                     self.build_type(ty)?;
                 }
                 sleb128_encode(&mut buf, Opcode::Func as i64)?;
                 leb128_encode(&mut buf, func.args.len() as u64)?;
                 for ty in &func.args {
-                    self.encode(&mut buf, ty)?;
+                    self.encode(&mut buf, &ty.typ)?;
                 }
                 leb128_encode(&mut buf, func.rets.len() as u64)?;
                 for ty in &func.rets {

--- a/rust/candid/src/types/mod.rs
+++ b/rust/candid/src/types/mod.rs
@@ -15,7 +15,7 @@ pub mod type_env;
 pub mod value;
 
 pub use self::internal::{
-    get_type, Field, FuncMode, Function, Label, SharedLabel, Type, TypeId, TypeInner,
+    get_type, ArgType, Field, FuncMode, Function, Label, SharedLabel, Type, TypeId, TypeInner,
 };
 pub use type_env::TypeEnv;
 

--- a/rust/candid/src/types/subtype.rs
+++ b/rust/candid/src/types/subtype.rs
@@ -129,8 +129,18 @@ fn subtype_(
             if f1.modes != f2.modes {
                 return Err(Error::msg("Function mode mismatch"));
             }
-            let args1 = to_tuple(&f1.args);
-            let args2 = to_tuple(&f2.args);
+            let f1_args = f1
+                .args
+                .iter()
+                .map(|arg| arg.typ.clone())
+                .collect::<std::vec::Vec<_>>();
+            let f2_args = f2
+                .args
+                .iter()
+                .map(|arg| arg.typ.clone())
+                .collect::<std::vec::Vec<_>>();
+            let args1 = to_tuple(&f1_args);
+            let args2 = to_tuple(&f2_args);
             let rets1 = to_tuple(&f1.rets);
             let rets2 = to_tuple(&f2.rets);
             subtype_(report, gamma, env, &args2, &args1)
@@ -212,8 +222,18 @@ pub fn equal(gamma: &mut Gamma, env: &TypeEnv, t1: &Type, t2: &Type) -> Result<(
             if f1.modes != f2.modes {
                 return Err(Error::msg("Function mode mismatch"));
             }
-            let args1 = to_tuple(&f1.args);
-            let args2 = to_tuple(&f2.args);
+            let f1_args = f1
+                .args
+                .iter()
+                .map(|arg| arg.typ.clone())
+                .collect::<std::vec::Vec<_>>();
+            let f2_args = f2
+                .args
+                .iter()
+                .map(|arg| arg.typ.clone())
+                .collect::<std::vec::Vec<_>>();
+            let args1 = to_tuple(&f1_args);
+            let args2 = to_tuple(&f2_args);
             let rets1 = to_tuple(&f1.rets);
             let rets2 = to_tuple(&f2.rets);
             equal(gamma, env, &args1, &args2).context("Mismatch in function input type")?;
@@ -221,12 +241,20 @@ pub fn equal(gamma: &mut Gamma, env: &TypeEnv, t1: &Type, t2: &Type) -> Result<(
             Ok(())
         }
         (Class(init1, ty1), Class(init2, ty2)) => {
-            let init_1 = to_tuple(init1);
-            let init_2 = to_tuple(init2);
+            let init1_typ = init1
+                .iter()
+                .map(|arg| arg.typ.clone())
+                .collect::<std::vec::Vec<_>>();
+            let init2_typ = init2
+                .iter()
+                .map(|arg| arg.typ.clone())
+                .collect::<std::vec::Vec<_>>();
+            let init_1 = to_tuple(&init1_typ);
+            let init_2 = to_tuple(&init2_typ);
             equal(gamma, env, &init_1, &init_2).context(format!(
                 "Mismatch in init args: {} and {}",
-                pp_args(init1),
-                pp_args(init2)
+                pp_args(&init1),
+                pp_args(&init2)
             ))?;
             equal(gamma, env, ty1, ty2)
         }
@@ -277,7 +305,7 @@ fn to_tuple(args: &[Type]) -> Type {
     .into()
 }
 #[cfg(not(feature = "printer"))]
-fn pp_args(args: &[crate::types::Type]) -> String {
+fn pp_args(args: &[crate::types::ArgType]) -> String {
     use std::fmt::Write;
     let mut s = String::new();
     write!(&mut s, "(").unwrap();
@@ -288,7 +316,7 @@ fn pp_args(args: &[crate::types::Type]) -> String {
     s
 }
 #[cfg(feature = "printer")]
-fn pp_args(args: &[crate::types::Type]) -> String {
+fn pp_args(args: &[crate::types::ArgType]) -> String {
     use crate::pretty::candid::pp_args;
     pp_args(args).pretty(80).to_string()
 }

--- a/rust/candid_parser/src/bindings/analysis.rs
+++ b/rust/candid_parser/src/bindings/analysis.rs
@@ -56,7 +56,8 @@ pub fn chase_type<'a>(
             }
         }
         Func(f) => {
-            for ty in f.args.iter().chain(f.rets.iter()) {
+            let args = f.args.iter().map(|arg| &arg.typ);
+            for ty in args.clone().chain(f.rets.iter()) {
                 chase_type(seen, res, env, ty)?;
             }
         }
@@ -67,7 +68,7 @@ pub fn chase_type<'a>(
         }
         Class(args, t) => {
             for arg in args.iter() {
-                chase_type(seen, res, env, arg)?;
+                chase_type(seen, res, env, &arg.typ)?;
             }
             chase_type(seen, res, env, t)?;
         }
@@ -94,7 +95,7 @@ pub fn chase_def_use<'a>(
     if let TypeInner::Class(args, _) = actor.as_ref() {
         for (i, arg) in args.iter().enumerate() {
             let mut used = Vec::new();
-            chase_type(&mut BTreeSet::new(), &mut used, env, arg)?;
+            chase_type(&mut BTreeSet::new(), &mut used, env, &arg.typ)?;
             for var in used {
                 res.entry(var.to_string())
                     .or_insert_with(Vec::new)
@@ -106,7 +107,7 @@ pub fn chase_def_use<'a>(
         let func = env.as_func(ty)?;
         for (i, arg) in func.args.iter().enumerate() {
             let mut used = Vec::new();
-            chase_type(&mut BTreeSet::new(), &mut used, env, arg)?;
+            chase_type(&mut BTreeSet::new(), &mut used, env, &arg.typ)?;
             for var in used {
                 res.entry(var.to_string())
                     .or_insert_with(Vec::new)
@@ -159,7 +160,8 @@ pub fn infer_rec<'a>(_env: &'a TypeEnv, def_list: &'a [&'a str]) -> Result<BTree
                 }
             }
             Func(f) => {
-                for ty in f.args.iter().chain(f.rets.iter()) {
+                let args = f.args.iter().map(|arg| &arg.typ);
+                for ty in args.clone().chain(f.rets.iter()) {
                     go(seen, res, _env, ty)?;
                 }
             }
@@ -170,7 +172,7 @@ pub fn infer_rec<'a>(_env: &'a TypeEnv, def_list: &'a [&'a str]) -> Result<BTree
             }
             Class(args, t) => {
                 for arg in args.iter() {
-                    go(seen, res, _env, arg)?;
+                    go(seen, res, _env, &arg.typ)?;
                 }
                 go(seen, res, _env, t)?;
             }

--- a/rust/candid_parser/src/bindings/motoko.rs
+++ b/rust/candid_parser/src/bindings/motoko.rs
@@ -3,7 +3,7 @@
 
 use candid::pretty::candid::is_valid_as_id;
 use candid::pretty::utils::*;
-use candid::types::FuncMode;
+use candid::types::{ArgType, FuncMode};
 use candid::types::{Field, Function, Label, SharedLabel, Type, TypeEnv, TypeInner};
 use pretty::RcDoc;
 
@@ -172,7 +172,7 @@ fn pp_variant(field: &Field) -> RcDoc {
 
 fn pp_function(func: &Function) -> RcDoc {
     let args = pp_args(&func.args);
-    let rets = pp_args(&func.rets);
+    let rets = pp_rets(&func.rets);
     match func.modes.as_slice() {
         [FuncMode::Oneway] => kwd("shared").append(args).append(" -> ").append("()"),
         [FuncMode::Query] => kwd("shared query")
@@ -194,7 +194,33 @@ fn pp_function(func: &Function) -> RcDoc {
     }
     .nest(INDENT_SPACE)
 }
-fn pp_args(args: &[Type]) -> RcDoc {
+fn pp_args(args: &[ArgType]) -> RcDoc {
+    match args {
+        [ty] => {
+            let typ = if is_tuple(&ty.typ) {
+                enclose("(", pp_ty(&ty.typ), ")")
+            } else {
+                pp_ty(&ty.typ)
+            };
+            match &ty.name {
+                Some(name) => enclose("(", escape(name, false).append(" : ").append(typ), ")"),
+                None => typ,
+            }
+        }
+        _ => {
+            let doc = concat(
+                args.iter().map(|arg| match &arg.name {
+                    Some(name) => escape(name, false).append(" : ").append(pp_ty(&arg.typ)),
+                    None => pp_ty(&arg.typ),
+                }),
+                ",",
+            );
+            enclose("(", doc, ")")
+        }
+    }
+}
+
+fn pp_rets(args: &[Type]) -> RcDoc {
     match args {
         [ty] => {
             if is_tuple(ty) {

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -3,8 +3,8 @@ use crate::{
     configs::{ConfigState, ConfigTree, Configs, Context, StateElem},
     Deserialize,
 };
-use candid::pretty::utils::*;
 use candid::types::{Field, Function, Label, SharedLabel, Type, TypeEnv, TypeInner};
+use candid::{pretty::utils::*, types::ArgType};
 use convert_case::{Case, Casing};
 use pretty::RcDoc;
 use serde::Serialize;
@@ -168,9 +168,15 @@ impl<'a> State<'a> {
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect(),
         );
-        let src = candid::pretty::candid::pp_init_args(&env, &[src.clone()])
-            .pretty(80)
-            .to_string();
+        let src = candid::pretty::candid::pp_init_args(
+            &env,
+            &[ArgType {
+                name: None,
+                typ: src.clone(),
+            }],
+        )
+        .pretty(80)
+        .to_string();
         let match_path = self.state.config_source.get("use_type").unwrap().join(".");
         let test_name = use_type.replace(|c: char| !c.is_ascii_alphanumeric(), "_");
         let body = format!(
@@ -487,7 +493,22 @@ fn test_{test_name}() {{
         }
         lines(res.into_iter())
     }
-    fn pp_args<'b>(&mut self, args: &'b [Type], prefix: &'b str) -> RcDoc<'b> {
+    fn pp_args<'b>(&mut self, args: &'b [ArgType], prefix: &'b str) -> RcDoc<'b> {
+        let doc: Vec<_> = args
+            .iter()
+            .enumerate()
+            .map(|(i, t)| {
+                let lab = t.name.clone().unwrap_or_else(|| format!("{prefix}{i}"));
+                let old = self.state.push_state(&StateElem::Label(&lab));
+                let res = self.pp_ty(&t.typ, true);
+                self.state.pop_state(old, StateElem::Label(&lab));
+                res
+            })
+            .collect();
+        let doc = concat(doc.into_iter(), ",");
+        enclose("(", doc, ")")
+    }
+    fn pp_rets<'b>(&mut self, args: &'b [Type], prefix: &'b str) -> RcDoc<'b> {
         let doc: Vec<_> = args
             .iter()
             .enumerate()
@@ -506,7 +527,7 @@ fn test_{test_name}() {{
         let lab = StateElem::TypeStr("func");
         let old = self.state.push_state(&lab);
         let args = self.pp_args(&f.args, "arg");
-        let rets = self.pp_args(&f.rets, "ret");
+        let rets = self.pp_rets(&f.rets, "ret");
         let modes = candid::pretty::candid::pp_modes(&f.modes);
         let res = args
             .append(" ->")
@@ -552,8 +573,8 @@ fn test_{test_name}() {{
             .args
             .iter()
             .enumerate()
-            .map(|(i, ty)| {
-                let lab = format!("arg{i}");
+            .map(|(i, arg)| {
+                let lab = arg.name.clone().unwrap_or_else(|| format!("arg{i}"));
                 let old = self.state.push_state(&StateElem::Label(&lab));
                 let name = self
                     .state
@@ -562,7 +583,7 @@ fn test_{test_name}() {{
                     .clone()
                     .unwrap_or_else(|| lab.clone());
                 self.state.update_stats("name");
-                let res = self.pp_ty(ty, true);
+                let res = self.pp_ty(&arg.typ, true);
                 self.state.pop_state(old, StateElem::Label(&lab));
                 (name, res)
             })
@@ -609,8 +630,8 @@ fn test_{test_name}() {{
             let args: Vec<_> = args
                 .iter()
                 .enumerate()
-                .map(|(i, ty)| {
-                    let lab = format!("arg{i}");
+                .map(|(i, arg)| {
+                    let lab = arg.name.clone().unwrap_or_else(|| format!("arg{i}"));
                     let old = self.state.push_state(&StateElem::Label(&lab));
                     let name = self
                         .state
@@ -619,7 +640,7 @@ fn test_{test_name}() {{
                         .clone()
                         .unwrap_or_else(|| lab.clone());
                     self.state.update_stats("name");
-                    let res = self.pp_ty(ty, true);
+                    let res = self.pp_ty(&arg.typ, true);
                     self.state.pop_state(old, StateElem::Label(&lab));
                     (name, res.pretty(LINE_WIDTH).to_string())
                 })
@@ -896,8 +917,8 @@ impl NominalState<'_> {
                             .args
                             .into_iter()
                             .enumerate()
-                            .map(|(i, ty)| {
-                                let lab = format!("arg{i}");
+                            .map(|(i, arg)| {
+                                let lab = arg.name.clone().unwrap_or_else(|| format!("arg{i}"));
                                 let old = self.state.push_state(&StateElem::Label(&lab));
                                 let idx = if i == 0 {
                                     "".to_string()
@@ -905,10 +926,13 @@ impl NominalState<'_> {
                                     i.to_string()
                                 };
                                 path.push(TypePath::Func(format!("arg{idx}")));
-                                let ty = self.nominalize(env, path, &ty);
+                                let ty = self.nominalize(env, path, &arg.typ);
                                 path.pop();
                                 self.state.pop_state(old, StateElem::Label(&lab));
-                                ty
+                                ArgType {
+                                    name: arg.name.clone(),
+                                    typ: ty,
+                                }
                             })
                             .collect(),
                         rets: func
@@ -982,14 +1006,17 @@ impl NominalState<'_> {
             },
             TypeInner::Class(args, ty) => TypeInner::Class(
                 args.iter()
-                    .map(|ty| {
+                    .map(|arg| {
                         let elem = StateElem::Label("init");
                         let old = self.state.push_state(&elem);
                         path.push(TypePath::Init);
-                        let ty = self.nominalize(env, path, ty);
+                        let ty = self.nominalize(env, path, &arg.typ);
                         path.pop();
                         self.state.pop_state(old, elem);
-                        ty
+                        ArgType {
+                            name: arg.name.clone(),
+                            typ: ty,
+                        }
                     })
                     .collect(),
                 self.nominalize(env, path, ty),

--- a/rust/candid_parser/src/bindings/typescript.rs
+++ b/rust/candid_parser/src/bindings/typescript.rs
@@ -109,7 +109,7 @@ fn pp_field<'a>(env: &'a TypeEnv, field: &'a Field, is_ref: bool) -> RcDoc<'a> {
 }
 
 fn pp_function<'a>(env: &'a TypeEnv, func: &'a Function) -> RcDoc<'a> {
-    let args = func.args.iter().map(|ty| pp_ty(env, ty, true));
+    let args = func.args.iter().map(|arg| pp_ty(env, &arg.typ, true));
     let args = enclose("[", concat(args, ","), "]");
     let rets = match func.rets.len() {
         0 => str("undefined"),

--- a/rust/candid_parser/src/grammar.lalrpop
+++ b/rust/candid_parser/src/grammar.lalrpop
@@ -1,4 +1,4 @@
-use super::types::{IDLType, PrimType, TypeField, FuncType, Binding, Dec, IDLProg, IDLTypes, IDLInitArgs};
+use super::types::{IDLType, PrimType, TypeField, FuncType, Binding, Dec, IDLProg, IDLTypes, IDLInitArgs, IDLArgType};
 use super::test::{Assert, Input, Test};
 use super::token::{Token, error2, LexicalError, Span};
 use candid::{Principal, types::Label};
@@ -217,16 +217,18 @@ VariantFieldTyp: TypeField = {
     FieldId =>? Ok(TypeField { label: Label::Id(<>), typ: IDLType::PrimT(PrimType::Null) }),
 }
 
-TupTyp: Vec<IDLType> = "(" <SepBy<ArgTyp, ",">> ")" => <>;
+ArgTupTyp: Vec<IDLArgType> = "(" <SepBy<ArgTyp, ",">> ")" => <>;
+
+TupTyp: Vec<IDLType> = "(" <SepBy<Typ, ",">> ")" => <>;
 
 FuncTyp: FuncType = {
-    <args:TupTyp> "->" <rets:TupTyp> <modes:FuncMode*> =>
+    <args:ArgTupTyp> "->" <rets:TupTyp> <modes:FuncMode*> =>
         FuncType { modes, args, rets },
 }
 
-ArgTyp: IDLType = {
-    Typ => <>,
-    Name ":" <Typ> => <>,
+ArgTyp: IDLArgType = {
+    <t:Typ> => IDLArgType { typ: t, name: None },
+    <n:Name> ":" <t:Typ> => IDLArgType { typ: t, name: Some(n) },
 }
 
 FuncMode: FuncMode = {
@@ -263,7 +265,7 @@ Actor: IDLType = {
 
 MainActor: IDLType = {
     "service" "id"? ":" <t:Actor> ";"? => <>,
-    "service" "id"? ":" <args:TupTyp> "->" <t:Actor> ";"? => IDLType::ClassT(args, Box::new(t)),
+    "service" "id"? ":" <args:ArgTupTyp> "->" <t:Actor> ";"? => IDLType::ClassT(args, Box::new(t)),
 }
 
 pub IDLProg: IDLProg = {
@@ -271,7 +273,7 @@ pub IDLProg: IDLProg = {
 }
 
 pub IDLInitArgs: IDLInitArgs = {
-    <decs:SepBy<Def, ";">> <args:TupTyp> => IDLInitArgs { decs, args }
+    <decs:SepBy<Def, ";">> <args:ArgTupTyp> => IDLInitArgs { decs, args }
 }
 
 // Test file

--- a/rust/candid_parser/src/lib.rs
+++ b/rust/candid_parser/src/lib.rs
@@ -69,7 +69,7 @@
 //!
 //! let method = env.get_method(&actor, "g").unwrap();
 //! assert_eq!(method.is_query(), true);
-//! assert_eq!(method.args, vec![TypeInner::Var("List".to_string()).into()]);
+//! assert_eq!(method.args.iter().map(|arg| arg.typ.clone()).collect::<Vec<_>>(), vec![TypeInner::Var("List".to_string()).into()]);
 //! # Ok(())
 //! # }
 //! ```
@@ -102,7 +102,7 @@
 //! let method = env.get_method(&actor, "f").unwrap();
 //! let args = parse_idl_args("(42, 42, 42, 42)")?;
 //! // Serialize arguments with candid types
-//! let encoded = args.to_bytes_with_types(&env, &method.args)?;
+//! let encoded = args.to_bytes_with_types(&env, &method.args.iter().map(|arg| arg.typ.clone()).collect::<Vec<_>>())?;
 //! let decoded = IDLArgs::from_bytes(&encoded)?;
 //! assert_eq!(decoded.args,
 //!        vec![IDLValue::Nat8(42),

--- a/rust/candid_parser/src/types.rs
+++ b/rust/candid_parser/src/types.rs
@@ -11,7 +11,7 @@ pub enum IDLType {
     RecordT(Vec<TypeField>),
     VariantT(Vec<TypeField>),
     ServT(Vec<Binding>),
-    ClassT(Vec<IDLType>, Box<IDLType>),
+    ClassT(Vec<IDLArgType>, Box<IDLType>),
     PrincipalT,
 }
 
@@ -63,8 +63,14 @@ pub enum PrimType {
 #[derive(Debug, Clone)]
 pub struct FuncType {
     pub modes: Vec<FuncMode>,
-    pub args: Vec<IDLType>,
+    pub args: Vec<IDLArgType>,
     pub rets: Vec<IDLType>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IDLArgType {
+    pub typ: IDLType,
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -95,7 +101,7 @@ pub struct IDLProg {
 #[derive(Debug)]
 pub struct IDLInitArgs {
     pub decs: Vec<Dec>,
-    pub args: Vec<IDLType>,
+    pub args: Vec<IDLArgType>,
 }
 
 impl std::str::FromStr for IDLProg {

--- a/rust/candid_parser/src/utils.rs
+++ b/rust/candid_parser/src/utils.rs
@@ -54,7 +54,10 @@ pub fn instantiate_candid(candid: CandidSource) -> Result<(Vec<Type>, (TypeEnv, 
     let serv = serv.ok_or_else(|| Error::msg("the Candid interface has no main service type"))?;
     let serv = env.trace_type(&serv)?;
     Ok(match serv.as_ref() {
-        TypeInner::Class(args, ty) => (args.clone(), (env, ty.clone())),
+        TypeInner::Class(args, ty) => (
+            args.iter().map(|arg| arg.typ.clone()).collect::<Vec<_>>(),
+            (env, ty.clone()),
+        ),
         TypeInner::Service(_) => (vec![], (env, serv)),
         _ => unreachable!(),
     })
@@ -110,6 +113,6 @@ pub fn check_rust_type<T: candid::CandidType>(candid_args: &str) -> Result<()> {
     let ty = rust_env.add::<T>();
     let ty = env.merge_type(rust_env.env, ty);
     let mut gamma = std::collections::HashSet::new();
-    equal(&mut gamma, &env, &args[0], &ty)?;
+    equal(&mut gamma, &env, &args[0].typ, &ty)?;
     Ok(())
 }

--- a/rust/candid_parser/tests/assets/class.did
+++ b/rust/candid_parser/tests/assets/class.did
@@ -1,6 +1,6 @@
 type Profile = record { age: nat8; name: text };
 type List = opt record { int; List };
-service : (int, List, Profile) -> {
+service : (int, l : List, Profile) -> {
   get : () -> (List);
   set : (List) -> (List);
 }

--- a/rust/candid_parser/tests/assets/ok/class.did
+++ b/rust/candid_parser/tests/assets/ok/class.did
@@ -1,3 +1,6 @@
 type List = opt record { int; List };
 type Profile = record { age : nat8; name : text };
-service : (int, List, Profile) -> { get : () -> (List); set : (List) -> (List) }
+service : (int, l : List, Profile) -> {
+  get : () -> (List);
+  set : (List) -> (List);
+}

--- a/rust/candid_parser/tests/assets/ok/class.mo
+++ b/rust/candid_parser/tests/assets/ok/class.mo
@@ -4,7 +4,7 @@
 module {
   public type List = ?(Int, List);
   public type Profile = { age : Nat8; name : Text };
-  public type Self = (Int, List, Profile) -> async actor {
+  public type Self = (Int, l : List, Profile) -> async actor {
     get : shared () -> async List;
     set : shared List -> async List;
   }

--- a/rust/candid_parser/tests/assets/ok/class.rs
+++ b/rust/candid_parser/tests/assets/ok/class.rs
@@ -9,7 +9,7 @@ pub struct List(pub Option<(candid::Int,Box<List>,)>);
 pub struct Profile { pub age: u8, pub name: String }
 
 #[ic_cdk::init]
-fn init(arg0: candid::Int, arg1: List, arg2: Profile) {
+fn init(arg0: candid::Int, l: List, arg2: Profile) {
   unimplemented!()
 }
 #[ic_cdk::update]

--- a/rust/candid_parser/tests/assets/ok/example.did
+++ b/rust/candid_parser/tests/assets/ok/example.did
@@ -4,7 +4,7 @@ type List = opt record { head : int; tail : List };
 type a = variant { a; b : b };
 type b = record { int; nat };
 type broker = service {
-  find : (text) -> (service { current : () -> (nat32); up : () -> () });
+  find : (name : text) -> (service { current : () -> (nat32); up : () -> () });
 };
 type f = func (List, func (int32) -> (int64)) -> (opt List, res);
 type list = opt node;
@@ -26,7 +26,7 @@ type node = record { head : nat; tail : list };
 type res = variant { Ok : record { int; nat }; Err : record { error : text } };
 type s = service { f : t; g : (list) -> (B, tree, stream) };
 type stream = opt record { head : nat; next : func () -> (stream) query };
-type t = func (s) -> ();
+type t = func (server : s) -> ();
 type tree = variant {
   branch : record { val : int; left : tree; right : tree };
   leaf : int;
@@ -34,7 +34,7 @@ type tree = variant {
 service : {
   bbbbb : (b) -> ();
   f : t;
-  f1 : (list, blob, opt bool) -> () oneway;
+  f1 : (list, test : blob, opt bool) -> () oneway;
   g : (list) -> (B, tree, stream);
   g1 : (my_type, List, opt List, nested) -> (int, broker, nested_res) query;
   h : (vec opt text, variant { A : nat; B : opt text }, opt List) -> (

--- a/rust/candid_parser/tests/assets/ok/example.mo
+++ b/rust/candid_parser/tests/assets/ok/example.mo
@@ -8,7 +8,7 @@ module {
   public type a = { #a; #b : b };
   public type b = (Int, Nat);
   public type broker = actor {
-    find : shared Text -> async actor {
+    find : shared (name : Text) -> async actor {
         current : shared () -> async Nat32;
         up : shared () -> async ();
       };
@@ -36,7 +36,7 @@ module {
   public type res = { #Ok : (Int, Nat); #Err : { error : Text } };
   public type s = actor { f : t; g : shared list -> async (B, tree, stream) };
   public type stream = ?{ head : Nat; next : shared query () -> async stream };
-  public type t = shared s -> async ();
+  public type t = shared (server : s) -> async ();
   public type tree = {
     #branch : { val : Int; left : tree; right : tree };
     #leaf : Int;
@@ -44,7 +44,7 @@ module {
   public type Self = actor {
     bbbbb : shared b -> async ();
     f : t;
-    f1 : shared (list, Blob, ?Bool) -> ();
+    f1 : shared (list, test : Blob, ?Bool) -> ();
     g : shared list -> async (B, tree, stream);
     g1 : shared query (my_type, List, ?List, nested) -> async (
         Int,

--- a/rust/candid_parser/tests/assets/ok/example.rs
+++ b/rust/candid_parser/tests/assets/ok/example.rs
@@ -107,11 +107,11 @@ impl Service {
   pub async fn bbbbb(&self, arg0: &B) -> Result<()> {
     ic_cdk::call(self.0, "bbbbb", (arg0,)).await
   }
-  pub async fn f(&self, arg0: &S) -> Result<()> {
-    ic_cdk::call(self.0, "f", (arg0,)).await
+  pub async fn f(&self, server: &S) -> Result<()> {
+    ic_cdk::call(self.0, "f", (server,)).await
   }
-  pub async fn f_1(&self, arg0: &List, arg1: &serde_bytes::ByteBuf, arg2: &Option<bool>) -> Result<()> {
-    ic_cdk::call(self.0, "f1", (arg0,arg1,arg2,)).await
+  pub async fn f_1(&self, arg0: &List, test: &serde_bytes::ByteBuf, arg2: &Option<bool>) -> Result<()> {
+    ic_cdk::call(self.0, "f1", (arg0,test,arg2,)).await
   }
   pub async fn g(&self, arg0: &List) -> Result<(B,Tree,Stream,)> {
     ic_cdk::call(self.0, "g", (arg0,)).await

--- a/rust/candid_parser/tests/assets/ok/fieldnat.did
+++ b/rust/candid_parser/tests/assets/ok/fieldnat.did
@@ -1,7 +1,7 @@
 type non_tuple = record { 1 : text; 2 : text };
 type tuple = record { text; text };
 service : {
-  bab : (int, nat) -> ();
+  bab : (two : int, "2" : nat) -> ();
   bar : (record { "2" : int }) -> (variant { e20; e30 });
   bas : (record { int; int }) -> (record { text; nat });
   baz : (record { 2 : int; "2" : nat }) -> (record {});

--- a/rust/candid_parser/tests/assets/ok/fieldnat.mo
+++ b/rust/candid_parser/tests/assets/ok/fieldnat.mo
@@ -5,7 +5,7 @@ module {
   public type non_tuple = { _1_  : Text; _2_  : Text };
   public type tuple = (Text, Text);
   public type Self = actor {
-    bab : shared (Int, Nat) -> async ();
+    bab : shared (two : Int, _50_ : Nat) -> async ();
     bar : shared { _50_ : Int } -> async { #e20; #e30 };
     bas : shared ((Int, Int)) -> async ((Text, Nat));
     baz : shared { _2_  : Int; _50_ : Nat } -> async {};

--- a/rust/candid_parser/tests/assets/ok/fieldnat.rs
+++ b/rust/candid_parser/tests/assets/ok/fieldnat.rs
@@ -29,8 +29,8 @@ pub struct FooRet { pub _2_: candid::Int, pub _2: candid::Int }
 
 pub struct Service(pub Principal);
 impl Service {
-  pub async fn bab(&self, arg0: &candid::Int, arg1: &candid::Nat) -> Result<()> {
-    ic_cdk::call(self.0, "bab", (arg0,arg1,)).await
+  pub async fn bab(&self, two: &candid::Int, 2: &candid::Nat) -> Result<()> {
+    ic_cdk::call(self.0, "bab", (two,2,)).await
   }
   pub async fn bar(&self, arg0: &BarArg) -> Result<(BarRet,)> {
     ic_cdk::call(self.0, "bar", (arg0,)).await

--- a/rust/candid_parser/tests/assets/ok/keyword.did
+++ b/rust/candid_parser/tests/assets/ok/keyword.did
@@ -7,7 +7,7 @@ type node = record { head : nat; tail : list };
 type o = opt o;
 type return = service { f : t; g : (list) -> (if, stream) };
 type stream = opt record { head : nat; next : func () -> (stream) query };
-type t = func (return) -> ();
+type t = func (server : return) -> ();
 service : {
   Oneway : () -> () oneway;
   f_ : (o) -> (o);

--- a/rust/candid_parser/tests/assets/ok/keyword.mo
+++ b/rust/candid_parser/tests/assets/ok/keyword.mo
@@ -11,7 +11,7 @@ module {
   public type o = ?o;
   public type return_ = actor { f : t; g : shared list -> async (if_, stream) };
   public type stream = ?{ head : Nat; next : shared query () -> async stream };
-  public type t = shared return_ -> async ();
+  public type t = shared (server : return_) -> async ();
   public type Self = actor {
     Oneway : shared () -> ();
     f__ : shared o -> async o;

--- a/rust/candid_parser/tests/assets/ok/keyword.rs
+++ b/rust/candid_parser/tests/assets/ok/keyword.rs
@@ -66,8 +66,8 @@ impl Service {
   pub async fn r#return(&self, arg0: &O) -> Result<(O,)> {
     ic_cdk::call(self.0, "return", (arg0,)).await
   }
-  pub async fn service(&self, arg0: &Return) -> Result<()> {
-    ic_cdk::call(self.0, "service", (arg0,)).await
+  pub async fn service(&self, server: &Return) -> Result<()> {
+    ic_cdk::call(self.0, "service", (server,)).await
   }
   pub async fn tuple(&self, arg0: &(candid::Int,serde_bytes::ByteBuf,String,)) -> Result<((candid::Int,u8,),)> {
     ic_cdk::call(self.0, "tuple", (arg0,)).await

--- a/rust/candid_parser/tests/assets/ok/recursion.did
+++ b/rust/candid_parser/tests/assets/ok/recursion.did
@@ -4,7 +4,7 @@ type list = opt node;
 type node = record { head : nat; tail : list };
 type s = service { f : t; g : (list) -> (B, tree, stream) };
 type stream = opt record { head : nat; next : func () -> (stream) query };
-type t = func (s) -> ();
+type t = func (server : s) -> ();
 type tree = variant {
   branch : record { val : int; left : tree; right : tree };
   leaf : int;

--- a/rust/candid_parser/tests/assets/ok/recursion.mo
+++ b/rust/candid_parser/tests/assets/ok/recursion.mo
@@ -8,7 +8,7 @@ module {
   public type node = { head : Nat; tail : list };
   public type s = actor { f : t; g : shared list -> async (B, tree, stream) };
   public type stream = ?{ head : Nat; next : shared query () -> async stream };
-  public type t = shared s -> async ();
+  public type t = shared (server : s) -> async ();
   public type tree = {
     #branch : { val : Int; left : tree; right : tree };
     #leaf : Int;

--- a/rust/candid_parser/tests/assets/ok/recursion.rs
+++ b/rust/candid_parser/tests/assets/ok/recursion.rs
@@ -31,8 +31,8 @@ candid::define_service!(pub S : {
 
 pub struct Service(pub Principal);
 impl Service {
-  pub async fn f(&self, arg0: &S) -> Result<()> {
-    ic_cdk::call(self.0, "f", (arg0,)).await
+  pub async fn f(&self, server: &S) -> Result<()> {
+    ic_cdk::call(self.0, "f", (server,)).await
   }
   pub async fn g(&self, arg0: &List) -> Result<(B,Tree,Stream,)> {
     ic_cdk::call(self.0, "g", (arg0,)).await

--- a/rust/candid_parser/tests/value.rs
+++ b/rust/candid_parser/tests/value.rs
@@ -37,7 +37,16 @@ service : {
     let method = env.get_method(&actor, "f").unwrap();
     {
         let args = parse_idl_args("(42,42,42,42)").unwrap();
-        let encoded = args.to_bytes_with_types(&env, &method.args).unwrap();
+        let encoded = args
+            .to_bytes_with_types(
+                &env,
+                &method
+                    .args
+                    .iter()
+                    .map(|arg| arg.typ.clone())
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
         let decoded = IDLArgs::from_bytes(&encoded).unwrap();
         assert_eq!(
             decoded.args,

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -146,10 +146,9 @@ impl TypeAnnotation {
                     .ok_or_else(|| Error::msg("Cannot use --method with a non-service did file"))?;
                 let func = env.get_method(&actor, meth)?;
                 let types = match mode {
-                    Mode::Encode => &func.args,
-                    Mode::Decode => &func.rets,
-                }
-                .clone();
+                    Mode::Encode => func.args.iter().map(|arg| arg.typ.clone()).collect(),
+                    Mode::Decode => func.rets.clone(),
+                };
                 Ok((env, types))
             }
             _ => unreachable!(),


### PR DESCRIPTION
**Overview**
Adds support for named arguments: if a `.did` Candid declaration file declares functions, classes or services with named arguments, those names are parsed by the `candid-parser` and preserved in the generated bindings.
At the same time, the names of the arguments are preserved if the Candid declaration file is generated from a Rust canister.

**Requirements**
To consider this feature complete, the Motoko compiler should preserve the actor methods names from Motoko canisters to the Candid declaration files.

**Considerations**
This change should be backwards compatible.

Picked up from https://github.com/ilbertt/candid/tree/luca/arg-names
