### PR TITLE
feat: support doc comments in Rust bindings generation

### DIFF
--- a/rust/candid/src/types/syntax.rs
+++ b/rust/candid/src/types/syntax.rs
@@ -233,25 +233,6 @@ impl IDLMergedProg {
         }))
     }
 
-    pub fn resolve_actor_methods(&self) -> Result<Vec<Binding>> {
-        let typ = match self.resolve_actor()? {
-            Some(IDLActorType { typ, .. }) => typ,
-            None => return Ok(vec![]),
-        };
-
-        if let IDLType::ServT(methods) = typ {
-            Ok(methods)
-        } else if let IDLType::ClassT(_, inner) = typ {
-            if let IDLType::ServT(methods) = inner.as_ref() {
-                Ok(methods.to_vec())
-            } else {
-                Ok(vec![])
-            }
-        } else {
-            Ok(vec![])
-        }
-    }
-
     // NOTE: We don't worry about cyclic type definitions, as we rule those out earlier when checking the type decs
     fn chase_service(&self, ty: IDLType, import_name: Option<&str>) -> Result<Vec<Binding>> {
         match ty {

--- a/rust/candid/src/types/syntax.rs
+++ b/rust/candid/src/types/syntax.rs
@@ -146,7 +146,7 @@ pub struct IDLInitArgs {
     pub args: Vec<IDLArgType>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct IDLMergedProg {
     typ_decs: Vec<Binding>,
     main_actor: Option<IDLActorType>,
@@ -179,10 +179,6 @@ impl IDLMergedProg {
 
     pub fn decs(&self) -> Vec<Dec> {
         self.typ_decs.iter().map(|b| Dec::TypD(b.clone())).collect()
-    }
-
-    pub fn insert_binding(&mut self, id: String, typ: IDLType, docs: Vec<String>) {
-        self.typ_decs.push(Binding { id, typ, docs });
     }
 
     pub fn resolve_actor(&self) -> Result<Option<IDLActorType>> {

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -542,7 +542,7 @@ fn test_{test_name}() {{
                 .clone()
                 .map(RcDoc::text)
                 .unwrap_or(RcDoc::text("#[derive(CandidType, Deserialize)]"));
-            let derive = docs.append(derive).append(RcDoc::line());
+            let docs_with_derive = docs.clone().append(derive).append(RcDoc::line());
             let line = match ty.as_ref() {
                 TypeInner::Record(fs) => {
                     let separator = if is_tuple(fs) {
@@ -551,7 +551,7 @@ fn test_{test_name}() {{
                         RcDoc::nil()
                     };
                     let syntax_fields = record_syntax_fields(syntax_ty);
-                    derive
+                    docs_with_derive
                         .append(vis)
                         .append("struct ")
                         .append(name)
@@ -561,14 +561,15 @@ fn test_{test_name}() {{
                 }
                 TypeInner::Variant(fs) => {
                     if as_result(fs).is_some() {
-                        vis.append(kwd("type"))
+                        docs.append(vis)
+                            .append(kwd("type"))
                             .append(name)
                             .append(" = ")
                             .append(self.pp_ty(ty, false))
                             .append(";")
                     } else {
                         let syntax_fields = variant_syntax_fields(syntax_ty);
-                        derive
+                        docs_with_derive
                             .append(vis)
                             .append("enum ")
                             .append(name)
@@ -590,7 +591,7 @@ fn test_{test_name}() {{
                     .append(");"),
                 _ => {
                     if self.recs.contains(id) {
-                        derive
+                        docs_with_derive
                             .append(vis.clone())
                             .append("struct ")
                             .append(name)
@@ -598,7 +599,8 @@ fn test_{test_name}() {{
                             .append(enclose("(", vis.append(self.pp_ty(ty, false)), ")"))
                             .append(";")
                     } else {
-                        vis.append(kwd("type"))
+                        docs.append(vis)
+                            .append(kwd("type"))
                             .append(name)
                             .append(" = ")
                             .append(self.pp_ty(ty, false))

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -474,12 +474,12 @@ fn test_{test_name}() {{
     fn pp_variant_field<'b>(&mut self, field: &'b Field, syntax: Option<&'b IDLType>) -> RcDoc<'b> {
         let lab = field.id.to_string();
         let old = self.state.push_state(&StateElem::Label(&lab));
-        let res = match (field.ty.as_ref(), syntax) {
-            (TypeInner::Null, _) => self.pp_label(&field.id, true, false),
-            (TypeInner::Record(fs), _) => self
+        let res = match field.ty.as_ref() {
+            TypeInner::Null => self.pp_label(&field.id, true, false),
+            TypeInner::Record(fs) => self
                 .pp_label(&field.id, true, false)
                 .append(self.pp_record_fields(fs, None, false, false)),
-            (_, _) => self.pp_label(&field.id, true, false).append(enclose(
+            _ => self.pp_label(&field.id, true, false).append(enclose(
                 "(",
                 self.pp_ty_rich(&field.ty, syntax, false),
                 ")",

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -201,22 +201,22 @@ fn variant_syntax_fields(syntax: Option<&IDLType>) -> Option<&[syntax::TypeField
     }
 }
 
-fn actor_methods(actor: Option<&IDLActorType>) -> Vec<syntax::Binding> {
+fn actor_methods(actor: Option<&IDLActorType>) -> &[syntax::Binding] {
     let typ = match actor {
         Some(IDLActorType { typ, .. }) => typ,
-        None => return vec![],
+        None => return &[],
     };
 
     match typ {
-        IDLType::ServT(methods) => methods.to_vec(),
+        IDLType::ServT(methods) => methods,
         IDLType::ClassT(_, inner) => {
             if let IDLType::ServT(methods) = inner.as_ref() {
-                methods.to_vec()
+                methods
             } else {
-                vec![]
+                &[]
             }
         }
-        _ => vec![],
+        _ => &[],
     }
 }
 

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -250,9 +250,6 @@ fn test_{test_name}() {{
                 (TypeInner::Variant(ref fields), Some(IDLType::VariantT(syntax_fields))) => {
                     self.pp_variant(fields, Some(syntax_fields), is_ref)
                 }
-                (TypeInner::Opt(ref inner), Some(IDLType::OptT(syntax))) => {
-                    self.pp_opt(inner, Some(syntax), is_ref)
-                }
                 (_, _) => self.pp_ty(ty, is_ref),
             }
         };
@@ -287,7 +284,7 @@ fn test_{test_name}() {{
                 Empty => str("candid::Empty"),
                 Var(ref id) => self.pp_var(id, is_ref),
                 Principal => str("Principal"),
-                Opt(ref t) => self.pp_opt(t, None, is_ref),
+                Opt(ref t) => self.pp_opt(t, is_ref),
                 // It's a bit tricky to use `deserialize_with = "serde_bytes"`. It's not working for `type t = blob`
                 Vec(ref t) if matches!(t.as_ref(), Nat8) => str("serde_bytes::ByteBuf"),
                 Vec(ref t) => self.pp_vec(t, is_ref),
@@ -370,8 +367,8 @@ fn test_{test_name}() {{
         str("Vec").append(enclose("<", self.pp_ty(ty, is_ref), ">"))
     }
 
-    fn pp_opt<'b>(&mut self, ty: &'b Type, syntax: Option<&'b IDLType>, is_ref: bool) -> RcDoc<'b> {
-        str("Option").append(enclose("<", self.pp_ty_rich(ty, syntax, is_ref), ">"))
+    fn pp_opt<'b>(&mut self, ty: &'b Type, is_ref: bool) -> RcDoc<'b> {
+        str("Option").append(enclose("<", self.pp_ty(ty, is_ref), ">"))
     }
 
     fn pp_tuple<'b>(&mut self, fs: &'b [Field], need_vis: bool, is_ref: bool) -> RcDoc<'b> {

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -3,13 +3,18 @@ use crate::{
     configs::{ConfigState, ConfigTree, Configs, Context, StateElem},
     Deserialize,
 };
-use candid::types::{Field, Function, Label, SharedLabel, Type, TypeEnv, TypeInner};
+use candid::types::{
+    syntax::{self, IDLMergedProg, IDLType},
+    Field, Function, Label, SharedLabel, Type, TypeEnv, TypeInner,
+};
 use candid::{pretty::utils::*, types::ArgType};
 use convert_case::{Case, Casing};
 use pretty::RcDoc;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
+
+const DOC_COMMENT_PREFIX: &str = "/// ";
 
 #[derive(Default, Deserialize, Clone, Debug)]
 pub struct BindingConfig {
@@ -76,6 +81,7 @@ impl ConfigState for BindingConfig {
 }
 struct State<'a> {
     state: crate::configs::State<'a, BindingConfig>,
+    prog: &'a IDLMergedProg,
     recs: RecPoints<'a>,
     tests: BTreeMap<String, String>,
 }
@@ -153,6 +159,28 @@ fn pp_vis<'a>(vis: &Option<String>) -> RcDoc<'a> {
     }
 }
 
+fn pp_docs<'a>(docs: &'a [String]) -> RcDoc<'a> {
+    lines(
+        docs.iter()
+            .map(|line| RcDoc::text(DOC_COMMENT_PREFIX).append(line)),
+    )
+}
+
+fn find_field<'a>(
+    fields: Option<&'a [syntax::TypeField]>,
+    label: &'a Label,
+) -> (RcDoc<'a>, Option<&'a syntax::IDLType>) {
+    let mut docs = RcDoc::nil();
+    let mut syntax_field_ty = None;
+    if let Some(bs) = fields {
+        if let Some(field) = bs.iter().find(|b| b.label == *label) {
+            docs = pp_docs(&field.docs);
+            syntax_field_ty = Some(&field.typ);
+        }
+    };
+    (docs, syntax_field_ty)
+}
+
 impl<'a> State<'a> {
     fn generate_test(&mut self, src: &Type, use_type: &str) {
         if self.tests.contains_key(use_type) {
@@ -189,18 +217,55 @@ fn test_{test_name}() {{
         );
         self.tests.insert(use_type.to_string(), body);
     }
-    fn pp_ty<'b>(&mut self, ty: &'b Type, is_ref: bool) -> RcDoc<'b> {
-        use TypeInner::*;
-        let elem = StateElem::Type(ty);
-        let old = self.state.push_state(&elem);
-        let res = if let Some(t) = &self.state.config.use_type {
+
+    fn use_type_doc<'b>(&mut self, ty: &'b Type) -> Option<RcDoc<'b>> {
+        if let Some(t) = &self.state.config.use_type {
             let (t, need_test) = parse_use_type(t);
             if need_test {
                 self.generate_test(ty, &t);
             }
             let res = RcDoc::text(t);
             self.state.update_stats("use_type");
-            res
+            Some(res)
+        } else {
+            None
+        }
+    }
+
+    fn pp_ty_rich<'b>(
+        &mut self,
+        ty: &'b Type,
+        syntax: Option<&'b IDLType>,
+        is_ref: bool,
+    ) -> RcDoc<'b> {
+        let elem = StateElem::Type(ty);
+        let old = self.state.push_state(&elem);
+        let res = if let Some(use_type_doc) = self.use_type_doc(ty) {
+            use_type_doc
+        } else {
+            match (ty.as_ref(), syntax) {
+                (TypeInner::Record(ref fields), Some(IDLType::RecordT(syntax_fields))) => {
+                    self.pp_record_fields(fields, Some(syntax_fields), false, is_ref)
+                }
+                (TypeInner::Variant(ref fields), Some(IDLType::VariantT(syntax_fields))) => {
+                    self.pp_variant(fields, Some(syntax_fields), is_ref)
+                }
+                (TypeInner::Opt(ref inner), Some(IDLType::OptT(syntax))) => {
+                    self.pp_opt(inner, Some(syntax), is_ref)
+                }
+                (_, _) => self.pp_ty(ty, is_ref),
+            }
+        };
+        self.state.pop_state(old, elem);
+        res
+    }
+
+    fn pp_ty<'b>(&mut self, ty: &'b Type, is_ref: bool) -> RcDoc<'b> {
+        use TypeInner::*;
+        let elem = StateElem::Type(ty);
+        let old = self.state.push_state(&elem);
+        let res = if let Some(use_type_doc) = self.use_type_doc(ty) {
+            use_type_doc
         } else {
             match ty.as_ref() {
                 Null => str("()"),
@@ -220,54 +285,14 @@ fn test_{test_name}() {{
                 Text => str("String"),
                 Reserved => str("candid::Reserved"),
                 Empty => str("candid::Empty"),
-                Var(ref id) => {
-                    let name = if let Some(name) = &self.state.config.name {
-                        let res = RcDoc::text(name.clone());
-                        self.state.update_stats("name");
-                        res
-                    } else {
-                        ident(id, Some(Case::Pascal))
-                    };
-                    if !is_ref && self.recs.contains(id.as_str()) {
-                        str("Box<").append(name).append(">")
-                    } else {
-                        name
-                    }
-                }
+                Var(ref id) => self.pp_var(id, is_ref),
                 Principal => str("Principal"),
-                Opt(ref t) => str("Option").append(enclose("<", self.pp_ty(t, is_ref), ">")),
+                Opt(ref t) => self.pp_opt(t, None, is_ref),
                 // It's a bit tricky to use `deserialize_with = "serde_bytes"`. It's not working for `type t = blob`
                 Vec(ref t) if matches!(t.as_ref(), Nat8) => str("serde_bytes::ByteBuf"),
-                Vec(ref t) => str("Vec").append(enclose("<", self.pp_ty(t, is_ref), ">")),
-                Record(ref fs) => self.pp_record_fields(fs, false, is_ref),
-                Variant(ref fs) => {
-                    // only possible for result variant
-                    let (ok, err, is_motoko) = as_result(fs).unwrap();
-                    // This is a hacky way to redirect Result type
-                    let old = self
-                        .state
-                        .push_state(&StateElem::TypeStr("std::result::Result"));
-                    let result = if let Some(t) = &self.state.config.use_type {
-                        let (res, _) = parse_use_type(t);
-                        // not generating test for this use_type. rustc should be able to catch type mismatches.
-                        self.state.update_stats("use_type");
-                        res
-                    } else if is_motoko {
-                        "candid::MotokoResult".to_string()
-                    } else {
-                        "std::result::Result".to_string()
-                    };
-                    self.state
-                        .pop_state(old, StateElem::TypeStr("std::result::Result"));
-                    let old = self.state.push_state(&StateElem::Label("Ok"));
-                    let ok = self.pp_ty(ok, is_ref);
-                    self.state.pop_state(old, StateElem::Label("Ok"));
-                    let old = self.state.push_state(&StateElem::Label("Err"));
-                    let err = self.pp_ty(err, is_ref);
-                    self.state.pop_state(old, StateElem::Label("Err"));
-                    let body = ok.append(", ").append(err);
-                    RcDoc::text(result).append(enclose("<", body, ">"))
-                }
+                Vec(ref t) => self.pp_vec(t, is_ref),
+                Record(ref fs) => self.pp_record_fields(fs, None, false, is_ref),
+                Variant(ref fs) => self.pp_variant(fs, None, is_ref),
                 Func(_) => unreachable!(), // not possible after rewriting
                 Service(_) => unreachable!(), // not possible after rewriting
                 Class(_, _) => unreachable!(),
@@ -277,6 +302,7 @@ fn test_{test_name}() {{
         self.state.pop_state(old, elem);
         res
     }
+
     fn pp_label<'b>(&mut self, id: &'b SharedLabel, is_variant: bool, need_vis: bool) -> RcDoc<'b> {
         let vis = if need_vis {
             self.state.update_stats("visibility");
@@ -324,6 +350,30 @@ fn test_{test_name}() {{
             }
         }
     }
+
+    fn pp_var<'b>(&mut self, id: &'b str, is_ref: bool) -> RcDoc<'b> {
+        let name = if let Some(name) = &self.state.config.name {
+            let res = RcDoc::text(name.clone());
+            self.state.update_stats("name");
+            res
+        } else {
+            ident(id, Some(Case::Pascal))
+        };
+        if !is_ref && self.recs.contains(id) {
+            str("Box<").append(name).append(">")
+        } else {
+            name
+        }
+    }
+
+    fn pp_vec<'b>(&mut self, ty: &'b Type, is_ref: bool) -> RcDoc<'b> {
+        str("Vec").append(enclose("<", self.pp_ty(ty, is_ref), ">"))
+    }
+
+    fn pp_opt<'b>(&mut self, ty: &'b Type, syntax: Option<&'b IDLType>, is_ref: bool) -> RcDoc<'b> {
+        str("Option").append(enclose("<", self.pp_ty_rich(ty, syntax, is_ref), ">"))
+    }
+
     fn pp_tuple<'b>(&mut self, fs: &'b [Field], need_vis: bool, is_ref: bool) -> RcDoc<'b> {
         let tuple = fs.iter().enumerate().map(|(i, f)| {
             let lab = i.to_string();
@@ -340,17 +390,31 @@ fn test_{test_name}() {{
         });
         enclose("(", RcDoc::concat(tuple), ")")
     }
-    fn pp_record_field<'b>(&mut self, field: &'b Field, need_vis: bool, is_ref: bool) -> RcDoc<'b> {
+
+    fn pp_record_field<'b>(
+        &mut self,
+        field: &'b Field,
+        syntax: Option<&'b IDLType>,
+        need_vis: bool,
+        is_ref: bool,
+    ) -> RcDoc<'b> {
         let lab = field.id.to_string();
         let old = self.state.push_state(&StateElem::Label(&lab));
         let res = self
             .pp_label(&field.id, false, need_vis)
             .append(kwd(":"))
-            .append(self.pp_ty(&field.ty, is_ref));
+            .append(self.pp_ty_rich(&field.ty, syntax, is_ref));
         self.state.pop_state(old, StateElem::Label(&lab));
         res
     }
-    fn pp_record_fields<'b>(&mut self, fs: &'b [Field], need_vis: bool, is_ref: bool) -> RcDoc<'b> {
+
+    fn pp_record_fields<'b>(
+        &mut self,
+        fs: &'b [Field],
+        syntax: Option<&'b [syntax::TypeField]>,
+        need_vis: bool,
+        is_ref: bool,
+    ) -> RcDoc<'b> {
         let old = if self.state.path.last() == Some(&"record".to_string()) {
             // don't push record again when coming from pp_ty
             None
@@ -362,7 +426,10 @@ fn test_{test_name}() {{
         } else {
             let fields: Vec<_> = fs
                 .iter()
-                .map(|f| self.pp_record_field(f, need_vis, is_ref))
+                .map(|f| {
+                    let (docs, syntax_field) = find_field(syntax, &f.id);
+                    docs.append(self.pp_record_field(f, syntax_field, need_vis, is_ref))
+                })
                 .collect();
             let fields = concat(fields.into_iter(), ",");
             enclose_space("{", fields, "}")
@@ -372,31 +439,81 @@ fn test_{test_name}() {{
         }
         res
     }
-    fn pp_variant_field<'b>(&mut self, field: &'b Field) -> RcDoc<'b> {
+
+    fn pp_variant<'b>(
+        &mut self,
+        fs: &'b [Field],
+        syntax: Option<&'b [syntax::TypeField]>,
+        is_ref: bool,
+    ) -> RcDoc<'b> {
+        // only possible for result variant
+        if let Some((ok, err, is_motoko)) = as_result(fs) {
+            // This is a hacky way to redirect Result type
+            let old = self
+                .state
+                .push_state(&StateElem::TypeStr("std::result::Result"));
+            let result = if let Some(t) = &self.state.config.use_type {
+                let (res, _) = parse_use_type(t);
+                // not generating test for this use_type. rustc should be able to catch type mismatches.
+                self.state.update_stats("use_type");
+                res
+            } else if is_motoko {
+                "candid::MotokoResult".to_string()
+            } else {
+                "std::result::Result".to_string()
+            };
+            self.state
+                .pop_state(old, StateElem::TypeStr("std::result::Result"));
+            let old = self.state.push_state(&StateElem::Label("Ok"));
+            let ok = self.pp_ty(ok, is_ref);
+            self.state.pop_state(old, StateElem::Label("Ok"));
+            let old = self.state.push_state(&StateElem::Label("Err"));
+            let err = self.pp_ty(err, is_ref);
+            self.state.pop_state(old, StateElem::Label("Err"));
+            let body = ok.append(", ").append(err);
+            RcDoc::text(result).append(enclose("<", body, ">"))
+        } else {
+            self.pp_variant_fields(fs, syntax)
+        }
+    }
+
+    fn pp_variant_field<'b>(&mut self, field: &'b Field, syntax: Option<&'b IDLType>) -> RcDoc<'b> {
         let lab = field.id.to_string();
         let old = self.state.push_state(&StateElem::Label(&lab));
-        let res = match field.ty.as_ref() {
-            TypeInner::Null => self.pp_label(&field.id, true, false),
-            TypeInner::Record(fs) => self
+        let res = match (field.ty.as_ref(), syntax) {
+            (TypeInner::Null, _) => self.pp_label(&field.id, true, false),
+            (TypeInner::Record(fs), _) => self
                 .pp_label(&field.id, true, false)
-                .append(self.pp_record_fields(fs, false, false)),
-            _ => self.pp_label(&field.id, true, false).append(enclose(
+                .append(self.pp_record_fields(fs, None, false, false)),
+            (_, _) => self.pp_label(&field.id, true, false).append(enclose(
                 "(",
-                self.pp_ty(&field.ty, false),
+                self.pp_ty_rich(&field.ty, syntax, false),
                 ")",
             )),
         };
         self.state.pop_state(old, StateElem::Label(&lab));
         res
     }
-    fn pp_variant_fields<'b>(&mut self, fs: &'b [Field]) -> RcDoc<'b> {
+
+    fn pp_variant_fields<'b>(
+        &mut self,
+        fs: &'b [Field],
+        syntax: Option<&'b [syntax::TypeField]>,
+    ) -> RcDoc<'b> {
         let old = self.state.push_state(&StateElem::TypeStr("variant"));
-        let fields: Vec<_> = fs.iter().map(|f| self.pp_variant_field(f)).collect();
+        let fields: Vec<_> = fs
+            .iter()
+            .map(|f| {
+                let (docs, syntax_field) = find_field(syntax, &f.id);
+                docs.append(self.pp_variant_field(f, syntax_field))
+            })
+            .collect();
         let fields = concat(fields.into_iter(), ",");
         let res = enclose_space("{", fields, "}");
         self.state.pop_state(old, StateElem::TypeStr("variant"));
         res
     }
+
     fn pp_defs(&mut self, def_list: &'a [&'a str]) -> RcDoc<'a> {
         let mut res = Vec::with_capacity(def_list.len());
         for id in def_list {
@@ -413,6 +530,11 @@ fn test_{test_name}() {{
                 .clone()
                 .map(RcDoc::text)
                 .unwrap_or_else(|| ident(id, Some(Case::Pascal)));
+            let syntax = self.prog.lookup(id);
+            let syntax_ty = syntax.map(|b| &b.typ);
+            let docs = syntax
+                .map(|b| pp_docs(b.docs.as_ref()))
+                .unwrap_or(RcDoc::nil());
             self.state.update_stats("name");
             self.state.update_stats("visibility");
             self.state.update_stats("attributes");
@@ -424,6 +546,7 @@ fn test_{test_name}() {{
                 .clone()
                 .map(RcDoc::text)
                 .unwrap_or(RcDoc::text("#[derive(CandidType, Deserialize)]"));
+            let derive = docs.append(derive).append(RcDoc::line());
             let line = match ty.as_ref() {
                 TypeInner::Record(fs) => {
                     let separator = if is_tuple(fs) {
@@ -431,13 +554,19 @@ fn test_{test_name}() {{
                     } else {
                         RcDoc::nil()
                     };
+                    let syntax_fields = syntax_ty.and_then(|t| {
+                        if let IDLType::RecordT(syntax_fields) = &t {
+                            Some(syntax_fields.as_slice())
+                        } else {
+                            None
+                        }
+                    });
                     derive
-                        .append(RcDoc::line())
                         .append(vis)
                         .append("struct ")
                         .append(name)
                         .append(" ")
-                        .append(self.pp_record_fields(fs, true, false))
+                        .append(self.pp_record_fields(fs, syntax_fields, true, false))
                         .append(separator)
                 }
                 TypeInner::Variant(fs) => {
@@ -445,16 +574,22 @@ fn test_{test_name}() {{
                         vis.append(kwd("type"))
                             .append(name)
                             .append(" = ")
-                            .append(self.pp_ty(ty, false))
+                            .append(self.pp_ty_rich(ty, syntax_ty, false))
                             .append(";")
                     } else {
+                        let syntax_fields = syntax_ty.and_then(|t| {
+                            if let IDLType::VariantT(syntax_fields) = &t {
+                                Some(syntax_fields.as_slice())
+                            } else {
+                                None
+                            }
+                        });
                         derive
-                            .append(RcDoc::line())
                             .append(vis)
                             .append("enum ")
                             .append(name)
                             .append(" ")
-                            .append(self.pp_variant_fields(fs))
+                            .append(self.pp_variant_fields(fs, syntax_fields))
                     }
                 }
                 TypeInner::Func(func) => str("candid::define_function!(")
@@ -472,18 +607,21 @@ fn test_{test_name}() {{
                 _ => {
                     if self.recs.contains(id) {
                         derive
-                            .append(RcDoc::line())
                             .append(vis.clone())
                             .append("struct ")
                             .append(name)
                             // TODO: Unfortunately, the visibility of the inner newtype is also controlled by var.visibility
-                            .append(enclose("(", vis.append(self.pp_ty(ty, false)), ")"))
+                            .append(enclose(
+                                "(",
+                                vis.append(self.pp_ty_rich(ty, syntax_ty, false)),
+                                ")",
+                            ))
                             .append(";")
                     } else {
                         vis.append(kwd("type"))
                             .append(name)
                             .append(" = ")
-                            .append(self.pp_ty(ty, false))
+                            .append(self.pp_ty_rich(ty, syntax_ty, false))
                             .append(";")
                     }
                 }
@@ -537,6 +675,7 @@ fn test_{test_name}() {{
         self.state.pop_state(old, lab);
         res
     }
+
     fn pp_ty_service<'b>(&mut self, serv: &'b [(String, Type)]) -> RcDoc<'b> {
         let lab = StateElem::TypeStr("service");
         let old = self.state.push_state(&lab);
@@ -559,7 +698,13 @@ fn test_{test_name}() {{
         self.state.pop_state(old, lab);
         res
     }
-    fn pp_function(&mut self, id: &str, func: &Function) -> Method {
+
+    fn pp_function(
+        &mut self,
+        id: &str,
+        func: &Function,
+        syntax: Option<&syntax::Binding>,
+    ) -> Method {
         use candid::types::internal::FuncMode;
         let old = self.state.push_state(&StateElem::Label(id));
         let name = self
@@ -619,10 +764,12 @@ fn test_{test_name}() {{
                 .map(|x| x.pretty(LINE_WIDTH).to_string())
                 .collect(),
             mode,
+            docs: syntax.map(|b| b.docs.clone()).unwrap_or_default(),
         };
         self.state.pop_state(old, StateElem::Label(id));
         res
     }
+
     fn pp_actor(&mut self, actor: &Type) -> (Vec<Method>, Option<Vec<(String, String)>>) {
         let actor = self.state.env.trace_type(actor).unwrap();
         let init = if let TypeInner::Class(args, _) = actor.as_ref() {
@@ -650,22 +797,28 @@ fn test_{test_name}() {{
         } else {
             None
         };
-        let serv = self.state.env.as_service(&actor).unwrap();
+
         let mut res = Vec::new();
+        let serv = self.state.env.as_service(&actor).unwrap();
+        let syntax_methods = self.prog.resolve_actor_methods().unwrap();
         for (id, func) in serv.iter() {
             let func = self.state.env.as_func(func).unwrap();
-            res.push(self.pp_function(id, func));
+            let syntax = syntax_methods.iter().find(|b| b.id == *id);
+            res.push(self.pp_function(id, func, syntax));
         }
         (res, init)
     }
 }
+
 #[derive(Serialize, Debug)]
 pub struct Output {
     pub type_defs: String,
     pub methods: Vec<Method>,
     pub init_args: Option<Vec<(String, String)>>,
     pub tests: String,
+    pub actor_docs: Vec<String>,
 }
+
 #[derive(Serialize, Debug)]
 pub struct Method {
     pub name: String,
@@ -673,10 +826,18 @@ pub struct Method {
     pub args: Vec<(String, String)>,
     pub rets: Vec<String>,
     pub mode: String,
+    pub docs: Vec<String>,
 }
-pub fn emit_bindgen(tree: &Config, env: &TypeEnv, actor: &Option<Type>) -> (Output, Vec<String>) {
+
+pub fn emit_bindgen(
+    tree: &Config,
+    env: &TypeEnv,
+    actor: &Option<Type>,
+    prog: &mut IDLMergedProg,
+) -> (Output, Vec<String>) {
     let mut state = NominalState {
         state: crate::configs::State::new(&tree.0, env),
+        prog,
     };
     let (env, actor) = state.nominalize_all(actor);
     let old_stats = state.state.stats.clone();
@@ -688,15 +849,19 @@ pub fn emit_bindgen(tree: &Config, env: &TypeEnv, actor: &Option<Type>) -> (Outp
     let recs = infer_rec(&env, &def_list).unwrap();
     let mut state = State {
         state: crate::configs::State::new(&tree.0, &env),
+        prog,
         recs,
         tests: BTreeMap::new(),
     };
     state.state.stats = old_stats;
     let defs = state.pp_defs(&def_list);
-    let (methods, init_args) = if let Some(actor) = &actor {
-        state.pp_actor(actor)
+    let (methods, init_args, actor_docs) = if let Some(actor) = &actor {
+        let (meths, args) = state.pp_actor(actor);
+        let syntax_actor = prog.resolve_actor().ok().flatten();
+        let docs = syntax_actor.map(|a| a.docs.clone()).unwrap_or_default();
+        (meths, args, docs)
     } else {
-        (Vec::new(), None)
+        (Vec::new(), None, Vec::new())
     };
     let tests = state.tests.into_values().collect::<Vec<_>>().join("\n");
     let unused = state.state.report_unused();
@@ -706,6 +871,7 @@ pub fn emit_bindgen(tree: &Config, env: &TypeEnv, actor: &Option<Type>) -> (Outp
             methods,
             init_args,
             tests,
+            actor_docs,
         },
         unused,
     )
@@ -720,6 +886,7 @@ pub fn output_handlebar(output: Output, config: ExternalConfig, template: &str) 
         methods: Vec<Method>,
         init_args: Option<Vec<(String, String)>>,
         tests: String,
+        actor_docs: Vec<String>,
     }
     let data = HBOutput {
         type_defs: output.type_defs,
@@ -727,6 +894,7 @@ pub fn output_handlebar(output: Output, config: ExternalConfig, template: &str) 
         external: config.0,
         init_args: output.init_args,
         tests: output.tests,
+        actor_docs: output.actor_docs,
     };
     hbs.render_template(template, &data).unwrap()
 }
@@ -745,6 +913,7 @@ impl Default for ExternalConfig {
                 ("candid_crate", "candid"),
                 ("service_name", "service"),
                 ("target", "canister_call"),
+                ("doc_comment_prefix", DOC_COMMENT_PREFIX),
             ]
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -756,8 +925,10 @@ pub fn compile(
     tree: &Config,
     env: &TypeEnv,
     actor: &Option<Type>,
+    prog: &IDLMergedProg,
     mut external: ExternalConfig,
 ) -> (String, Vec<String>) {
+    let mut prog = prog.clone();
     let source = match external.0.get("target").map(|s| s.as_str()) {
         Some("canister_call") | None => Cow::Borrowed(include_str!("rust_call.hbs")),
         Some("agent") => Cow::Borrowed(include_str!("rust_agent.hbs")),
@@ -777,7 +948,7 @@ pub fn compile(
         }
         _ => unimplemented!(),
     };
-    let (output, unused) = emit_bindgen(tree, env, actor);
+    let (output, unused) = emit_bindgen(tree, env, actor, &mut prog);
     (output_handlebar(output, external, &source), unused)
 }
 
@@ -809,10 +980,17 @@ fn path_to_var(path: &[TypePath]) -> String {
 }
 struct NominalState<'a> {
     state: crate::configs::State<'a, BindingConfig>,
+    prog: &'a mut IDLMergedProg,
 }
 impl NominalState<'_> {
     // Convert structural typing to nominal typing to fit Rust's type system
-    fn nominalize(&mut self, env: &mut TypeEnv, path: &mut Vec<TypePath>, t: &Type) -> Type {
+    fn nominalize(
+        &mut self,
+        env: &mut TypeEnv,
+        path: &mut Vec<TypePath>,
+        t: &Type,
+        syntax: Option<&IDLType>,
+    ) -> Type {
         let elem = StateElem::Type(t);
         let old = if matches!(t.as_ref(), TypeInner::Func(_)) {
             // strictly speaking, we want to avoid func label from the main service. But this is probably good enough.
@@ -823,17 +1001,38 @@ impl NominalState<'_> {
         let res = match t.as_ref() {
             TypeInner::Opt(ty) => {
                 path.push(TypePath::Opt);
-                let ty = self.nominalize(env, path, ty);
+                let syntax_ty = syntax.and_then(|s| {
+                    if let IDLType::OptT(inner) = s {
+                        Some(inner.as_ref())
+                    } else {
+                        None
+                    }
+                });
+                let ty = self.nominalize(env, path, ty, syntax_ty);
                 path.pop();
                 TypeInner::Opt(ty)
             }
             TypeInner::Vec(ty) => {
                 path.push(TypePath::Vec);
-                let ty = self.nominalize(env, path, ty);
+                let syntax_ty = syntax.and_then(|s| {
+                    if let IDLType::VecT(inner) = s {
+                        Some(inner.as_ref())
+                    } else {
+                        None
+                    }
+                });
+                let ty = self.nominalize(env, path, ty, syntax_ty);
                 path.pop();
                 TypeInner::Vec(ty)
             }
             TypeInner::Record(fs) => {
+                let syntax_fields = syntax.and_then(|s| {
+                    if let IDLType::RecordT(syntax_fields) = s {
+                        Some(syntax_fields)
+                    } else {
+                        None
+                    }
+                });
                 if matches!(
                     path.last(),
                     None | Some(TypePath::VariantField(_)) | Some(TypePath::Id(_))
@@ -846,7 +1045,10 @@ impl NominalState<'_> {
                             let elem = StateElem::Label(&lab);
                             let old = self.state.push_state(&elem);
                             path.push(TypePath::RecordField(id.to_string()));
-                            let ty = self.nominalize(env, path, ty);
+                            let syntax_field = syntax_fields.and_then(|s| {
+                                s.iter().find(|f| f.label == **id).map(|f| f.typ.clone())
+                            });
+                            let ty = self.nominalize(env, path, ty, syntax_field.as_ref());
                             path.pop();
                             self.state.pop_state(old, elem);
                             Field { id: id.clone(), ty }
@@ -861,16 +1063,27 @@ impl NominalState<'_> {
                     } else {
                         path_to_var(path)
                     };
+                    let new_syntax = IDLType::RecordT(syntax_fields.cloned().unwrap_or_default());
                     let ty = self.nominalize(
                         env,
                         &mut vec![TypePath::Id(new_var.clone())],
                         &TypeInner::Record(fs.to_vec()).into(),
+                        Some(&new_syntax),
                     );
                     env.0.insert(new_var.clone(), ty);
+                    self.prog
+                        .insert_binding(new_var.clone(), new_syntax, vec![]);
                     TypeInner::Var(new_var)
                 }
             }
             TypeInner::Variant(fs) => {
+                let syntax_fields = syntax.and_then(|s| {
+                    if let IDLType::VariantT(syntax_fields) = s {
+                        Some(syntax_fields)
+                    } else {
+                        None
+                    }
+                });
                 let is_result = as_result(fs).is_some();
                 if matches!(path.last(), None | Some(TypePath::Id(_))) || is_result {
                     let fs: Vec<_> = fs
@@ -884,7 +1097,10 @@ impl NominalState<'_> {
                             } else {
                                 path.push(TypePath::VariantField(id.to_string()));
                             }
-                            let ty = self.nominalize(env, path, ty);
+                            let syntax_field = syntax_fields.and_then(|s| {
+                                s.iter().find(|f| f.label == **id).map(|f| f.typ.clone())
+                            });
+                            let ty = self.nominalize(env, path, ty, syntax_field.as_ref());
                             path.pop();
                             self.state.pop_state(old, StateElem::Label(&lab));
                             Field { id: id.clone(), ty }
@@ -899,12 +1115,16 @@ impl NominalState<'_> {
                     } else {
                         path_to_var(path)
                     };
+                    let new_syntax = IDLType::VariantT(syntax_fields.cloned().unwrap_or_default());
                     let ty = self.nominalize(
                         env,
                         &mut vec![TypePath::Id(new_var.clone())],
                         &TypeInner::Variant(fs.to_vec()).into(),
+                        Some(&new_syntax),
                     );
                     env.0.insert(new_var.clone(), ty);
+                    self.prog
+                        .insert_binding(new_var.clone(), new_syntax, vec![]);
                     TypeInner::Var(new_var)
                 }
             }
@@ -926,7 +1146,7 @@ impl NominalState<'_> {
                                     i.to_string()
                                 };
                                 path.push(TypePath::Func(format!("arg{idx}")));
-                                let ty = self.nominalize(env, path, &arg.typ);
+                                let ty = self.nominalize(env, path, &arg.typ, None);
                                 path.pop();
                                 self.state.pop_state(old, StateElem::Label(&lab));
                                 ArgType {
@@ -948,7 +1168,7 @@ impl NominalState<'_> {
                                     i.to_string()
                                 };
                                 path.push(TypePath::Func(format!("ret{idx}")));
-                                let ty = self.nominalize(env, path, &ty);
+                                let ty = self.nominalize(env, path, &ty, None);
                                 path.pop();
                                 self.state.pop_state(old, StateElem::Label(&lab));
                                 ty
@@ -968,6 +1188,7 @@ impl NominalState<'_> {
                         env,
                         &mut vec![TypePath::Id(new_var.clone())],
                         &TypeInner::Func(func.clone()).into(),
+                        None,
                     );
                     env.0.insert(new_var.clone(), ty);
                     TypeInner::Var(new_var)
@@ -980,7 +1201,7 @@ impl NominalState<'_> {
                             let lab = meth.to_string();
                             let old = self.state.push_state(&StateElem::Label(&lab));
                             path.push(TypePath::Id(meth.to_string()));
-                            let ty = self.nominalize(env, path, ty);
+                            let ty = self.nominalize(env, path, ty, None);
                             path.pop();
                             self.state.pop_state(old, StateElem::Label(&lab));
                             (meth.clone(), ty)
@@ -999,28 +1220,38 @@ impl NominalState<'_> {
                         env,
                         &mut vec![TypePath::Id(new_var.clone())],
                         &TypeInner::Service(serv.clone()).into(),
+                        None,
                     );
                     env.0.insert(new_var.clone(), ty);
                     TypeInner::Var(new_var)
                 }
             },
-            TypeInner::Class(args, ty) => TypeInner::Class(
-                args.iter()
-                    .map(|arg| {
-                        let elem = StateElem::Label("init");
-                        let old = self.state.push_state(&elem);
-                        path.push(TypePath::Init);
-                        let ty = self.nominalize(env, path, &arg.typ);
-                        path.pop();
-                        self.state.pop_state(old, elem);
-                        ArgType {
-                            name: arg.name.clone(),
-                            typ: ty,
-                        }
-                    })
-                    .collect(),
-                self.nominalize(env, path, ty),
-            ),
+            TypeInner::Class(args, ty) => {
+                let syntax_ty = syntax.and_then(|s| {
+                    if let IDLType::ClassT(_, syntax_ty) = s {
+                        Some(syntax_ty.as_ref())
+                    } else {
+                        None
+                    }
+                });
+                TypeInner::Class(
+                    args.iter()
+                        .map(|arg| {
+                            let elem = StateElem::Label("init");
+                            let old = self.state.push_state(&elem);
+                            path.push(TypePath::Init);
+                            let ty = self.nominalize(env, path, &arg.typ, None);
+                            path.pop();
+                            self.state.pop_state(old, elem);
+                            ArgType {
+                                name: arg.name.clone(),
+                                typ: ty,
+                            }
+                        })
+                        .collect(),
+                    self.nominalize(env, path, ty, syntax_ty),
+                )
+            }
             t => t.clone(),
         }
         .into();
@@ -1035,13 +1266,19 @@ impl NominalState<'_> {
         for (id, ty) in self.state.env.0.iter() {
             let elem = StateElem::Label(id);
             let old = self.state.push_state(&elem);
-            let ty = self.nominalize(&mut res, &mut vec![TypePath::Id(id.clone())], ty);
+            let syntax = self.prog.lookup(id).map(|t| t.typ.clone());
+            let ty = self.nominalize(
+                &mut res,
+                &mut vec![TypePath::Id(id.clone())],
+                ty,
+                syntax.as_ref(),
+            );
             res.0.insert(id.to_string(), ty);
             self.state.pop_state(old, elem);
         }
         let actor = actor
             .as_ref()
-            .map(|ty| self.nominalize(&mut res, &mut vec![], ty));
+            .map(|ty| self.nominalize(&mut res, &mut vec![], ty, None));
         (res, actor)
     }
 }

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -244,9 +244,6 @@ fn test_{test_name}() {{
             use_type_doc
         } else {
             match (ty.as_ref(), syntax) {
-                (TypeInner::Record(ref fields), Some(IDLType::RecordT(syntax_fields))) => {
-                    self.pp_record_fields(fields, Some(syntax_fields), false, is_ref)
-                }
                 (TypeInner::Variant(ref fields), Some(IDLType::VariantT(syntax_fields))) => {
                     self.pp_variant(fields, Some(syntax_fields), is_ref)
                 }

--- a/rust/candid_parser/src/bindings/rust_agent.hbs
+++ b/rust/candid_parser/src/bindings/rust_agent.hbs
@@ -6,9 +6,15 @@ type Result<T> = std::result::Result<T, ic_agent::AgentError>;
 
 {{type_defs}}
 {{#if methods}}
+{{#each actor_docs}}
+{{../doc_comment_prefix}}{{this}}
+{{/each}}
 pub struct {{PascalCase service_name}}<'a>(pub Principal, pub &'a ic_agent::Agent);
 impl<'a> {{PascalCase service_name}}<'a> {
   {{#each methods}}
+  {{#each this.docs}}
+  {{../../doc_comment_prefix}}{{this}}
+  {{/each}}
   pub async fn {{this.name}}(&self{{#each this.args}}, {{this.0}}: &{{this.1}}{{/each}}) -> Result<{{vec_to_arity this.rets}}> {
     let args = Encode!({{#each this.args}}&{{this.0}}{{#unless @last}},{{/unless}}{{/each}})?;
     let bytes = self.1.{{#if (eq this.mode "update")}}update{{else}}query{{/if}}(&self.0, "{{escape_debug this.original_name}}").with_arg(args).{{#if (eq this.mode "update")}}call_and_wait{{else}}call{{/if}}().await?;
@@ -17,7 +23,8 @@ impl<'a> {{PascalCase service_name}}<'a> {
   {{/each}}
 }
 {{#if canister_id}}
-pub const CANISTER_ID : Principal = Principal::from_slice(&[{{principal_slice canister_id}}]); // {{canister_id}}
+{{doc_comment_prefix}}Canister ID: `{{canister_id}}`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[{{principal_slice canister_id}}]);
 {{/if}}
 {{/if}}
 {{#if tests}}

--- a/rust/candid_parser/src/bindings/rust_call.hbs
+++ b/rust/candid_parser/src/bindings/rust_call.hbs
@@ -6,16 +6,23 @@ use ic_cdk::api::call::CallResult as Result;
 
 {{type_defs}}
 {{#if methods}}
+{{#each actor_docs}}
+{{../doc_comment_prefix}}{{this}}
+{{/each}}
 pub struct {{PascalCase service_name}}(pub Principal);
 impl {{PascalCase service_name}} {
   {{#each methods}}
+  {{#each this.docs}}
+  {{../../doc_comment_prefix}}{{this}}
+  {{/each}}
   pub async fn {{this.name}}(&self{{#each this.args}}, {{this.0}}: &{{this.1}}{{/each}}) -> Result<({{#each this.rets}}{{this}},{{/each}})> {
     ic_cdk::call(self.0, "{{escape_debug this.original_name}}", ({{#each this.args}}{{this.0}},{{/each}})).await
   }
   {{/each}}
 }
 {{#if canister_id}}
-pub const CANISTER_ID : Principal = Principal::from_slice(&[{{principal_slice canister_id}}]); // {{canister_id}}
+{{doc_comment_prefix}}Canister ID: `{{canister_id}}`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[{{principal_slice canister_id}}]);
 pub const {{snake_case service_name}} : {{PascalCase service_name}} = {{PascalCase service_name}}(CANISTER_ID);
 {{/if}}
 {{/if}}

--- a/rust/candid_parser/src/bindings/rust_stub.hbs
+++ b/rust/candid_parser/src/bindings/rust_stub.hbs
@@ -11,6 +11,9 @@ fn init({{#each init_args}}{{#if (not @first)}}, {{/if}}{{this.0}}: {{this.1}}{{
 }
 {{/if}}
 {{#each methods}}
+{{#each this.docs}}
+{{../../doc_comment_prefix}}{{this}}
+{{/each}}
 #[ic_cdk::{{cdk_attribute this.mode this.name this.original_name}}]
 fn {{this.name}}({{#each this.args}}{{#if (not @first)}}, {{/if}}{{this.0}}: {{this.1}}{{/each}}) -> {{vec_to_arity this.rets}} {
   unimplemented!()

--- a/rust/candid_parser/tests/assets/example.did
+++ b/rust/candid_parser/tests/assets/example.did
@@ -27,6 +27,7 @@ type nested = record {
   40:nat;
   variant{ A; 0x2a; B; C };
 };
+// Doc comment for res type
 type res = variant {
   // Doc comment for Ok variant
   Ok: record{int;nat};

--- a/rust/candid_parser/tests/assets/ok/actor.rs
+++ b/rust/candid_parser/tests/assets/ok/actor.rs
@@ -28,6 +28,7 @@ impl Service {
     ic_cdk::call(self.0, "o", (arg0,)).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 

--- a/rust/candid_parser/tests/assets/ok/class.rs
+++ b/rust/candid_parser/tests/assets/ok/class.rs
@@ -12,6 +12,7 @@ pub struct Profile { pub age: u8, pub name: String }
 fn init(arg0: candid::Int, l: List, arg2: Profile) {
   unimplemented!()
 }
+/// Doc comment for get method in class service
 #[ic_cdk::update]
 fn get() -> List {
   unimplemented!()

--- a/rust/candid_parser/tests/assets/ok/comment.rs
+++ b/rust/candid_parser/tests/assets/ok/comment.rs
@@ -4,6 +4,8 @@
 use candid::{self, CandidType, Deserialize, Principal};
 use ic_cdk::api::call::CallResult as Result;
 
+/// line comment
+/// 
 pub type Id = u8;
 
 

--- a/rust/candid_parser/tests/assets/ok/cyclic.rs
+++ b/rust/candid_parser/tests/assets/ok/cyclic.rs
@@ -18,6 +18,7 @@ impl Service {
     ic_cdk::call(self.0, "f", (arg0,arg1,arg2,arg3,arg4,arg5,)).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 

--- a/rust/candid_parser/tests/assets/ok/empty.rs
+++ b/rust/candid_parser/tests/assets/ok/empty.rs
@@ -27,6 +27,7 @@ impl Service {
     ic_cdk::call(self.0, "h", (arg0,)).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 

--- a/rust/candid_parser/tests/assets/ok/escape.rs
+++ b/rust/candid_parser/tests/assets/ok/escape.rs
@@ -22,6 +22,7 @@ impl Service {
     ic_cdk::call(self.0, "\n\'\"\'\'\"\"\r\t", (arg0,)).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 

--- a/rust/candid_parser/tests/assets/ok/example.mo
+++ b/rust/candid_parser/tests/assets/ok/example.mo
@@ -68,6 +68,7 @@ module {
     };
   };
   public type node = { head : Nat; tail : list };
+  /// Doc comment for res type
   public type res = {
     /// Doc comment for Ok variant
     #Ok : (Int, Nat);

--- a/rust/candid_parser/tests/assets/ok/example.rs
+++ b/rust/candid_parser/tests/assets/ok/example.rs
@@ -107,7 +107,10 @@ pub(crate) struct MyVariantCInner {
 pub(crate) enum MyVariant {
   /// Doc comment for my_variant field a
   #[serde(rename="a")]
-  A{ b: String },
+  A{
+    /// Doc comment for my_variant field a field b
+    b: String,
+  },
   /// Doc comment for my_variant field c
   #[serde(rename="c")]
   C(Option<MyVariantCInner>),

--- a/rust/candid_parser/tests/assets/ok/example.rs
+++ b/rust/candid_parser/tests/assets/ok/example.rs
@@ -8,6 +8,7 @@ use ic_cdk::api::call::CallResult as Result;
 pub(crate) struct Node { pub(crate) head: u128, pub(crate) tail: Box<List> }
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) struct List(pub(crate) Option<Node>);
+/// Doc comment for prim type
 type CanisterId = Principal;
 #[derive(CandidType, Deserialize, Clone)]
 pub(crate) struct ListInner {
@@ -74,6 +75,7 @@ pub(crate) struct ResErr {
   /// on multiple lines
   pub(crate) error: String,
 }
+/// Doc comment for res type
 pub(crate) type Res = std::result::Result<(candid::Int,u128,), ResErr>;
 candid::define_function!(pub(crate) F : (MyList, FArg1) -> (
     Option<MyList>,

--- a/rust/candid_parser/tests/assets/ok/example.rs
+++ b/rust/candid_parser/tests/assets/ok/example.rs
@@ -11,12 +11,15 @@ pub(crate) struct List(pub(crate) Option<Node>);
 type CanisterId = Principal;
 #derive[CandidType, Deserialize, Clone]
 pub(crate) struct ListInner {
+  /// Doc comment for List head
   #[serde(skip_deserializing)]
   #[serde(rename="head")]
   HEAD: candid::Int,
+  /// Doc comment for List tail
   #[serde(skip_deserializing)]
   tail: Arc<MyList>,
 }
+/// Doc comment for List
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) struct MyList(pub(crate) Option<ListInner>);
 #[derive(CandidType, Deserialize, Debug)]
@@ -34,10 +37,12 @@ pub(crate) enum Nested41 {
   B,
   C,
 }
+/// Doc comment for nested type
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) struct Nested {
   pub(crate) _0_: u128,
   pub(crate) _1_: u128,
+  /// Doc comment for nested record
   pub(crate) _2_: (u128,candid::Int,),
   pub(crate) _3_: Nested3,
   pub(crate) _40_: u128,
@@ -64,7 +69,11 @@ pub(crate) struct HRet42 {}
 pub(crate) struct HRet { pub(crate) _42_: HRet42, pub(crate) id: u128 }
 candid::define_function!(pub(crate) FArg1 : (i32) -> (i64));
 #[derive(CandidType, Deserialize, Debug)]
-pub(crate) struct ResErr { pub(crate) error: String }
+pub(crate) struct ResErr {
+  /// Doc comment for error field in Err variant,
+  /// on multiple lines
+  pub(crate) error: String,
+}
 pub(crate) type Res = std::result::Result<(candid::Int,u128,), ResErr>;
 candid::define_function!(pub(crate) F : (MyList, FArg1) -> (
     Option<MyList>,
@@ -79,17 +88,27 @@ pub(crate) struct XRet2Ok { pub(crate) result: String }
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) enum Error { #[serde(rename="a")] A, #[serde(rename="b")] B }
 #[derive(CandidType, Deserialize, Debug)]
-pub(crate) struct NestedRecordsNestedInner { pub(crate) nested_field: String }
+pub(crate) struct NestedRecordsNestedInner {
+  /// Doc comment for nested_records field nested_field
+  pub(crate) nested_field: String,
+}
+/// Doc comment for nested_records
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) struct NestedRecords {
+  /// Doc comment for nested_records field nested
   pub(crate) nested: Option<NestedRecordsNestedInner>,
 }
 #[derive(CandidType, Deserialize, Debug)]
-pub(crate) struct MyVariantCInner { pub(crate) d: String }
+pub(crate) struct MyVariantCInner {
+  /// Doc comment for my_variant field c field d
+  pub(crate) d: String,
+}
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) enum MyVariant {
+  /// Doc comment for my_variant field a
   #[serde(rename="a")]
   A{ b: String },
+  /// Doc comment for my_variant field c
   #[serde(rename="c")]
   C(Option<MyVariantCInner>),
 }
@@ -117,8 +136,10 @@ candid::define_service!(pub(crate) S : {
 });
 candid::define_function!(pub(crate) T : (S) -> ());
 
+/// Doc comment for service
 pub struct Service(pub Principal);
 impl Service {
+  /// Doc comment for f1 method of service
   pub async fn f_1(&self, arg0: &List, test: &serde_bytes::ByteBuf, arg2: &Option<bool>) -> Result<()> {
     ic_cdk::call(self.0, "f1", (arg0,test,arg2,)).await
   }
@@ -128,6 +149,7 @@ impl Service {
   pub async fn h(&self, arg0: &Vec<Option<String>>, arg1: &HArg1, arg2: &Option<MyList>) -> Result<(HRet,)> {
     ic_cdk::call(self.0, "h", (arg0,arg1,arg2,)).await
   }
+  /// Doc comment for i method of service
   pub async fn i(&self, arg0: &MyList, arg1: &FArg1) -> Result<(Option<MyList>,Res,)> {
     ic_cdk::call(self.0, "i", (arg0,arg1,)).await
   }
@@ -143,11 +165,13 @@ impl Service {
   pub async fn g(&self, arg0: &List) -> Result<(B,Tree,Stream,)> {
     ic_cdk::call(self.0, "g", (arg0,)).await
   }
+  /// Doc comment for imported bbbbb service method
   pub async fn bbbbb(&self, arg0: &B) -> Result<()> {
     ic_cdk::call(self.0, "bbbbb", (arg0,)).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 #[test]
 fn test_Arc_MyList_() {

--- a/rust/candid_parser/tests/assets/ok/fieldnat.rs
+++ b/rust/candid_parser/tests/assets/ok/fieldnat.rs
@@ -51,6 +51,7 @@ impl Service {
     ic_cdk::call(self.0, "foo", (arg0,)).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 

--- a/rust/candid_parser/tests/assets/ok/inline_methods.rs
+++ b/rust/candid_parser/tests/assets/ok/inline_methods.rs
@@ -46,6 +46,7 @@ impl Service {
     ic_cdk::call(self.0, "high_order_fn_via_record_inline", (arg0,)).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 

--- a/rust/candid_parser/tests/assets/ok/keyword.rs
+++ b/rust/candid_parser/tests/assets/ok/keyword.rs
@@ -76,6 +76,7 @@ impl Service {
     ic_cdk::call(self.0, "variant", (arg0,)).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 

--- a/rust/candid_parser/tests/assets/ok/management.rs
+++ b/rust/candid_parser/tests/assets/ok/management.rs
@@ -301,5 +301,6 @@ impl<'a> Service<'a> {
     Ok(Decode!(&bytes)?)
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 

--- a/rust/candid_parser/tests/assets/ok/recursion.rs
+++ b/rust/candid_parser/tests/assets/ok/recursion.rs
@@ -38,6 +38,7 @@ impl Service {
     ic_cdk::call(self.0, "g", (arg0,)).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 

--- a/rust/candid_parser/tests/assets/ok/recursive_class.rs
+++ b/rust/candid_parser/tests/assets/ok/recursive_class.rs
@@ -12,6 +12,7 @@ impl Service {
     ic_cdk::call(self.0, "next", ()).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 

--- a/rust/candid_parser/tests/assets/ok/service.rs
+++ b/rust/candid_parser/tests/assets/ok/service.rs
@@ -30,6 +30,7 @@ impl Service {
     ic_cdk::call(self.0, "asVariant", ()).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 

--- a/rust/candid_parser/tests/assets/ok/unicode.rs
+++ b/rust/candid_parser/tests/assets/ok/unicode.rs
@@ -42,6 +42,7 @@ impl Service {
     ic_cdk::call(self.0, "👀", (arg0,)).await
   }
 }
-pub const CANISTER_ID : Principal = Principal::from_slice(&[]); // aaaaa-aa
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
 pub const service : Service = Service(CANISTER_ID);
 

--- a/rust/candid_parser/tests/parse_type.rs
+++ b/rust/candid_parser/tests/parse_type.rs
@@ -168,8 +168,11 @@ fn compiler_test(resource: &str) {
                     _ => (),
                 }
                 let mut output = mint.new_goldenfile(filename.with_extension("rs")).unwrap();
-                let (content, unused) = rust::compile(&config, &env, &actor, external);
-                assert!(unused.is_empty());
+                let (content, unused) = rust::compile(&config, &env, &actor, &prog, external);
+                assert!(
+                    unused.is_empty(),
+                    "Expected no unused fields, got {unused:?}"
+                );
                 writeln!(output, "{content}").unwrap();
             }
             {

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -237,7 +237,7 @@ fn main() -> Result<()> {
                         .map(|x| x.clone().try_into().unwrap())
                         .unwrap_or(ExternalConfig::default());
                     let config = Config::new(configs);
-                    let (res, unused) = compile(&config, &env, &actor, external);
+                    let (res, unused) = compile(&config, &env, &actor, &prog, external);
                     warn_unused(&unused);
                     res
                 }
@@ -251,7 +251,7 @@ fn main() -> Result<()> {
                         _ => unreachable!(),
                     };
                     external.0.insert("target".to_string(), target.to_string());
-                    let (res, unused) = compile(&config, &env, &actor, external);
+                    let (res, unused) = compile(&config, &env, &actor, &prog, external);
                     warn_unused(&unused);
                     res
                 }


### PR DESCRIPTION
**Overview**
Adds support for doc comments in the Rust bindings generator.

**Considerations**
Not all doc comments are supported due to how the Rust code is _nominalized_, as you can notice from the `rust/candid_parser/tests/assets/ok/example.rs` as compared to the `rust/candid_parser/tests/assets/ok/example.mo` Motoko one.
