### PR TITLE
chore: disable `uninlined_format_args` in clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,12 @@ anyhow = "1.0"
 rand = "0.8"
 arbitrary = "1.3"
 console = "0.15"
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = 0 }
+uninlined_format_args = { level = "allow", priority = 1 }
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(wasm_bindgen_unstable_test_coverage)',
+] }

--- a/rust/bench/Cargo.toml
+++ b/rust/bench/Cargo.toml
@@ -21,6 +21,3 @@ hex = "0.4.3"
 candid = { path = "../candid" }
 candid_derive = { path = "../candid_derive" }
 ic_principal = { path = "../ic_principal" }
-
-[lints]
-workspace = true

--- a/rust/bench/Cargo.toml
+++ b/rust/bench/Cargo.toml
@@ -21,3 +21,6 @@ hex = "0.4.3"
 candid = { path = "../candid" }
 candid_derive = { path = "../candid_derive" }
 ic_principal = { path = "../ic_principal" }
+
+[lints]
+workspace = true

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -67,3 +67,6 @@ required-features = ["bignum"]
 features = ["all"]
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/rust/candid/fuzz/Cargo.toml
+++ b/rust/candid/fuzz/Cargo.toml
@@ -21,9 +21,6 @@ features = ["all"]
 [workspace]
 members = ["."]
 
-[lints]
-workspace = true
-
 [[bin]]
 name = "parser"
 path = "fuzz_targets/parser.rs"

--- a/rust/candid/fuzz/Cargo.toml
+++ b/rust/candid/fuzz/Cargo.toml
@@ -21,6 +21,9 @@ features = ["all"]
 [workspace]
 members = ["."]
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "parser"
 path = "fuzz_targets/parser.rs"

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -24,3 +24,6 @@ quote = "1.0.7"
 syn = { version = "2.0", features = ["visit", "full"] }
 proc-macro2 = "1.0.19"
 lazy_static = "1.4.0"
+
+[lints]
+workspace = true

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -38,7 +38,10 @@ arbitrary = { workspace = true, optional = true }
 fake = { version = "2.4", optional = true }
 rand = { version = "0.8", optional = true }
 num-traits = { workspace = true, optional = true }
-dialoguer = { version = "0.11", default-features = false, features = ["editor", "completion"], optional = true }
+dialoguer = { version = "0.11", default-features = false, features = [
+    "editor",
+    "completion",
+], optional = true }
 ctrlc = { version = "3.4", optional = true }
 console = { workspace = true, optional = true }
 
@@ -58,3 +61,6 @@ all = ["random", "assist"]
 features = ["all"]
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/rust/ic_principal/Cargo.toml
+++ b/rust/ic_principal/Cargo.toml
@@ -35,3 +35,6 @@ arbitrary = ['dep:arbitrary', 'serde']
 convert = ['dep:crc32fast', 'dep:data-encoding', 'dep:thiserror']
 self_authenticating = ['dep:sha2']
 serde = ['dep:serde', 'convert']
+
+[lints]
+workspace = true

--- a/tools/didc-js/wasm-package/Cargo.toml
+++ b/tools/didc-js/wasm-package/Cargo.toml
@@ -32,7 +32,5 @@ getrandom = { version = "0.2", features = ["js"] }
 serde-wasm-bindgen = "0.5"
 js-sys = "0.3"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(wasm_bindgen_unstable_test_coverage)',
-] }
+[lints]
+workspace = true

--- a/tools/didc-js/wasm-package/src/lib.rs
+++ b/tools/didc-js/wasm-package/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(clippy::all)]
 use types::{JsDecodeArgs, JsEncodeArgs};
 use wasm_bindgen::prelude::*;
 

--- a/tools/didc/Cargo.toml
+++ b/tools/didc/Cargo.toml
@@ -13,3 +13,5 @@ anyhow.workspace = true
 rand.workspace = true
 console.workspace = true
 
+[lints]
+workspace = true


### PR DESCRIPTION
**Overview**
Fixes an issue in the CI after upgrading to the latest Rust `stable` toolchain (1.88.0 as of today)
