### PR TITLE
ci: turn on terminal colors

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTC_VERSION: 1.82.0
+      CARGO_TERM_COLOR: always # Force Cargo to use colors
+      TERM: xterm-256color
     steps:
       - uses: actions/checkout@v4
       - name: Checkout base branch

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,53 +5,57 @@ on:
       - master
   pull_request:
 
+env:
+  CARGO_TERM_COLOR: always # Force Cargo to use colors
+  TERM: xterm-256color
+
 jobs:
   rust:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy
-    - name: Cache cargo build
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Build
-      run: |
-        cargo build
-    - name: Run tests
-      run: |
-        cargo test --no-default-features
-        cargo test
-        cargo test --features all
-    - name: fmt
-      run: cargo fmt -v -- --check
-    - name: lint
-      run: cargo clippy --features all --tests -- -D warnings
-    - name: doc
-      run: cargo doc
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build
+        run: |
+          cargo build
+      - name: Run tests
+        run: |
+          cargo test --no-default-features --color always -- --color always
+          cargo test --color always -- --color always
+          cargo test --features all --color always -- --color always
+      - name: fmt
+        run: cargo fmt -v -- --check
+      - name: lint
+        run: cargo clippy --features all --tests -- -D warnings
+      - name: doc
+        run: cargo doc
   fuzzing:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust (nightly)
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-    - name: Install cargo-fuzz
-      run: |
-        cargo install cargo-fuzz
-    - name: Build fuzzers
-      run: |
-        cd rust/candid
-        cargo +nightly fuzz build
+      - uses: actions/checkout@v4
+      - name: Install Rust (nightly)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Install cargo-fuzz
+        run: |
+          cargo install cargo-fuzz
+      - name: Build fuzzers
+        run: |
+          cd rust/candid
+          cargo +nightly fuzz build


### PR DESCRIPTION
**Overview**
Improved logs readability by turning on terminal colors.

Before
![image](https://github.com/user-attachments/assets/6d5435f3-e893-4221-87c0-adec37459dc7)
![image](https://github.com/user-attachments/assets/1d6328c2-db36-44d6-a3bb-c8385a9760d5)

After
![image](https://github.com/user-attachments/assets/bb4eaaec-45f8-429d-b95e-63471acf97ad)
![image](https://github.com/user-attachments/assets/a55e25a1-0093-4cd6-a553-d9e55c2a5fc1)

**Considerations**
May affect scripts that process raw output text.
