### PR TITLE
fix: support block comments and empty lines in `candid_derive`

### DIFF
--- a/rust/candid/src/pretty/candid.rs
+++ b/rust/candid/src/pretty/candid.rs
@@ -296,7 +296,14 @@ pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {
 ///
 /// ```ignore
 /// let mut doc_comments = DocComments::empty();
-/// doc_comments.add_service_method("method_name".to_string(), vec!["Doc comment line 1".to_string(), "Doc comment line 2".to_string()]);
+/// doc_comments.add_service_method(
+///   "method_name".to_string(),
+///   vec![
+///     "Doc comment line 1".to_string(),
+///     "".to_string(), // empty lines are preserved
+///     "Doc comment line 2".to_string(),
+///   ],
+/// );
 /// let candid = compile_with_docs(&env, &actor, &doc_comments);
 /// ```
 pub fn compile_with_docs(env: &TypeEnv, actor: &Option<Type>, docs: &DocComments) -> String {

--- a/rust/candid/tests/types.rs
+++ b/rust/candid/tests/types.rs
@@ -226,16 +226,31 @@ fn test_func() {
         unreachable!()
     }
 
+    /// Doc comment
+    /**
+     * even with blocks
+     * in the middle
+     */
+    /// and a closing line comment
     #[candid_method]
     fn id_tuple_destructure((a, b): (u8, u8)) -> (u8, u8) {
         (a, b)
     }
 
+    /**
+     * Block doc comment,
+     * on multiple lines.
+     * The * at the start of the line will be reflected in the generated doc comment.
+     */
     #[candid_method]
     fn id_struct_destructure(internal::NamedStruct { a, b }: internal::NamedStruct) -> (u16, i32) {
         (a, b)
     }
 
+    ///
+    /// Empty lines
+    ///
+    /// are preserved
     #[candid_method]
     fn id_unused_arg(_a: u8) -> Result<List<u8>, candid::Empty> {
         unreachable!()
@@ -267,8 +282,23 @@ service : (List_2) -> {
   id_struct : (record { List }) -> (Result) query;
   // Doc comment for id_struct_composite
   id_struct_composite : (record { List }) -> (Result) composite_query;
+  // 
+  // * Block doc comment,
+  // * on multiple lines.
+  // * The * at the start of the line will be reflected in the generated doc comment.
+  // 
   id_struct_destructure : (NamedStruct) -> (nat16, int32);
+  // Doc comment
+  // 
+  // * even with blocks
+  // * in the middle
+  // 
+  // and a closing line comment
   id_tuple_destructure : (record { nat8; nat8 }) -> (nat8, nat8);
+  // 
+  // Empty lines
+  // 
+  // are preserved
   id_unused_arg : (nat8) -> (Result);
   // Doc comment for id_variant
   id_variant : (vec A) -> (Result_1);

--- a/rust/candid/tests/types.rs
+++ b/rust/candid/tests/types.rs
@@ -251,6 +251,7 @@ fn test_func() {
     /// Empty lines
     ///
     /// are preserved
+    ///
     #[candid_method]
     fn id_unused_arg(_a: u8) -> Result<List<u8>, candid::Empty> {
         unreachable!()
@@ -299,6 +300,7 @@ service : (List_2) -> {
   // Empty lines
   // 
   // are preserved
+  // 
   id_unused_arg : (nat8) -> (Result);
   // Doc comment for id_variant
   id_variant : (vec A) -> (Result_1);

--- a/rust/candid_derive/src/func.rs
+++ b/rust/candid_derive/src/func.rs
@@ -276,9 +276,13 @@ fn extract_doc_comments(attrs: &[Attribute]) -> Vec<String> {
             if let syn::Meta::NameValue(meta) = &attr.meta {
                 if let Ok(lit) = get_lit_str(&meta.value) {
                     let doc_content = lit.value();
-                    let trimmed = doc_content.trim_start_matches(' ');
-                    if !trimmed.is_empty() {
-                        docs.push(trimmed.to_string());
+                    if !doc_content.is_empty() {
+                        for line in doc_content.lines() {
+                            let trimmed = line.trim().to_string();
+                            docs.push(trimmed);
+                        }
+                    } else {
+                        docs.push("".to_string());
                     }
                 }
             }


### PR DESCRIPTION
**Overview**
Adds support for Rust block comments when collecting them from the Rust canister methods and reflecting them to the candid declaration.
It also fixes empty lines preservation, so that doc comments sections can be properly separated.

Fixes #654.

**Considerations**
We do not remove the leading `*` from the block comments, in order to avoid losing intentional `*` characters (e.g. bullet list). Rust developers should anyway prefer the `///` doc comments.
