### PR TITLE
test: fix typo

### DIFF
--- a/rust/candid_parser/tests/assets/example.toml
+++ b/rust/candid_parser/tests/assets/example.toml
@@ -3,7 +3,7 @@ attributes = "#[derive(CandidType, Deserialize, Debug)]"
 visibility = "pub(crate)"
 List.name = "MyList"
 Nested41.variant.A = { name = "AAA", attributes = "#[serde(skip_deserializing)]" }
-ListInner.attributes = "#derive[CandidType, Deserialize, Clone]"
+ListInner.attributes = "#[derive(CandidType, Deserialize, Clone)]"
 ListInner.record = { visibility = "", head.name = "HEAD", attributes = "#[serde(skip_deserializing)]", tail.use_type = "Arc<MyList>" }
 my_type = { visibility = "", name = "CanisterId" }
 nat.use_type = "u128 (no test)"

--- a/rust/candid_parser/tests/assets/ok/example.rs
+++ b/rust/candid_parser/tests/assets/ok/example.rs
@@ -9,7 +9,7 @@ pub(crate) struct Node { pub(crate) head: u128, pub(crate) tail: Box<List> }
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) struct List(pub(crate) Option<Node>);
 type CanisterId = Principal;
-#derive[CandidType, Deserialize, Clone]
+#[derive(CandidType, Deserialize, Clone)]
 pub(crate) struct ListInner {
   #[serde(skip_deserializing)]
   #[serde(rename="head")]


### PR DESCRIPTION
**Overview**
Fixes a typo in the `example.toml` template file in the tests.
