### PR TITLE
chore: patch release 2025-07-25, yank #653

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ## 2025-07-25
 
-### candid 0.10.15
+### candid 0.11.0
+
+* Breaking changes:
+  + Parameters of class initializers and functions in `TypeInner` now take `ArgType` instead of `Type`, to preserve argument names.
 
 * Non-breaking changes:
   + Makes the warning message for the special opt subtyping rule more explicit in the `candid::types::subtype::subtype` and `candid::types::subtype::subtype_with_config` functions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,14 +209,14 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.15"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bincode",
  "binread",
  "byteorder",
- "candid_derive 0.10.15",
- "candid_parser 0.2.0",
+ "candid_derive 0.11.0",
+ "candid_parser 0.2.1",
  "hex",
  "ic_principal 0.1.1",
  "leb128",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.15"
+version = "0.11.0"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.86",
@@ -276,11 +276,11 @@ dependencies = [
 
 [[package]]
 name = "candid_parser"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arbitrary",
- "candid 0.10.15",
+ "candid 0.11.0",
  "codespan-reporting",
  "console",
  "convert_case",
@@ -482,7 +482,7 @@ name = "didc"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "candid_parser 0.2.0",
+ "candid_parser 0.2.1",
  "clap",
  "console",
  "hex",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.10.15"
+version = "0.11.0"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
 # `candid` and `candid_derive` are kept in sync with the same version.
-candid_derive = { path = "../candid_derive", version = "=0.10.15" }
+candid_derive = { path = "../candid_derive", version = "=0.11.0" }
 ic_principal = { path = "../ic_principal", version = "0.1.0" }
 binread = { version = "2.2", features = ["debug_template"] }
 byteorder = "1.5.0"

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid_derive"
-version = "0.10.15" # Sync with `candid` version
+version = "0.11.0" # Sync with `candid` version
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid_parser"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]
@@ -19,7 +19,7 @@ build = "build.rs"
 lalrpop = "0.20.0"
 
 [dependencies]
-candid = { path = "../candid", version = "0.10.15", features = ["all"] }
+candid = { path = "../candid", version = "0.11.0", features = ["all"] }
 codespan-reporting = "0.11"
 hex.workspace = true
 num-bigint.workspace = true
@@ -38,10 +38,7 @@ arbitrary = { workspace = true, optional = true }
 fake = { version = "2.4", optional = true }
 rand = { version = "0.8", optional = true }
 num-traits = { workspace = true, optional = true }
-dialoguer = { version = "0.11", default-features = false, features = [
-    "editor",
-    "completion",
-], optional = true }
+dialoguer = { version = "0.11", default-features = false, features = ["editor", "completion"], optional = true }
 ctrlc = { version = "3.4", optional = true }
 console = { workspace = true, optional = true }
 


### PR DESCRIPTION
candid 0.10.15 from #653 contained a breaking change. This re-releases it:
- candid 0.10.15 yanked, 0.11.0 released
- candid_derive 0.10.15 yanked, 0.11.0 released
- candid_parser 0.2.0 yanked, 0.2.1 released