### PR TITLE
chore: cleanup settings for color in logs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,6 +8,7 @@ jobs:
     env:
       RUSTC_VERSION: 1.82.0
       CARGO_TERM_COLOR: always # Force Cargo to use colors
+      TERM: xterm-256color
     steps:
       - uses: actions/checkout@v4
       - name: Checkout base branch

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTC_VERSION: 1.82.0
+      CARGO_TERM_COLOR: always # Force Cargo to use colors
     steps:
       - uses: actions/checkout@v4
       - name: Checkout base branch
@@ -37,7 +38,7 @@ jobs:
             rust/bench/target
           key: ${{ runner.os }}-bench-0.1.4-${{ hashFiles('**/Cargo.lock') }}
       - name: Install canbench
-        run: cargo install --version 0.2.0 --locked canbench --color always
+        run: cargo install --version 0.2.0 --locked canbench
       - name: Run perf for base branch
         run: |
           pushd main/rust/bench

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTC_VERSION: 1.82.0
-      CARGO_TERM_COLOR: always # Force Cargo to use colors
-      TERM: xterm-256color
     steps:
       - uses: actions/checkout@v4
       - name: Checkout base branch

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTC_VERSION: 1.82.0
+      CARGO_TERM_COLOR: always # Force Cargo to use colors
     steps:
       - uses: actions/checkout@v4
       - name: Checkout base branch

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTC_VERSION: 1.82.0
-      CARGO_TERM_COLOR: always # Force Cargo to use colors
     steps:
       - uses: actions/checkout@v4
       - name: Checkout base branch
@@ -38,7 +37,7 @@ jobs:
             rust/bench/target
           key: ${{ runner.os }}-bench-0.1.4-${{ hashFiles('**/Cargo.lock') }}
       - name: Install canbench
-        run: cargo install --version 0.2.0 --locked canbench
+        run: cargo install --version 0.2.0 --locked canbench --color always
       - name: Run perf for base branch
         run: |
           pushd main/rust/bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
 
+env:
+  CARGO_TERM_COLOR: always # Force Cargo to use colors
+
 jobs:
   rust:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,9 +34,9 @@ jobs:
           cargo build
       - name: Run tests
         run: |
-          cargo test --no-default-features
-          cargo test
-          cargo test --features all
+          cargo test --no-default-features -- --color always
+          cargo test -- --color always
+          cargo test --features all -- --color always
       - name: fmt
         run: cargo fmt -v -- --check
       - name: lint

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,9 +33,9 @@ jobs:
           cargo build
       - name: Run tests
         run: |
-          cargo test --no-default-features -- --color always
-          cargo test -- --color always
-          cargo test --features all -- --color always
+          cargo test --no-default-features --color always
+          cargo test --color always
+          cargo test --features all --color always
       - name: fmt
         run: cargo fmt -v -- --check
       - name: lint

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always # Force Cargo to use colors
+  TERM: xterm-256color
 
 jobs:
   rust:
@@ -33,9 +34,9 @@ jobs:
           cargo build
       - name: Run tests
         run: |
-          cargo test --no-default-features --color always -- --color always
-          cargo test --color always -- --color always
-          cargo test --features all --color always -- --color always
+          cargo test --no-default-features
+          cargo test
+          cargo test --features all
       - name: fmt
         run: cargo fmt -v -- --check
       - name: lint

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
 
+env:
+  CARGO_TERM_COLOR: always # Force Cargo to use colors
+
 jobs:
   rust:
     runs-on: ubuntu-latest
@@ -27,12 +30,12 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build
         run: |
-          cargo build --color always
+          cargo build
       - name: Run tests
         run: |
-          cargo test --no-default-features --color always -- --color always
-          cargo test --color always -- --color always
-          cargo test --features all --color always -- --color always
+          cargo test --no-default-features -- --color always
+          cargo test -- --color always
+          cargo test --features all -- --color always
       - name: fmt
         run: cargo fmt -v -- --check
       - name: lint

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,9 +33,9 @@ jobs:
           cargo build
       - name: Run tests
         run: |
-          cargo test --no-default-features --color always
-          cargo test --color always
-          cargo test --features all --color always
+          cargo test --no-default-features --color always -- --color always
+          cargo test --color always -- --color always
+          cargo test --features all --color always -- --color always
       - name: fmt
         run: cargo fmt -v -- --check
       - name: lint

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,10 +5,6 @@ on:
       - master
   pull_request:
 
-env:
-  CARGO_TERM_COLOR: always # Force Cargo to use colors
-  TERM: xterm-256color
-
 jobs:
   rust:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,9 +5,6 @@ on:
       - master
   pull_request:
 
-env:
-  CARGO_TERM_COLOR: always # Force Cargo to use colors
-
 jobs:
   rust:
     runs-on: ubuntu-latest
@@ -30,7 +27,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build
         run: |
-          cargo build
+          cargo build --color always
       - name: Run tests
         run: |
           cargo test --no-default-features --color always -- --color always


### PR DESCRIPTION
Remove unnecessary flags.

The colors in tests still present:
![image](https://github.com/user-attachments/assets/af3be01c-0fc2-495c-8767-38a2da15549f)
