### PR TITLE
wip: lex documentation comments, and attach them to declarations

### DIFF
--- a/rust/candid_parser/src/grammar.lalrpop
+++ b/rust/candid_parser/src/grammar.lalrpop
@@ -1,12 +1,12 @@
-use super::types::{IDLType, PrimType, TypeField, FuncType, Binding, Dec, IDLProg, IDLTypes, IDLInitArgs, IDLArgType};
+use super::types::{IDLType, PrimType, TypeField, FuncType, Binding, Dec, DecInner, IDLProg, IDLTypes, IDLInitArgs, IDLArgType};
 use super::test::{Assert, Input, Test};
-use super::token::{Token, error, error2, LexicalError, Span};
+use super::token::{Token, error, error2, LexicalError, Span, TriviaMap};
 use candid::{Principal, types::Label};
 use candid::types::value::{IDLField, IDLValue, IDLArgs, VariantValue};
 use candid::types::{TypeEnv, FuncMode};
 use candid::utils::check_unique;
 
-grammar;
+grammar(trivia: Option<&TriviaMap>);
 
 extern {
     type Location = usize;
@@ -257,11 +257,17 @@ MethTyp: Binding = {
     <n:Name> ":" <id:"id"> => Binding { id: n, typ: IDLType::VarT(id) },
 }
 
-// Type declarations
 Def: Dec = {
-    "type" <id:"id"> "=" <t:Typ> => Dec::TypD(Binding { id: id, typ: t }),
-    "import" <Text> => Dec::ImportType(<>),
-    "import" "service" <Text> => Dec::ImportServ(<>),
+  <doc_comment: DocComment> <inner: DefInner> => {
+    Dec { doc_comment, inner }
+  }
+}
+
+// Type declarations
+DefInner: DecInner = {
+    "type" <id:"id"> "=" <t:Typ> => DecInner::TypD(Binding { id: id, typ: t }),
+    "import" <Text> => DecInner::ImportType(<>),
+    "import" "service" <Text> => DecInner::ImportServ(<>),
 }
 
 Actor: IDLType = {
@@ -327,3 +333,13 @@ SepBy<T, S>: Vec<T> = {
 #[inline]
 Sp<T>: (T, Span) =
     <l: @L> <t: T> <r: @R> => (t, l..r);
+
+#[inline]
+DocComment: Option<Vec<String>> =
+    <l: @L> => {
+      let mut comment = None;
+      if let Some(trivia) = &trivia {
+        comment = trivia.borrow().get(&l).cloned();
+      }
+      comment
+    };

--- a/rust/candid_parser/src/lib.rs
+++ b/rust/candid_parser/src/lib.rs
@@ -144,10 +144,10 @@ pub mod test;
 
 pub fn parse_idl_args(s: &str) -> crate::Result<candid::IDLArgs> {
     let lexer = token::Tokenizer::new(s);
-    Ok(grammar::ArgsParser::new().parse(lexer)?)
+    Ok(grammar::ArgsParser::new().parse(None, lexer)?)
 }
 
 pub fn parse_idl_value(s: &str) -> crate::Result<candid::IDLValue> {
     let lexer = token::Tokenizer::new(s);
-    Ok(grammar::ArgParser::new().parse(lexer)?)
+    Ok(grammar::ArgParser::new().parse(None, lexer)?)
 }

--- a/rust/candid_parser/src/test.rs
+++ b/rust/candid_parser/src/test.rs
@@ -78,7 +78,7 @@ impl std::str::FromStr for Test {
     type Err = Error;
     fn from_str(str: &str) -> std::result::Result<Self, Self::Err> {
         let lexer = super::token::Tokenizer::new(str);
-        Ok(super::grammar::TestParser::new().parse(lexer)?)
+        Ok(super::grammar::TestParser::new().parse(None, lexer)?)
     }
 }
 

--- a/rust/candid_parser/src/token.rs
+++ b/rust/candid_parser/src/token.rs
@@ -1,3 +1,4 @@
+use std::{cell::RefCell, collections::HashMap, mem, rc::Rc};
 use lalrpop_util::ParseError;
 use logos::{Lexer, Logos};
 
@@ -5,6 +6,8 @@ use logos::{Lexer, Logos};
 #[logos(skip r"[ \t\r\n]+")]
 #[logos(skip r"//[^\n]*")] // line comment
 pub enum Token {
+    #[regex(r"///[^\n]*")]
+    DocComment,
     #[token("/*")]
     StartComment,
     #[token("=")]
@@ -118,22 +121,26 @@ fn parse_number(lex: &mut Lexer<Token>) -> String {
     }
 }
 
+pub type TriviaMap = Rc<RefCell<HashMap<usize, Vec<String>>>>;
+
 pub struct Tokenizer<'input> {
     lex: Lexer<'input, Token>,
+    comment_buffer: Vec<String>,
+    trivia: Option<TriviaMap>,
 }
 impl<'input> Tokenizer<'input> {
     pub fn new(input: &'input str) -> Self {
         let lex = Token::lexer(input);
-        Tokenizer { lex }
+        Tokenizer { lex, comment_buffer: vec![], trivia: None }
+    }
+
+    pub fn new_with_trivia(input: &'input str, trivia: TriviaMap) -> Self {
+        let lex = Token::lexer(input);
+        Tokenizer { lex, comment_buffer: vec![], trivia: Some(trivia) }
     }
 }
 
 pub type Span = std::ops::Range<usize>;
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Spanned<T> {
-    pub span: Span,
-    pub value: T,
-}
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LexicalError {
     pub err: String,
@@ -178,6 +185,13 @@ impl Iterator for Tokenizer<'_> {
             Err(_) => {
                 let err = format!("Unknown token {}", self.lex.slice());
                 Some(Err(LexicalError::new(err, span)))
+            }
+            Ok(Token::DocComment) => {
+                let content = self.lex.slice();
+                if self.trivia.is_some() {
+                    self.comment_buffer.push(content.to_string());
+                }
+                self.next()
             }
             Ok(Token::StartComment) => {
                 let mut lex = self.lex.to_owned().morph::<Comment>();
@@ -278,7 +292,15 @@ impl Iterator for Tokenizer<'_> {
                 self.lex = lex.morph::<Token>();
                 Some(Ok((span.start, Token::Text(result), self.lex.span().end)))
             }
-            Ok(token) => Some(Ok((span.start, token, span.end))),
+            Ok(token) => {
+                if let Some(trivia) = &mut self.trivia {
+                    if !self.comment_buffer.is_empty() {
+                        let content: Vec<String> = mem::take(&mut self.comment_buffer);
+                        trivia.borrow_mut().insert(span.start, content);
+                    }
+                }
+                Some(Ok((span.start, token, span.end)))
+            }
         }
     }
 }


### PR DESCRIPTION
DON'T MERGE

Uses a side-table to store documentation comments from the lexer, and uses a bit of interior mutability to let the parser attach them to nodes as it parses. This lets us specify where documentation comments are parsed in the grammar without introducing a breaking change for existing documentation comments in unsupported locations.

/cc @ilbertt @crusso 