### PR TITLE
chore: fix release action and update changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,8 @@ name: Release
 on:
   push:
     tags:
-      - '*'
-    branches: # TODO: Remove before merging.
-      - fix-ci  # Pushing the feature branch should test this PR.
+      - "*"
+
 jobs:
   build:
     name: Build for ${{ matrix.name }}
@@ -13,15 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             name: linux64
             artifact_name: target/x86_64-unknown-linux-musl/release/didc
             asset_name: didc-linux64
-          - os: macos-12
+          - os: macos-13-large
             name: macos
             artifact_name: target/release/didc
             asset_name: didc-macos
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             name: arm
             artifact_name: target/arm-unknown-linux-gnueabihf/release/didc
             asset_name: didc-arm32
@@ -49,19 +48,19 @@ jobs:
           sudo apt-get update -yy
           sudo apt-get install -yy musl musl-dev musl-tools
           rustup target add x86_64-unknown-linux-musl
-          cargo build --release --locked --target x86_64-unknown-linux-musl
+          cargo build --package didc --release --locked --target x86_64-unknown-linux-musl
       - name: Build
         if: matrix.name == 'macos'
-        run: cargo build --release --locked
+        run: cargo build --package didc --release --locked
       - name: Cross build
         if: matrix.name == 'arm'
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: build
-          args: --target arm-unknown-linux-gnueabihf --release --locked
-      - name: 'Upload assets'
-        uses: actions/upload-artifact@v3
+          args: --package didc --target arm-unknown-linux-gnueabihf --release --locked
+      - name: "Upload assets"
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
           path: ${{ matrix.artifact_name }}
@@ -74,18 +73,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - os: ubuntu-24.04
+            asset_name: didc-linux64
           - os: ubuntu-22.04
             asset_name: didc-linux64
-          - os: ubuntu-20.04
-            asset_name: didc-linux64
-          - os: macos-13
+          - os: macos-14-large
             asset_name: didc-macos
-          - os: macos-12
+          - os: macos-13-large
             asset_name: didc-macos
     steps:
       - name: Get executable
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
       - name: Executable runs
@@ -105,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get executable
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
       - name: Upload binaries to release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Candid
 
+* Breaking changes:
+  + The `args` field of the `candid::types::internal::Function` struct now is a `Vec<ArgType>` instead of `Vec<Type>`, to preserve argument names.
+  + The `TypeInner::Class` variant now takes `Vec<ArgType>` instead of `Vec<Type>` as its first parameter, to preserve argument names.
+
 * Non-breaking changes:
   + Makes the warning message for the special opt subtyping rule more explicit in the `candid::types::subtype::subtype` and `candid::types::subtype::subtype_with_config` functions.
   + Added `pp_named_args`, `pp_named_init_args` and `pp_label_raw` in `pretty::candid` module.


### PR DESCRIPTION
**Overview**
Copies changes from https://github.com/dfinity/candid/pull/653 for the `.github/workflows/release.yml` file.

Updates changelog, explaining what are the current breaking changes in the `candid` crate.
