### PR TITLE
fix: support doc comments in `vec` inner types

### DIFF
--- a/rust/candid_parser/tests/assets/example.did
+++ b/rust/candid_parser/tests/assets/example.did
@@ -62,6 +62,10 @@ type my_variant = variant {
   c: opt record {
     // Doc comment for my_variant field c field d
     d: text;
+    e: vec record {
+      // Doc comment for my_variant field c field e inner vec element
+      f: nat;
+    };
   }
 }
 

--- a/rust/candid_parser/tests/assets/ok/example.d.ts
+++ b/rust/candid_parser/tests/assets/ok/example.d.ts
@@ -53,6 +53,14 @@ export type my_variant = {
          * Doc comment for my_variant field c field d
          */
         'd' : string,
+        'e' : Array<
+          {
+            /**
+             * Doc comment for my_variant field c field e inner vec element
+             */
+            'f' : bigint,
+          }
+        >,
       }
     ]
   };

--- a/rust/candid_parser/tests/assets/ok/example.did
+++ b/rust/candid_parser/tests/assets/ok/example.did
@@ -11,7 +11,7 @@ type list = opt node;
 type my_type = principal;
 type my_variant = variant {
   a : record { b : text };
-  c : opt record { d : text };
+  c : opt record { d : text; e : vec record { f : nat } };
 };
 type nested = record {
   0 : nat;

--- a/rust/candid_parser/tests/assets/ok/example.js
+++ b/rust/candid_parser/tests/assets/ok/example.js
@@ -58,7 +58,12 @@ export const idlFactory = ({ IDL }) => {
   });
   const my_variant = IDL.Variant({
     'a' : IDL.Record({ 'b' : IDL.Text }),
-    'c' : IDL.Opt(IDL.Record({ 'd' : IDL.Text })),
+    'c' : IDL.Opt(
+      IDL.Record({
+        'd' : IDL.Text,
+        'e' : IDL.Vec(IDL.Record({ 'f' : IDL.Nat })),
+      })
+    ),
   });
   const A = B;
   B.fill(IDL.Opt(A));

--- a/rust/candid_parser/tests/assets/ok/example.mo
+++ b/rust/candid_parser/tests/assets/ok/example.mo
@@ -37,6 +37,12 @@ module {
     #c : ?{
       /// Doc comment for my_variant field c field d
       d : Text;
+      e : [
+        {
+          /// Doc comment for my_variant field c field e inner vec element
+          f : Nat;
+        }
+      ];
     };
   };
   /// Doc comment for nested type

--- a/rust/candid_parser/tests/assets/ok/example.rs
+++ b/rust/candid_parser/tests/assets/ok/example.rs
@@ -101,9 +101,15 @@ pub(crate) struct NestedRecords {
   pub(crate) nested: Option<NestedRecordsNestedInner>,
 }
 #[derive(CandidType, Deserialize, Debug)]
+pub(crate) struct MyVariantCInnerEItem {
+  /// Doc comment for my_variant field c field e inner vec element
+  pub(crate) f: u128,
+}
+#[derive(CandidType, Deserialize, Debug)]
 pub(crate) struct MyVariantCInner {
   /// Doc comment for my_variant field c field d
   pub(crate) d: String,
+  pub(crate) e: Vec<MyVariantCInnerEItem>,
 }
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) enum MyVariant {


### PR DESCRIPTION
**Overview**
Adds support for doc comments in `vec` inner types for Motoko and TypeScript bindings generators.
Rust already supports them.

