### PR TITLE
refactor: changes the implementation of `concat` to not require a clone-able iterator

### DIFF
--- a/rust/candid/src/pretty/candid.rs
+++ b/rust/candid/src/pretty/candid.rs
@@ -145,8 +145,8 @@ pub(crate) fn pp_field(field: &Field, is_variant: bool) -> RcDoc {
 }
 
 fn pp_fields(fs: &[Field], is_variant: bool) -> RcDoc {
-    let fields = concat(fs.iter().map(|f| pp_field(f, is_variant)), ";");
-    enclose_space("{", fields, "}")
+    let fields = fs.iter().map(|f| pp_field(f, is_variant));
+    enclose_space("{", concat(fields, ";"), "}")
 }
 
 pub fn pp_function(func: &Function) -> RcDoc {
@@ -484,14 +484,14 @@ pub mod value {
                 if matches!(vs.first(), Some(Nat8(_))) || vs.len() > MAX_ELEMENTS_FOR_PRETTY_PRINT {
                     RcDoc::as_string(format!("{v:?}"))
                 } else {
-                    let body = concat(vs.iter().map(|v| pp_value(depth - 1, v)), ";");
-                    kwd("vec").append(enclose_space("{", body, "}"))
+                    let values = vs.iter().map(|v| pp_value(depth - 1, v));
+                    kwd("vec").append(enclose_space("{", concat(values, ";"), "}"))
                 }
             }
             Record(fields) => {
                 if is_tuple(v) {
-                    let tuple = concat(fields.iter().map(|f| pp_value(depth - 1, &f.val)), ";");
-                    kwd("record").append(enclose_space("{", tuple, "}"))
+                    let fields = fields.iter().map(|f| pp_value(depth - 1, &f.val));
+                    kwd("record").append(enclose_space("{", concat(fields, ";"), "}"))
                 } else {
                     kwd("record").append(pp_fields(depth, fields))
                 }
@@ -504,12 +504,10 @@ pub mod value {
     }
 
     pub fn pp_args(args: &IDLArgs) -> RcDoc {
-        let body = concat(
-            args.args
-                .iter()
-                .map(|v| pp_value(MAX_ELEMENTS_FOR_PRETTY_PRINT, v)),
-            ",",
-        );
-        enclose("(", body, ")")
+        let args = args
+            .args
+            .iter()
+            .map(|v| pp_value(MAX_ELEMENTS_FOR_PRETTY_PRINT, v));
+        enclose("(", concat(args, ","), ")")
     }
 }

--- a/rust/candid/src/pretty/utils.rs
+++ b/rust/candid/src/pretty/utils.rs
@@ -7,7 +7,8 @@ fn is_empty(doc: &RcDoc) -> bool {
     use pretty::Doc::*;
     match &**doc {
         Nil => true,
-        FlatAlt(t1, t2) | Union(t1, t2) => is_empty(t1) && is_empty(t2),
+        FlatAlt(t1, t2) => is_empty(t1) || is_empty(t2),
+        Union(t1, t2) => is_empty(t1) && is_empty(t2),
         Group(t) | Nest(_, t) | Annotated((), t) => is_empty(t),
         _ => false,
     }
@@ -52,11 +53,11 @@ where
 /// Append the separator to each item in `docs`. If it is displayed in a single line, omit the last separator.
 pub fn concat<'a, D>(docs: D, sep: &'a str) -> RcDoc<'a>
 where
-    D: Iterator<Item = RcDoc<'a>> + Clone,
+    D: Iterator<Item = RcDoc<'a>>,
 {
-    RcDoc::intersperse(docs.clone().map(|d| d.append(sep)), RcDoc::line()).flat_alt(
-        RcDoc::intersperse(docs, RcDoc::text(sep).append(RcDoc::line())),
-    )
+    let singleline = RcDoc::intersperse(docs, RcDoc::text(sep).append(RcDoc::line()));
+    let multiline = singleline.clone().append(sep);
+    multiline.flat_alt(singleline)
 }
 
 pub fn lines<'a, D>(docs: D) -> RcDoc<'a>

--- a/rust/candid/src/pretty/utils.rs
+++ b/rust/candid/src/pretty/utils.rs
@@ -7,7 +7,7 @@ fn is_empty(doc: &RcDoc) -> bool {
     use pretty::Doc::*;
     match &**doc {
         Nil => true,
-        FlatAlt(t1, t2) => is_empty(t1) || is_empty(t2),
+        FlatAlt(t1, t2) => is_empty(t2) || is_empty(t1),
         Union(t1, t2) => is_empty(t1) && is_empty(t2),
         Group(t) | Nest(_, t) | Annotated((), t) => is_empty(t),
         _ => false,

--- a/rust/candid_parser/src/bindings/javascript.rs
+++ b/rust/candid_parser/src/bindings/javascript.rs
@@ -164,8 +164,7 @@ fn pp_function(func: &Function) -> RcDoc {
     let args = pp_args(&func.args);
     let rets = pp_rets(&func.rets);
     let modes = pp_modes(&func.modes);
-    let items = [args, rets, modes];
-    let doc = concat(items.iter().cloned(), ",");
+    let doc = concat([args, rets, modes].into_iter(), ",");
     enclose("(", doc, ")").nest(INDENT_SPACE)
 }
 


### PR DESCRIPTION
Also refactors its callsites for clarity / to no longer allocate intermediate `Vec`s
