### PR TITLE
fix: make special opt subtyping rule warning more explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     - `Binding`
     - `IDLProg`
     - `IDLInitArgs`
+  + Changes the warning message for the special opt subtyping rule to be more explicit in `candid::types::subtype::subtype` and `candid::types::subtype::subtype_with_config` functions.
 
 ### candid_parser
 

--- a/rust/candid/src/types/subtype.rs
+++ b/rust/candid/src/types/subtype.rs
@@ -69,7 +69,7 @@ fn subtype_(
             Ok(())
         }
         (_, Opt(_)) => {
-            let msg = format!("FIX ME! {t1} <: {t2} via special opt rule.\nThis means the sender and receiver type has diverged, and can cause data loss.");
+            let msg = format!("WARNING: {t1} <: {t2} due to special subtyping rules involving optional types/fields (see https://github.com/dfinity/candid/blob/master/spec/Candid.md#upgrading-and-subtyping). This means the two interfaces have diverged, which could cause data loss.");
             match report {
                 OptReport::Silence => (),
                 OptReport::Warning => eprintln!("{msg}"),


### PR DESCRIPTION
**Overview**
Explains better the special opt subtyping rule warning, adding a link to the spec.
