### PR TITLE
fix: inline actor method typescript declaration

### DIFF
--- a/rust/candid_parser/tests/assets/actor.did
+++ b/rust/candid_parser/tests/assets/actor.did
@@ -8,4 +8,5 @@ service :
   g : f;
   h : g;
   o : (o) -> (o);
+  h2 : h;
 }

--- a/rust/candid_parser/tests/assets/inline_methods.did
+++ b/rust/candid_parser/tests/assets/inline_methods.did
@@ -1,0 +1,21 @@
+type Fn = func(nat) -> (nat) query;
+type RInline = record {
+    fn : func(nat) -> (nat) query;
+    x : nat
+};
+type R = record {
+    fn : Fn;
+    x : nat
+};
+
+service : {
+    add_two : (nat) -> (nat);
+
+    high_order_fn : (nat, Fn) -> (nat);
+    high_order_fn_inline : (nat, func(nat) -> (nat) query) -> (nat);
+    high_order_fn_via_record : (R) -> (nat);
+    high_order_fn_via_record_inline : (RInline) -> (nat);
+
+    fn : Fn;
+    inline_fn : (nat) -> (nat)
+}

--- a/rust/candid_parser/tests/assets/ok/actor.d.ts
+++ b/rust/candid_parser/tests/assets/ok/actor.d.ts
@@ -2,14 +2,15 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
-export type f = ActorMethod<[number], number>;
+export type f = [Principal, string];
 export type g = f;
-export type h = ActorMethod<[[Principal, string]], [Principal, string]>;
+export type h = [Principal, string];
 export type o = [] | [o];
 export interface _SERVICE {
-  'f' : ActorMethod<[bigint], [Principal, string]>,
-  'g' : f,
-  'h' : g,
+  'f' : ActorMethod<[bigint], h>,
+  'g' : ActorMethod<[number], number>,
+  'h' : ActorMethod<[number], number>,
+  'h2' : ActorMethod<[f], f>,
   'o' : ActorMethod<[o], o>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;

--- a/rust/candid_parser/tests/assets/ok/actor.did
+++ b/rust/candid_parser/tests/assets/ok/actor.did
@@ -2,4 +2,4 @@ type f = func (int8) -> (int8);
 type g = f;
 type h = func (f) -> (f);
 type o = opt o;
-service : { f : (nat) -> (h); g : f; h : g; o : (o) -> (o) }
+service : { f : (nat) -> (h); g : f; h : g; h2 : h; o : (o) -> (o) }

--- a/rust/candid_parser/tests/assets/ok/actor.js
+++ b/rust/candid_parser/tests/assets/ok/actor.js
@@ -8,6 +8,7 @@ export const idlFactory = ({ IDL }) => {
     'f' : IDL.Func([IDL.Nat], [h], []),
     'g' : f,
     'h' : g,
+    'h2' : h,
     'o' : IDL.Func([o], [o], []),
   });
 };

--- a/rust/candid_parser/tests/assets/ok/actor.mo
+++ b/rust/candid_parser/tests/assets/ok/actor.mo
@@ -10,6 +10,7 @@ module {
     f : shared Nat -> async h;
     g : f;
     h : g;
+    h2 : h;
     o : shared o -> async o;
   }
 }

--- a/rust/candid_parser/tests/assets/ok/actor.rs
+++ b/rust/candid_parser/tests/assets/ok/actor.rs
@@ -21,6 +21,9 @@ impl Service {
   pub async fn h(&self, arg0: &i8) -> Result<(i8,)> {
     ic_cdk::call(self.0, "h", (arg0,)).await
   }
+  pub async fn h_2(&self, arg0: &F) -> Result<(F,)> {
+    ic_cdk::call(self.0, "h2", (arg0,)).await
+  }
   pub async fn o(&self, arg0: &O) -> Result<(O,)> {
     ic_cdk::call(self.0, "o", (arg0,)).await
   }

--- a/rust/candid_parser/tests/assets/ok/example.d.ts
+++ b/rust/candid_parser/tests/assets/ok/example.d.ts
@@ -9,7 +9,7 @@ export type a = { 'a' : null } |
   { 'b' : b };
 export type b = [bigint, bigint];
 export interface broker { 'find' : ActorMethod<[string], Principal> }
-export type f = ActorMethod<[List, [Principal, string]], [[] | [List], res]>;
+export type f = [Principal, string];
 export type list = [] | [node];
 export type my_type = Principal;
 export interface nested {
@@ -29,16 +29,19 @@ export type nested_res = { 'Ok' : { 'Ok' : null } | { 'Err' : null } } |
 export interface node { 'head' : bigint, 'tail' : list }
 export type res = { 'Ok' : [bigint, bigint] } |
   { 'Err' : { 'error' : string } };
-export interface s { 'f' : t, 'g' : ActorMethod<[list], [B, tree, stream]> }
+export interface s {
+  'f' : ActorMethod<[Principal], undefined>,
+  'g' : ActorMethod<[list], [B, tree, stream]>,
+}
 export type stream = [] | [{ 'head' : bigint, 'next' : [Principal, string] }];
-export type t = ActorMethod<[Principal], undefined>;
+export type t = [Principal, string];
 export type tree = {
     'branch' : { 'val' : bigint, 'left' : tree, 'right' : tree }
   } |
   { 'leaf' : bigint };
 export interface _SERVICE {
   'bbbbb' : ActorMethod<[b], undefined>,
-  'f' : t,
+  'f' : ActorMethod<[Principal], undefined>,
   'f1' : ActorMethod<[list, Uint8Array | number[], [] | [boolean]], undefined>,
   'g' : ActorMethod<[list], [B, tree, stream]>,
   'g1' : ActorMethod<
@@ -54,7 +57,7 @@ export interface _SERVICE {
     ],
     { _42_ : {}, 'id' : bigint }
   >,
-  'i' : f,
+  'i' : ActorMethod<[List, [Principal, string]], [[] | [List], res]>,
   'x' : ActorMethod<
     [a, b],
     [

--- a/rust/candid_parser/tests/assets/ok/inline_methods.d.ts
+++ b/rust/candid_parser/tests/assets/ok/inline_methods.d.ts
@@ -1,0 +1,18 @@
+import type { Principal } from '@dfinity/principal';
+import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
+
+export type Fn = [Principal, string];
+export interface R { 'x' : bigint, 'fn' : Fn }
+export interface RInline { 'x' : bigint, 'fn' : [Principal, string] }
+export interface _SERVICE {
+  'add_two' : ActorMethod<[bigint], bigint>,
+  'fn' : ActorMethod<[bigint], bigint>,
+  'high_order_fn' : ActorMethod<[bigint, Fn], bigint>,
+  'high_order_fn_inline' : ActorMethod<[bigint, [Principal, string]], bigint>,
+  'high_order_fn_via_record' : ActorMethod<[R], bigint>,
+  'high_order_fn_via_record_inline' : ActorMethod<[RInline], bigint>,
+  'inline_fn' : ActorMethod<[bigint], bigint>,
+}
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/inline_methods.did
+++ b/rust/candid_parser/tests/assets/ok/inline_methods.did
@@ -1,0 +1,12 @@
+type Fn = func (nat) -> (nat) query;
+type R = record { x : nat; fn : Fn };
+type RInline = record { x : nat; fn : func (nat) -> (nat) query };
+service : {
+  add_two : (nat) -> (nat);
+  fn : Fn;
+  high_order_fn : (nat, Fn) -> (nat);
+  high_order_fn_inline : (nat, func (nat) -> (nat) query) -> (nat);
+  high_order_fn_via_record : (R) -> (nat);
+  high_order_fn_via_record_inline : (RInline) -> (nat);
+  inline_fn : (nat) -> (nat);
+}

--- a/rust/candid_parser/tests/assets/ok/inline_methods.js
+++ b/rust/candid_parser/tests/assets/ok/inline_methods.js
@@ -1,0 +1,22 @@
+export const idlFactory = ({ IDL }) => {
+  const Fn = IDL.Func([IDL.Nat], [IDL.Nat], ['query']);
+  const R = IDL.Record({ 'x' : IDL.Nat, 'fn' : Fn });
+  const RInline = IDL.Record({
+    'x' : IDL.Nat,
+    'fn' : IDL.Func([IDL.Nat], [IDL.Nat], ['query']),
+  });
+  return IDL.Service({
+    'add_two' : IDL.Func([IDL.Nat], [IDL.Nat], []),
+    'fn' : Fn,
+    'high_order_fn' : IDL.Func([IDL.Nat, Fn], [IDL.Nat], []),
+    'high_order_fn_inline' : IDL.Func(
+        [IDL.Nat, IDL.Func([IDL.Nat], [IDL.Nat], ['query'])],
+        [IDL.Nat],
+        [],
+      ),
+    'high_order_fn_via_record' : IDL.Func([R], [IDL.Nat], []),
+    'high_order_fn_via_record_inline' : IDL.Func([RInline], [IDL.Nat], []),
+    'inline_fn' : IDL.Func([IDL.Nat], [IDL.Nat], []),
+  });
+};
+export const init = ({ IDL }) => { return []; };

--- a/rust/candid_parser/tests/assets/ok/inline_methods.mo
+++ b/rust/candid_parser/tests/assets/ok/inline_methods.mo
@@ -1,0 +1,20 @@
+// This is a generated Motoko binding.
+// Please use `import service "ic:canister_id"` instead to call canisters on the IC if possible.
+
+module {
+  public type Fn = shared query Nat -> async Nat;
+  public type R = { x : Nat; fn : Fn };
+  public type RInline = { x : Nat; fn : shared query Nat -> async Nat };
+  public type Self = actor {
+    add_two : shared Nat -> async Nat;
+    fn : Fn;
+    high_order_fn : shared (Nat, Fn) -> async Nat;
+    high_order_fn_inline : shared (
+        Nat,
+        shared query Nat -> async Nat,
+      ) -> async Nat;
+    high_order_fn_via_record : shared R -> async Nat;
+    high_order_fn_via_record_inline : shared RInline -> async Nat;
+    inline_fn : shared Nat -> async Nat;
+  }
+}

--- a/rust/candid_parser/tests/assets/ok/inline_methods.rs
+++ b/rust/candid_parser/tests/assets/ok/inline_methods.rs
@@ -1,0 +1,43 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+#![allow(dead_code, unused_imports)]
+use candid::{self, CandidType, Deserialize, Principal};
+use ic_cdk::api::call::CallResult as Result;
+
+candid::define_function!(pub Fn : (candid::Nat) -> (candid::Nat) query);
+candid::define_function!(pub HighOrderFnInlineArg1 : (candid::Nat) -> (
+    candid::Nat,
+  ) query);
+#[derive(CandidType, Deserialize)]
+pub struct R { pub x: candid::Nat, pub r#fn: Fn }
+candid::define_function!(pub RInlineFn : (candid::Nat) -> (candid::Nat) query);
+#[derive(CandidType, Deserialize)]
+pub struct RInline { pub x: candid::Nat, pub r#fn: RInlineFn }
+
+pub struct Service(pub Principal);
+impl Service {
+  pub async fn add_two(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
+    ic_cdk::call(self.0, "add_two", (arg0,)).await
+  }
+  pub async fn r#fn(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
+    ic_cdk::call(self.0, "fn", (arg0,)).await
+  }
+  pub async fn high_order_fn(&self, arg0: &candid::Nat, arg1: &Fn) -> Result<(candid::Nat,)> {
+    ic_cdk::call(self.0, "high_order_fn", (arg0,arg1,)).await
+  }
+  pub async fn high_order_fn_inline(&self, arg0: &candid::Nat, arg1: &HighOrderFnInlineArg1) -> Result<(candid::Nat,)> {
+    ic_cdk::call(self.0, "high_order_fn_inline", (arg0,arg1,)).await
+  }
+  pub async fn high_order_fn_via_record(&self, arg0: &R) -> Result<(candid::Nat,)> {
+    ic_cdk::call(self.0, "high_order_fn_via_record", (arg0,)).await
+  }
+  pub async fn high_order_fn_via_record_inline(&self, arg0: &RInline) -> Result<(candid::Nat,)> {
+    ic_cdk::call(self.0, "high_order_fn_via_record_inline", (arg0,)).await
+  }
+  pub async fn inline_fn(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
+    ic_cdk::call(self.0, "inline_fn", (arg0,)).await
+  }
+}
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+pub const service : Service = Service(CANISTER_ID);
+

--- a/rust/candid_parser/tests/assets/ok/keyword.d.ts
+++ b/rust/candid_parser/tests/assets/ok/keyword.d.ts
@@ -9,9 +9,12 @@ export type if_ = {
 export type list = [] | [node];
 export interface node { 'head' : bigint, 'tail' : list }
 export type o = [] | [o];
-export interface return_ { 'f' : t, 'g' : ActorMethod<[list], [if_, stream]> }
+export interface return_ {
+  'f' : ActorMethod<[Principal], undefined>,
+  'g' : ActorMethod<[list], [if_, stream]>,
+}
 export type stream = [] | [{ 'head' : bigint, 'next' : [Principal, string] }];
-export type t = ActorMethod<[Principal], undefined>;
+export type t = [Principal, string];
 export interface _SERVICE {
   'Oneway' : ActorMethod<[], undefined>,
   'f_' : ActorMethod<[o], o>,
@@ -21,7 +24,7 @@ export interface _SERVICE {
   'oneway_' : ActorMethod<[number], undefined>,
   'query' : ActorMethod<[Uint8Array | number[]], Uint8Array | number[]>,
   'return' : ActorMethod<[o], o>,
-  'service' : t,
+  'service' : ActorMethod<[Principal], undefined>,
   'tuple' : ActorMethod<
     [[bigint, Uint8Array | number[], string]],
     [bigint, number]

--- a/rust/candid_parser/tests/assets/ok/recursion.d.ts
+++ b/rust/candid_parser/tests/assets/ok/recursion.d.ts
@@ -6,9 +6,12 @@ export type A = B;
 export type B = [] | [A];
 export type list = [] | [node];
 export interface node { 'head' : bigint, 'tail' : list }
-export interface s { 'f' : t, 'g' : ActorMethod<[list], [B, tree, stream]> }
+export interface s {
+  'f' : ActorMethod<[Principal], undefined>,
+  'g' : ActorMethod<[list], [B, tree, stream]>,
+}
 export type stream = [] | [{ 'head' : bigint, 'next' : [Principal, string] }];
-export type t = ActorMethod<[Principal], undefined>;
+export type t = [Principal, string];
 export type tree = {
     'branch' : { 'val' : bigint, 'left' : tree, 'right' : tree }
   } |

--- a/rust/candid_parser/tests/assets/ok/service.d.ts
+++ b/rust/candid_parser/tests/assets/ok/service.d.ts
@@ -2,20 +2,17 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
-export type Func = ActorMethod<[], Principal>;
-export interface Service { 'f' : Func }
+export type Func = [Principal, string];
+export interface Service { 'f' : ActorMethod<[], Principal> }
 export type Service2 = Service;
 export interface _SERVICE {
-  'asArray' : ActorMethod<[], [Array<Principal>, Array<[Principal, string]>]>,
-  'asPrincipal' : ActorMethod<[], [Principal, [Principal, string]]>,
-  'asRecord' : ActorMethod<
-    [],
-    [Principal, [] | [Principal], [Principal, string]]
-  >,
+  'asArray' : ActorMethod<[], [Array<Principal>, Array<Func>]>,
+  'asPrincipal' : ActorMethod<[], [Principal, Func]>,
+  'asRecord' : ActorMethod<[], [Principal, [] | [Principal], Func]>,
   'asVariant' : ActorMethod<
     [],
     { 'a' : Principal } |
-      { 'b' : { 'f' : [] | [[Principal, string]] } }
+      { 'b' : { 'f' : [] | [Func] } }
   >,
 }
 export declare const idlFactory: IDL.InterfaceFactory;


### PR DESCRIPTION
**Overview**
Fixes #606.

**Considerations**
We "loose" the information about the `func` type in the `export type ...` declaration, but we still keep it if that function is used as method in a service.
