### PR TITLE
refactor: move the `syntax` module from `candid` to `candid_parser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,30 +9,12 @@
   + `pretty::candid::pp_label` now takes a `&Label` parameter, instead of a `&SharedLabel`.
 
 * Non-breaking changes:
-  + The following structs have been moved from the `candid_parser` crate to the `candid::types::syntax` module. See the `candid_parser`'s changelog for more details.
   + Makes the warning message for the special opt subtyping rule more explicit in the `candid::types::subtype::subtype` and `candid::types::subtype::subtype_with_config` functions.
 
 ### candid_parser
 
 * Breaking changes:
-  + The following structs have been moved to the `candid` crate:
-    - `IDLType`
-    - `IDLTypes`
-    - `PrimType`
-    - `FuncType`
-    - `IDLArgType`
-    - `TypeField`
-    - `Dec`
-    - `Binding`
-    - `IDLProg`
-    - `IDLInitArgs`
-    As a consequence, the `FromStr` trait is no longer implemented for the following types:
-      - `IDLProg`
-      - `IDLInitArgs`
-      - `IDLType`
-      - `IDLTypes`
-    You must now use the `parse_idl_prog`, `parse_idl_init_args`, `parse_idl_type` and `parse_idl_types` functions to parse these types, respectively.
-  + `pretty_parse` doesn't work anymore with the `IDLProg` and `IDLTypes` types. Use `pretty_parse_idl_prog` and `pretty_parse_idl_types` instead.
+  + The `candid_parser::types` module has been renamed to `candid_parser::syntax`.
   + The `args` field in both `FuncType` and `IDLInitArgs` now have type `Vec<IDLArgType>`.
 
 * Non-breaking changes:

--- a/rust/candid/src/pretty/candid.rs
+++ b/rust/candid/src/pretty/candid.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use crate::pretty::syntax::pp_docs;
 use crate::pretty::utils::*;
 use crate::types::{ArgType, Field, FuncMode, Function, Label, Type, TypeEnv, TypeInner};
 use pretty::RcDoc;
@@ -62,7 +61,7 @@ fn needs_quote(id: &str) -> bool {
     !is_valid_as_id(id) || is_keyword(id)
 }
 
-pub(crate) fn ident_string(id: &str) -> String {
+fn ident_string(id: &str) -> String {
     if needs_quote(id) {
         format!("\"{}\"", id.escape_debug())
     } else {
@@ -70,7 +69,7 @@ pub(crate) fn ident_string(id: &str) -> String {
     }
 }
 
-pub(crate) fn pp_text(id: &str) -> RcDoc {
+pub fn pp_text(id: &str) -> RcDoc {
     RcDoc::text(ident_string(id))
 }
 
@@ -120,6 +119,10 @@ pub fn pp_ty_inner(ty: &TypeInner) -> RcDoc {
         Unknown => str("unknown"),
         Future => str("future"),
     }
+}
+
+pub fn pp_docs<'a>(docs: &'a [String]) -> RcDoc<'a> {
+    lines(docs.iter().map(|line| RcDoc::text("// ").append(line)))
 }
 
 pub fn pp_label(id: &Label) -> RcDoc {

--- a/rust/candid/src/pretty/mod.rs
+++ b/rust/candid/src/pretty/mod.rs
@@ -1,5 +1,4 @@
 //! pretty printer for Candid type and value
 
 pub mod candid;
-pub mod syntax;
 pub mod utils;

--- a/rust/candid/src/types/mod.rs
+++ b/rust/candid/src/types/mod.rs
@@ -9,7 +9,6 @@ use serde::ser::Error;
 mod impls;
 pub mod internal;
 pub mod subtype;
-pub mod syntax;
 pub mod type_env;
 #[cfg_attr(docsrs, doc(cfg(feature = "value")))]
 #[cfg(feature = "value")]

--- a/rust/candid_parser/src/bindings/motoko.rs
+++ b/rust/candid_parser/src/bindings/motoko.rs
@@ -1,9 +1,9 @@
 // This module implements the Candid to Motoko binding as specified in
 // https://github.com/dfinity/motoko/blob/master/design/IDL-Motoko.md
 
+use crate::syntax::{self, IDLActorType, IDLMergedProg, IDLType};
 use candid::pretty::candid::is_valid_as_id;
 use candid::pretty::utils::*;
-use candid::types::syntax::{self, IDLActorType, IDLMergedProg, IDLType};
 use candid::types::{ArgType, Field, FuncMode, Function, Label, SharedLabel, Type, TypeInner};
 use candid::TypeEnv;
 use pretty::RcDoc;

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -1,12 +1,10 @@
 use super::analysis::{chase_actor, infer_rec};
 use crate::{
     configs::{ConfigState, ConfigTree, Configs, Context, StateElem},
+    syntax::{self, IDLActorType, IDLMergedProg, IDLType},
     Deserialize,
 };
-use candid::types::{
-    syntax::{self, IDLActorType, IDLMergedProg, IDLType},
-    Field, Function, Label, SharedLabel, Type, TypeEnv, TypeInner,
-};
+use candid::types::{Field, Function, Label, SharedLabel, Type, TypeEnv, TypeInner};
 use candid::{pretty::utils::*, types::ArgType};
 use convert_case::{Case, Casing};
 use pretty::RcDoc;

--- a/rust/candid_parser/src/bindings/typescript.rs
+++ b/rust/candid_parser/src/bindings/typescript.rs
@@ -1,6 +1,6 @@
 use super::javascript::{ident, is_tuple_fields};
+use crate::syntax::{self, IDLMergedProg, IDLType};
 use candid::pretty::utils::*;
-use candid::types::syntax::{self, IDLMergedProg, IDLType};
 use candid::types::{Field, Function, Label, SharedLabel, Type, TypeEnv, TypeInner};
 use pretty::RcDoc;
 

--- a/rust/candid_parser/src/error.rs
+++ b/rust/candid_parser/src/error.rs
@@ -1,16 +1,14 @@
 //! When serializing or deserializing Candid goes wrong.
 
-use candid::types::syntax::{IDLProg, IDLTypes};
+use crate::token;
 use codespan_reporting::diagnostic::Label;
-use std::io;
-use thiserror::Error;
-
-use crate::{parse_idl_prog, parse_idl_types, token};
 use codespan_reporting::{
     diagnostic::Diagnostic,
     files::{Error as ReportError, SimpleFile},
     term::{self, termcolor::StandardStream},
 };
+use std::io;
+use thiserror::Error;
 
 pub type Result<T = ()> = std::result::Result<T, Error>;
 
@@ -106,20 +104,11 @@ impl From<toml::de::Error> for Error {
     }
 }
 
-/// Does not work for parsing [IDLProg] and [IDLTypes], use [pretty_parse_idl_prog] and [pretty_parse_idl_types] instead.
 pub fn pretty_parse<T>(name: &str, str: &str) -> Result<T>
 where
     T: std::str::FromStr<Err = Error>,
 {
     str.parse::<T>().or_else(|e| pretty_print_err(name, str, e))
-}
-
-pub fn pretty_parse_idl_prog(name: &str, str: &str) -> Result<IDLProg> {
-    parse_idl_prog(str).or_else(|e| pretty_print_err(name, str, e))
-}
-
-pub fn pretty_parse_idl_types(name: &str, str: &str) -> Result<IDLTypes> {
-    parse_idl_types(str).or_else(|e| pretty_print_err(name, str, e))
 }
 
 /// Wrap the parser error and pretty print the error message.

--- a/rust/candid_parser/src/grammar.lalrpop
+++ b/rust/candid_parser/src/grammar.lalrpop
@@ -1,7 +1,7 @@
 use super::test::{Assert, Input, Test};
 use super::token::{Token, error, error2, LexicalError, Span, TriviaMap};
 use candid::{Principal, types::Label};
-use candid::types::syntax::{IDLType, PrimType, TypeField, FuncType, Binding, Dec, IDLProg, IDLTypes, IDLInitArgs, IDLArgType, IDLActorType};
+use crate::syntax::{IDLType, PrimType, TypeField, FuncType, Binding, Dec, IDLProg, IDLTypes, IDLInitArgs, IDLArgType, IDLActorType};
 use candid::types::value::{IDLField, IDLValue, IDLArgs, VariantValue};
 use candid::types::{TypeEnv, FuncMode};
 use candid::utils::check_unique;

--- a/rust/candid_parser/src/lib.rs
+++ b/rust/candid_parser/src/lib.rs
@@ -47,7 +47,7 @@
 //! ```
 //! # fn f() -> anyhow::Result<()> {
 //! use candid::{TypeEnv, types::{Type, TypeInner}};
-//! use candid_parser::{check_prog, parse_idl_prog};
+//! use candid_parser::{IDLProg, check_prog};
 //! let did_file = r#"
 //!     type List = opt record { head: int; tail: List };
 //!     type byte = nat8;
@@ -58,7 +58,7 @@
 //! "#;
 //!
 //! // Parse did file into an AST
-//! let ast = parse_idl_prog(did_file)?;
+//! let ast: IDLProg = did_file.parse()?;
 //!
 //! // Type checking a given .did file
 //! // let (env, opt_actor) = check_file("a.did")?;
@@ -86,7 +86,7 @@
 //! use candid::{IDLArgs, types::value::IDLValue};
 //! use candid_parser::parse_idl_args;
 //! # use candid::TypeEnv;
-//! # use candid_parser::{check_prog, parse_idl_prog};
+//! # use candid_parser::{IDLProg, check_prog};
 //! # let did_file = r#"
 //! #    type List = opt record { head: int; tail: List };
 //! #    type byte = nat8;
@@ -95,7 +95,7 @@
 //! #      g : (List) -> (int) query;
 //! #    }
 //! # "#;
-//! # let ast = parse_idl_prog(did_file)?;
+//! # let ast = did_file.parse::<IDLProg>()?;
 //! # let mut env = TypeEnv::new();
 //! # let actor = check_prog(&mut env, &ast)?.unwrap();
 //! // Get method type f : (byte, int, nat, int8) -> (List)
@@ -119,15 +119,15 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod error;
-pub use error::{
-    pretty_parse, pretty_parse_idl_prog, pretty_parse_idl_types, pretty_wrap, Error, Result,
-};
+pub use error::{pretty_parse, pretty_wrap, Error, Result};
 
 pub mod bindings;
 pub mod grammar;
+pub mod syntax;
 pub mod token;
 pub mod typing;
 pub mod utils;
+pub use syntax::IDLProg;
 pub use typing::{check_file, check_prog, pretty_check_file};
 
 pub use candid;
@@ -141,28 +141,6 @@ pub mod configs;
 #[cfg(feature = "random")]
 pub mod random;
 pub mod test;
-
-pub fn parse_idl_prog(str: &str) -> Result<candid::types::syntax::IDLProg> {
-    let trivia = token::TriviaMap::default();
-    let lexer = token::Tokenizer::new_with_trivia(str, trivia.clone());
-    let res = grammar::IDLProgParser::new().parse(Some(&trivia.clone()), lexer)?;
-    Ok(res)
-}
-
-pub fn parse_idl_init_args(str: &str) -> Result<candid::types::syntax::IDLInitArgs> {
-    let lexer = token::Tokenizer::new(str);
-    Ok(grammar::IDLInitArgsParser::new().parse(None, lexer)?)
-}
-
-pub fn parse_idl_type(str: &str) -> Result<candid::types::syntax::IDLType> {
-    let lexer = token::Tokenizer::new(str);
-    Ok(grammar::TypParser::new().parse(None, lexer)?)
-}
-
-pub fn parse_idl_types(str: &str) -> Result<candid::types::syntax::IDLTypes> {
-    let lexer = token::Tokenizer::new(str);
-    Ok(grammar::TypsParser::new().parse(None, lexer)?)
-}
 
 pub fn parse_idl_args(s: &str) -> crate::Result<candid::IDLArgs> {
     let lexer = token::Tokenizer::new(s);

--- a/rust/candid_parser/src/syntax/mod.rs
+++ b/rust/candid_parser/src/syntax/mod.rs
@@ -1,8 +1,13 @@
-use crate::{
+mod pretty;
+
+pub use pretty::pretty_print;
+
+use crate::error;
+use anyhow::{anyhow, bail, Context, Result};
+use candid::{
     idl_hash,
     types::{FuncMode, Label},
 };
-use anyhow::{anyhow, bail, Context, Result};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,9 +40,27 @@ impl IDLType {
     }
 }
 
+impl std::str::FromStr for IDLType {
+    type Err = error::Error;
+    fn from_str(str: &str) -> error::Result<Self> {
+        let trivia = super::token::TriviaMap::default();
+        let lexer = super::token::Tokenizer::new_with_trivia(str, trivia.clone());
+        Ok(super::grammar::TypParser::new().parse(Some(&trivia), lexer)?)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct IDLTypes {
     pub args: Vec<IDLType>,
+}
+
+impl std::str::FromStr for IDLTypes {
+    type Err = error::Error;
+    fn from_str(str: &str) -> error::Result<Self> {
+        let trivia = super::token::TriviaMap::default();
+        let lexer = super::token::Tokenizer::new_with_trivia(str, trivia.clone());
+        Ok(super::grammar::TypsParser::new().parse(Some(&trivia), lexer)?)
+    }
 }
 
 macro_rules! enum_to_doc {
@@ -156,10 +179,28 @@ impl IDLProg {
     }
 }
 
+impl std::str::FromStr for IDLProg {
+    type Err = error::Error;
+    fn from_str(str: &str) -> error::Result<Self> {
+        let trivia = super::token::TriviaMap::default();
+        let lexer = super::token::Tokenizer::new_with_trivia(str, trivia.clone());
+        Ok(super::grammar::IDLProgParser::new().parse(Some(&trivia), lexer)?)
+    }
+}
+
 #[derive(Debug)]
 pub struct IDLInitArgs {
     pub decs: Vec<Dec>,
     pub args: Vec<IDLArgType>,
+}
+
+impl std::str::FromStr for IDLInitArgs {
+    type Err = error::Error;
+    fn from_str(str: &str) -> error::Result<Self> {
+        let trivia = super::token::TriviaMap::default();
+        let lexer = super::token::Tokenizer::new_with_trivia(str, trivia.clone());
+        Ok(super::grammar::IDLInitArgsParser::new().parse(Some(&trivia), lexer)?)
+    }
 }
 
 #[derive(Debug)]

--- a/rust/candid_parser/src/syntax/pretty.rs
+++ b/rust/candid_parser/src/syntax/pretty.rs
@@ -2,10 +2,10 @@ use pretty::RcDoc;
 
 use crate::{
     pretty::{
-        candid::{pp_label, pp_modes, pp_text},
+        candid::{pp_docs, pp_label, pp_modes, pp_text},
         utils::{concat, enclose, enclose_space, ident, kwd, lines, str, INDENT_SPACE, LINE_WIDTH},
     },
-    types::syntax::{
+    syntax::{
         Binding, FuncType, IDLActorType, IDLArgType, IDLMergedProg, IDLType, PrimType, TypeField,
     },
 };
@@ -151,10 +151,6 @@ fn pp_defs(prog: &IDLMergedProg) -> RcDoc {
             .append(pp_ty(&b.typ))
             .append(";")
     }))
-}
-
-pub(crate) fn pp_docs<'a>(docs: &'a [String]) -> RcDoc<'a> {
-    lines(docs.iter().map(|line| RcDoc::text("// ").append(line)))
 }
 
 fn pp_actor(actor: &IDLActorType) -> RcDoc {

--- a/rust/candid_parser/src/test.rs
+++ b/rust/candid_parser/src/test.rs
@@ -1,6 +1,6 @@
 use super::typing::check_prog;
+use crate::syntax::{Dec, IDLProg, IDLType};
 use crate::{Error, Result};
-use candid::types::syntax::{Dec, IDLProg, IDLType};
 use candid::types::value::IDLArgs;
 use candid::types::{Type, TypeEnv};
 use candid::DecoderConfig;

--- a/rust/candid_parser/tests/parse_type.rs
+++ b/rust/candid_parser/tests/parse_type.rs
@@ -1,10 +1,10 @@
-use candid::pretty::syntax::pretty_print;
-use candid::types::syntax::{Dec, IDLType};
 use candid::types::TypeEnv;
-use candid_parser::bindings::{javascript, motoko, rust, typescript};
-use candid_parser::configs::Configs;
-use candid_parser::parse_idl_prog;
-use candid_parser::typing::{check_file, check_prog};
+use candid_parser::{
+    bindings::{javascript, motoko, rust, typescript},
+    configs::Configs,
+    syntax::{pretty_print, Dec, IDLProg, IDLType},
+    typing::{check_file, check_prog},
+};
 use goldenfile::Mint;
 use std::io::Write;
 use std::path::Path;
@@ -36,7 +36,7 @@ service server : {
   i : f;
 }
     "#;
-    let ast = parse_idl_prog(prog).unwrap();
+    let ast = prog.parse::<IDLProg>().unwrap();
 
     // Assert doc comments
     let actor = ast.actor.unwrap();
@@ -125,7 +125,8 @@ fn compiler_test(resource: &str) {
                 let mut output = mint.new_goldenfile(filename.with_extension("did")).unwrap();
                 let content = pretty_print(&prog);
                 // Type check output
-                let ast = parse_idl_prog(&content)
+                let ast = content
+                    .parse::<IDLProg>()
                     .unwrap_or_else(|_| panic!("failed to parse candid. Content: {content}"));
                 check_prog(&mut TypeEnv::new(), &ast).unwrap();
                 writeln!(output, "{content}").unwrap();

--- a/rust/candid_parser/tests/parse_value.rs
+++ b/rust/candid_parser/tests/parse_value.rs
@@ -1,7 +1,8 @@
 use candid::types::value::{IDLArgs, IDLField, IDLValue, VariantValue};
 use candid::types::{Label, Type, TypeEnv, TypeInner};
 use candid::{record, variant, CandidType, Nat};
-use candid_parser::{parse_idl_args, parse_idl_type};
+use candid_parser::parse_idl_args;
+use candid_parser::syntax::IDLType;
 
 fn parse_args(input: &str) -> IDLArgs {
     parse_idl_args(input).unwrap()
@@ -13,7 +14,7 @@ fn parse_args_err(input: &str) -> candid_parser::Result<IDLArgs> {
 
 fn parse_type(input: &str) -> Type {
     let env = TypeEnv::new();
-    let ast = parse_idl_type(input).unwrap();
+    let ast = input.parse::<IDLType>().unwrap();
     candid_parser::typing::ast_to_type(&env, &ast).unwrap()
 }
 

--- a/rust/candid_parser/tests/value.rs
+++ b/rust/candid_parser/tests/value.rs
@@ -1,7 +1,12 @@
-use candid::types::value::{IDLArgs, IDLField, IDLValue, VariantValue};
-use candid::types::{Label, TypeEnv};
-use candid::{decode_args, decode_one, Decode};
-use candid_parser::{parse_idl_args, parse_idl_prog, typing::check_prog};
+use candid::{
+    decode_args, decode_one,
+    types::{
+        value::{IDLArgs, IDLField, IDLValue, VariantValue},
+        Label, TypeEnv,
+    },
+    Decode,
+};
+use candid_parser::{parse_idl_args, syntax::IDLProg, typing::check_prog};
 
 #[test]
 fn test_parser() {
@@ -31,7 +36,7 @@ service : {
   f : f;
 }
 "#;
-    let ast = parse_idl_prog(candid).unwrap();
+    let ast = candid.parse::<IDLProg>().unwrap();
     let mut env = TypeEnv::new();
     let actor = check_prog(&mut env, &ast).unwrap().unwrap();
     let method = env.get_method(&actor, "f").unwrap();

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -1,12 +1,12 @@
 use anyhow::{bail, Result};
-use candid_parser::candid::types::{
-    subtype,
+use candid_parser::{
+    candid::types::{subtype, Type},
+    pretty_parse,
     syntax::{IDLType, IDLTypes},
-    Type,
 };
 use candid_parser::{
-    configs::Configs, parse_idl_args, parse_idl_type, parse_idl_value, pretty_check_file,
-    pretty_parse_idl_types, pretty_wrap, typing::ast_to_type, Error, IDLArgs, IDLValue, TypeEnv,
+    configs::Configs, parse_idl_args, parse_idl_value, pretty_check_file, pretty_wrap,
+    typing::ast_to_type, Error, IDLArgs, IDLValue, TypeEnv,
 };
 use clap::Parser;
 use console::style;
@@ -91,9 +91,7 @@ enum Command {
     Subtype {
         #[clap(short, long)]
         defs: Option<PathBuf>,
-        #[clap(value_parser = parse_idl_type)]
         ty1: IDLType,
-        #[clap(value_parser = parse_idl_type)]
         ty2: IDLType,
     },
 }
@@ -156,7 +154,7 @@ fn parse_args(str: &str) -> Result<IDLArgs, Error> {
     pretty_wrap("candid arguments", str, parse_idl_args)
 }
 fn parse_types(str: &str) -> Result<IDLTypes, Error> {
-    pretty_parse_idl_types("type annotations", str)
+    pretty_parse("type annotations", str)
 }
 fn load_config(input: &Option<String>) -> Result<Configs, Error> {
     match input {
@@ -228,7 +226,7 @@ fn main() -> Result<()> {
             let content = match target.as_str() {
                 "js" => candid_parser::bindings::javascript::compile(&env, &actor),
                 "ts" => candid_parser::bindings::typescript::compile(&env, &actor, &prog),
-                "did" => candid_parser::candid::pretty::syntax::pretty_print(&prog),
+                "did" => candid_parser::syntax::pretty_print(&prog),
                 "mo" => candid_parser::bindings::motoko::compile(&env, &actor, &prog),
                 "rs" => {
                     use candid_parser::bindings::rust::{compile, Config, ExternalConfig};


### PR DESCRIPTION
**Overview**
Effectively reverts #622.
