### PR TITLE
fix: subtype arguments order for `Func`

### DIFF
--- a/rust/candid/src/types/subtype.rs
+++ b/rust/candid/src/types/subtype.rs
@@ -143,7 +143,7 @@ fn subtype_(
             let args2 = to_tuple(&f2_args);
             let rets1 = to_tuple(&f1.rets);
             let rets2 = to_tuple(&f2.rets);
-            subtype_(report, gamma, env, &args2, &args1)
+            subtype_(report, gamma, env, &args1, &args2)
                 .context("Subtype fails at function input type")?;
             subtype_(report, gamma, env, &rets1, &rets2)
                 .context("Subtype fails at function return type")?;

--- a/rust/candid/tests/subtype.rs
+++ b/rust/candid/tests/subtype.rs
@@ -1,0 +1,91 @@
+use std::collections::HashSet;
+
+use candid::types::subtype::{subtype, subtype_with_config, OptReport};
+use candid_parser::utils::CandidSource;
+
+const CANDID1: &str = r#"
+type Token = variant {
+    ICP;
+    USDC
+};
+
+type Asset = record {
+    token : opt Token
+};
+
+service : {
+    "go" : (Asset) -> (Asset) query
+}
+"#;
+const CANDID2: &str = r#"
+type Token = variant {
+    ICP;
+    USDC;
+    USDT
+};
+
+type Asset = record {
+    token : opt Token
+};
+
+service : {
+    "go" : (Asset) -> (Asset) query
+}
+"#;
+
+#[test]
+fn test_subtype() {
+    let (mut env, opt_new) = CandidSource::Text(CANDID1).load().unwrap();
+    let new_type = opt_new.unwrap();
+    let (env2, opt_old) = CandidSource::Text(CANDID2).load().unwrap();
+    let old_type = opt_old.unwrap();
+    let mut gamma = HashSet::new();
+    let old_type = env.merge_type(env2, old_type);
+
+    let result = subtype(&mut gamma, &env, &new_type, &old_type);
+    assert!(result.is_ok(), "{result:?}");
+
+    let result_with_config =
+        subtype_with_config(OptReport::Error, &mut gamma, &env, &new_type, &old_type);
+    assert!(result_with_config.is_ok(), "{result_with_config:?}");
+}
+
+#[test]
+fn test_subtype_with_config() {
+    let (mut env, opt_new) = CandidSource::Text(CANDID1).load().unwrap();
+    let new_type = opt_new.unwrap();
+    let (env2, opt_old) = CandidSource::Text(CANDID2).load().unwrap();
+    let old_type = opt_old.unwrap();
+    let mut gamma = HashSet::new();
+    let old_type = env.merge_type(env2, old_type);
+
+    let result = subtype_with_config(OptReport::Error, &mut gamma, &env, &new_type, &old_type);
+    assert!(result.is_ok(), "{result:?}");
+}
+
+#[test]
+fn test_subtype_inverse() {
+    let (mut env, opt_new) = CandidSource::Text(CANDID2).load().unwrap();
+    let new_type = opt_new.unwrap();
+    let (env2, opt_old) = CandidSource::Text(CANDID1).load().unwrap();
+    let old_type = opt_old.unwrap();
+    let mut gamma = HashSet::new();
+    let old_type = env.merge_type(env2, old_type);
+
+    let result = subtype(&mut gamma, &env, &new_type, &old_type);
+    // By default, the inner subtype_ does not return errors.
+    assert!(result.is_ok(), "{result:?}");
+}
+
+#[test]
+fn test_subtype_with_config_inverse() {
+    let (mut env, opt_new) = CandidSource::Text(CANDID2).load().unwrap();
+    let new_type = opt_new.unwrap();
+    let (env2, opt_old) = CandidSource::Text(CANDID1).load().unwrap();
+    let old_type = opt_old.unwrap();
+    let mut gamma = HashSet::new();
+    let old_type = env.merge_type(env2, old_type);
+
+    let result = subtype_with_config(OptReport::Error, &mut gamma, &env, &new_type, &old_type);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
**Overview**
In the case we are comparing this Candid declaration:

```
type Token = variant {
    ICP;
    USDC
};

type Asset = record {
    token : opt Token
};

service : {
    "go" : (Asset) -> (Asset) query
}
```

against this other declaration:

```
type Token = variant {
    ICP;
    USDC;
    USDT
};

type Asset = record {
    token : opt Token
};

service : {
    "go" : (Asset) -> (Asset) query
}
```

we get:
```
Method go: func (Asset) -> (Asset) query is not a subtype of func (Asset/1) -> (Asset/1) query
```

The correct behavior should be that the method from the second declaration is considered a subtype of the first one, which is the behavior outlined in the [spec](https://github.com/dfinity/candid/blob/master/spec/Candid.md#variants-1).