### PR TITLE
refactor!: move `IDL*` types into the candid crate, under the `parser` feature flag

### DIFF
--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -45,8 +45,9 @@ candid_parser = { path = "../candid_parser" }
 bignum = ["dep:num-bigint", "dep:num-traits"]
 printer = ["dep:pretty"]
 value = ["bignum", "printer"]
+parser = []
 default = ["serde_bytes", "printer", "bignum"]
-all = ["default", "value", "ic_principal/arbitrary"]
+all = ["default", "value", "ic_principal/arbitrary", "parser"]
 
 [[test]]
 name = "types"

--- a/rust/candid/src/types/mod.rs
+++ b/rust/candid/src/types/mod.rs
@@ -8,6 +8,8 @@ use serde::ser::Error;
 
 mod impls;
 pub mod internal;
+#[cfg(feature = "parser")]
+pub mod parser;
 pub mod subtype;
 pub mod type_env;
 #[cfg_attr(docsrs, doc(cfg(feature = "value")))]

--- a/rust/candid/src/types/parser.rs
+++ b/rust/candid/src/types/parser.rs
@@ -1,7 +1,6 @@
-use crate::Result;
-use candid::types::{FuncMode, Label};
+use crate::types::{FuncMode, Label};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IDLType {
     PrimT(PrimType),
     VarT(String),
@@ -60,14 +59,14 @@ pub enum PrimType {
     Empty,
 }}
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FuncType {
     pub modes: Vec<FuncMode>,
     pub args: Vec<IDLArgType>,
     pub rets: Vec<IDLType>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IDLArgType {
     pub typ: IDLType,
     pub name: Option<String>,
@@ -91,7 +90,7 @@ impl IDLArgType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeField {
     pub label: Label,
     pub typ: IDLType,
@@ -104,13 +103,13 @@ pub enum Dec {
     ImportServ(String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Binding {
     pub id: String,
     pub typ: IDLType,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct IDLProg {
     pub decs: Vec<Dec>,
     pub actor: Option<IDLType>,
@@ -120,35 +119,4 @@ pub struct IDLProg {
 pub struct IDLInitArgs {
     pub decs: Vec<Dec>,
     pub args: Vec<IDLArgType>,
-}
-
-impl std::str::FromStr for IDLProg {
-    type Err = crate::Error;
-    fn from_str(str: &str) -> Result<Self> {
-        let lexer = super::token::Tokenizer::new(str);
-        Ok(super::grammar::IDLProgParser::new().parse(lexer)?)
-    }
-}
-impl std::str::FromStr for IDLInitArgs {
-    type Err = crate::Error;
-    fn from_str(str: &str) -> Result<Self> {
-        let lexer = super::token::Tokenizer::new(str);
-        Ok(super::grammar::IDLInitArgsParser::new().parse(lexer)?)
-    }
-}
-
-impl std::str::FromStr for IDLType {
-    type Err = crate::Error;
-    fn from_str(str: &str) -> Result<Self> {
-        let lexer = super::token::Tokenizer::new(str);
-        Ok(super::grammar::TypParser::new().parse(lexer)?)
-    }
-}
-
-impl std::str::FromStr for IDLTypes {
-    type Err = crate::Error;
-    fn from_str(str: &str) -> Result<Self> {
-        let lexer = super::token::Tokenizer::new(str);
-        Ok(super::grammar::TypsParser::new().parse(lexer)?)
-    }
 }

--- a/rust/candid_parser/src/bindings/javascript.rs
+++ b/rust/candid_parser/src/bindings/javascript.rs
@@ -370,6 +370,7 @@ pub mod test {
     use super::value;
     use crate::test::{HostAssert, HostTest, Test};
     use candid::pretty::utils::*;
+    use candid::types::parser::IDLProg;
     use candid::TypeEnv;
     use pretty::RcDoc;
 
@@ -405,7 +406,7 @@ import { Principal } from './principal';
         let mut env = TypeEnv::new();
         crate::check_prog(
             &mut env,
-            &crate::IDLProg {
+            &IDLProg {
                 decs: test.defs,
                 actor: None,
             },

--- a/rust/candid_parser/src/bindings/motoko.rs
+++ b/rust/candid_parser/src/bindings/motoko.rs
@@ -3,8 +3,8 @@
 
 use candid::pretty::candid::is_valid_as_id;
 use candid::pretty::utils::*;
-use candid::types::{ArgType, FuncMode};
-use candid::types::{Field, Function, Label, SharedLabel, Type, TypeEnv, TypeInner};
+use candid::types::{ArgType, Field, FuncMode, Function, Label, SharedLabel, Type, TypeInner};
+use candid::TypeEnv;
 use pretty::RcDoc;
 
 // The definition of tuple is language specific.

--- a/rust/candid_parser/src/error.rs
+++ b/rust/candid_parser/src/error.rs
@@ -1,10 +1,11 @@
 //! When serializing or deserializing Candid goes wrong.
 
+use candid::types::parser::{IDLProg, IDLTypes};
 use codespan_reporting::diagnostic::Label;
 use std::io;
 use thiserror::Error;
 
-use crate::token;
+use crate::{parse_idl_prog, parse_idl_types, token};
 use codespan_reporting::{
     diagnostic::Diagnostic,
     files::{Error as ReportError, SimpleFile},
@@ -110,6 +111,20 @@ where
     T: std::str::FromStr<Err = Error>,
 {
     str.parse::<T>().or_else(|e| {
+        pretty_diagnose(name, str, &e)?;
+        Err(e)
+    })
+}
+
+pub fn pretty_parse_idl_prog(name: &str, str: &str) -> Result<IDLProg> {
+    parse_idl_prog(str).or_else(|e| {
+        pretty_diagnose(name, str, &e)?;
+        Err(e)
+    })
+}
+
+pub fn pretty_parse_idl_types(name: &str, str: &str) -> Result<IDLTypes> {
+    parse_idl_types(str).or_else(|e| {
         pretty_diagnose(name, str, &e)?;
         Err(e)
     })

--- a/rust/candid_parser/src/grammar.lalrpop
+++ b/rust/candid_parser/src/grammar.lalrpop
@@ -1,7 +1,7 @@
-use super::types::{IDLType, PrimType, TypeField, FuncType, Binding, Dec, IDLProg, IDLTypes, IDLInitArgs, IDLArgType};
 use super::test::{Assert, Input, Test};
 use super::token::{Token, error, error2, LexicalError, Span};
 use candid::{Principal, types::Label};
+use candid::types::parser::{IDLType, PrimType, TypeField, FuncType, Binding, Dec, IDLProg, IDLTypes, IDLInitArgs, IDLArgType};
 use candid::types::value::{IDLField, IDLValue, IDLArgs, VariantValue};
 use candid::types::{TypeEnv, FuncMode};
 use candid::utils::check_unique;

--- a/rust/candid_parser/src/lib.rs
+++ b/rust/candid_parser/src/lib.rs
@@ -47,7 +47,7 @@
 //! ```
 //! # fn f() -> anyhow::Result<()> {
 //! use candid::{TypeEnv, types::{Type, TypeInner}};
-//! use candid_parser::{IDLProg, check_prog};
+//! use candid_parser::{check_prog, parse_idl_prog};
 //! let did_file = r#"
 //!     type List = opt record { head: int; tail: List };
 //!     type byte = nat8;
@@ -58,7 +58,7 @@
 //! "#;
 //!
 //! // Parse did file into an AST
-//! let ast: IDLProg = did_file.parse()?;
+//! let ast = parse_idl_prog(did_file)?;
 //!
 //! // Type checking a given .did file
 //! // let (env, opt_actor) = check_file("a.did")?;
@@ -86,7 +86,7 @@
 //! use candid::{IDLArgs, types::value::IDLValue};
 //! use candid_parser::parse_idl_args;
 //! # use candid::TypeEnv;
-//! # use candid_parser::{IDLProg, check_prog};
+//! # use candid_parser::{check_prog, parse_idl_prog};
 //! # let did_file = r#"
 //! #    type List = opt record { head: int; tail: List };
 //! #    type byte = nat8;
@@ -95,7 +95,7 @@
 //! #      g : (List) -> (int) query;
 //! #    }
 //! # "#;
-//! # let ast = did_file.parse::<IDLProg>()?;
+//! # let ast = parse_idl_prog(did_file)?;
 //! # let mut env = TypeEnv::new();
 //! # let actor = check_prog(&mut env, &ast)?.unwrap();
 //! // Get method type f : (byte, int, nat, int8) -> (List)
@@ -119,15 +119,15 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod error;
-pub use error::{pretty_parse, pretty_wrap, Error, Result};
+pub use error::{
+    pretty_parse, pretty_parse_idl_prog, pretty_parse_idl_types, pretty_wrap, Error, Result,
+};
 
 pub mod bindings;
 pub mod grammar;
 pub mod token;
-pub mod types;
-pub mod utils;
-pub use types::IDLProg;
 pub mod typing;
+pub mod utils;
 pub use typing::{check_file, check_prog, pretty_check_file};
 
 pub use candid;
@@ -141,6 +141,26 @@ pub mod configs;
 #[cfg(feature = "random")]
 pub mod random;
 pub mod test;
+
+pub fn parse_idl_prog(str: &str) -> Result<candid::types::parser::IDLProg> {
+    let lexer = token::Tokenizer::new(str);
+    Ok(grammar::IDLProgParser::new().parse(lexer)?)
+}
+
+pub fn parse_idl_init_args(str: &str) -> Result<candid::types::parser::IDLInitArgs> {
+    let lexer = token::Tokenizer::new(str);
+    Ok(grammar::IDLInitArgsParser::new().parse(lexer)?)
+}
+
+pub fn parse_idl_type(str: &str) -> Result<candid::types::parser::IDLType> {
+    let lexer = token::Tokenizer::new(str);
+    Ok(grammar::TypParser::new().parse(lexer)?)
+}
+
+pub fn parse_idl_types(str: &str) -> Result<candid::types::parser::IDLTypes> {
+    let lexer = token::Tokenizer::new(str);
+    Ok(grammar::TypsParser::new().parse(lexer)?)
+}
 
 pub fn parse_idl_args(s: &str) -> crate::Result<candid::IDLArgs> {
     let lexer = token::Tokenizer::new(s);

--- a/rust/candid_parser/src/test.rs
+++ b/rust/candid_parser/src/test.rs
@@ -1,6 +1,6 @@
-use super::types::{Dec, IDLProg, IDLType};
 use super::typing::check_prog;
 use crate::{Error, Result};
+use candid::types::parser::{Dec, IDLProg, IDLType};
 use candid::types::value::IDLArgs;
 use candid::types::{Type, TypeEnv};
 use candid::DecoderConfig;

--- a/rust/candid_parser/tests/parse_type.rs
+++ b/rust/candid_parser/tests/parse_type.rs
@@ -2,14 +2,14 @@ use candid::pretty::candid::compile;
 use candid::types::TypeEnv;
 use candid_parser::bindings::{javascript, motoko, rust, typescript};
 use candid_parser::configs::Configs;
-use candid_parser::types::IDLProg;
+use candid_parser::parse_idl_prog;
 use candid_parser::typing::{check_file, check_prog};
 use goldenfile::Mint;
 use std::io::Write;
 use std::path::Path;
 
 #[test]
-fn parse_idl_prog() {
+fn test_parse_idl_prog() {
     let prog = r#"
 import "test.did";
 type my_type = principal;
@@ -28,7 +28,7 @@ service server : {
   i : f;
 }
     "#;
-    prog.parse::<IDLProg>().unwrap();
+    parse_idl_prog(prog).unwrap();
 }
 
 #[test_generator::test_resources("rust/candid_parser/tests/assets/*.did")]
@@ -45,7 +45,7 @@ fn compiler_test(resource: &str) {
                 let mut output = mint.new_goldenfile(filename.with_extension("did")).unwrap();
                 let content = compile(&env, &actor);
                 // Type check output
-                let ast = content.parse::<IDLProg>().unwrap();
+                let ast = parse_idl_prog(&content).unwrap();
                 check_prog(&mut TypeEnv::new(), &ast).unwrap();
                 writeln!(output, "{content}").unwrap();
             }

--- a/rust/candid_parser/tests/parse_value.rs
+++ b/rust/candid_parser/tests/parse_value.rs
@@ -1,7 +1,7 @@
 use candid::types::value::{IDLArgs, IDLField, IDLValue, VariantValue};
 use candid::types::{Label, Type, TypeEnv, TypeInner};
 use candid::{record, variant, CandidType, Nat};
-use candid_parser::parse_idl_args;
+use candid_parser::{parse_idl_args, parse_idl_type};
 
 fn parse_args(input: &str) -> IDLArgs {
     parse_idl_args(input).unwrap()
@@ -12,9 +12,8 @@ fn parse_args_err(input: &str) -> candid_parser::Result<IDLArgs> {
 }
 
 fn parse_type(input: &str) -> Type {
-    use candid_parser::types::IDLType;
     let env = TypeEnv::new();
-    let ast = input.parse::<IDLType>().unwrap();
+    let ast = parse_idl_type(input).unwrap();
     candid_parser::typing::ast_to_type(&env, &ast).unwrap()
 }
 

--- a/rust/candid_parser/tests/value.rs
+++ b/rust/candid_parser/tests/value.rs
@@ -1,7 +1,7 @@
 use candid::types::value::{IDLArgs, IDLField, IDLValue, VariantValue};
 use candid::types::{Label, TypeEnv};
 use candid::{decode_args, decode_one, Decode};
-use candid_parser::{parse_idl_args, types::IDLProg, typing::check_prog};
+use candid_parser::{parse_idl_args, parse_idl_prog, typing::check_prog};
 
 #[test]
 fn test_parser() {
@@ -31,7 +31,7 @@ service : {
   f : f;
 }
 "#;
-    let ast = candid.parse::<IDLProg>().unwrap();
+    let ast = parse_idl_prog(candid).unwrap();
     let mut env = TypeEnv::new();
     let actor = check_prog(&mut env, &ast).unwrap().unwrap();
     let method = env.get_method(&actor, "f").unwrap();

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -1,11 +1,12 @@
 use anyhow::{bail, Result};
-use candid_parser::candid::types::{subtype, Type};
+use candid_parser::candid::types::{
+    parser::{IDLType, IDLTypes},
+    subtype, Type,
+};
 use candid_parser::{
-    configs::Configs,
-    parse_idl_args, parse_idl_value, pretty_check_file, pretty_parse, pretty_wrap,
-    types::{IDLType, IDLTypes},
-    typing::ast_to_type,
-    Error, IDLArgs, IDLValue, TypeEnv,
+    configs::Configs, parse_idl_args, parse_idl_type, parse_idl_value, pretty_check_file,
+    pretty_parse, pretty_parse_idl_types, pretty_wrap, typing::ast_to_type, Error, IDLArgs,
+    IDLValue, TypeEnv,
 };
 use clap::Parser;
 use console::style;
@@ -98,7 +99,9 @@ enum Command {
     Subtype {
         #[clap(short, long)]
         defs: Option<PathBuf>,
+        #[clap(value_parser = parse_idl_type)]
         ty1: IDLType,
+        #[clap(value_parser = parse_idl_type)]
         ty2: IDLType,
     },
 }
@@ -160,7 +163,7 @@ fn parse_args(str: &str) -> Result<IDLArgs, Error> {
     pretty_wrap("candid arguments", str, parse_idl_args)
 }
 fn parse_types(str: &str) -> Result<IDLTypes, Error> {
-    pretty_parse("type annotations", str)
+    pretty_parse_idl_types("type annotations", str)
 }
 fn load_config(input: &Option<String>) -> Result<Configs, Error> {
     match input {


### PR DESCRIPTION
**Overview**
Move the parser's `IDL*` types under the `candid` crate, in order to share it between that crate and the `candid_parser` crate.

The main reason is that we want to use the `IDL*` types in the bindings generator, instead of bringing around the `TypeEnv`, which holds inner `Type`s that are not meant for codegen.

**Considerations**
Introduces breaking changes.
