### PR TITLE
chore: release 2025-07-28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-### Candid
+## 2025-07-28
+
+### candid 0.11.0
 
 * Breaking changes:
   + The `args` field of the `candid::types::internal::Function` struct now is a `Vec<ArgType>` instead of `Vec<Type>`, to preserve argument names.
@@ -12,7 +14,12 @@
   + Makes the warning message for the special opt subtyping rule more explicit in the `candid::types::subtype::subtype` and `candid::types::subtype::subtype_with_config` functions.
   + Added `pp_named_args`, `pp_named_init_args` and `pp_label_raw` in `pretty::candid` module.
 
-### candid_parser
+### candid_derive 0.11.0
+
+* Keeps argument names for Rust functions.
+* Starting from this release, `candid` and `candid_derive` are kept in sync with the same version.
+
+### candid_parser 0.2.1
 
 * Breaking changes:
   + The `candid_parser::types` module has been renamed to `candid_parser::syntax`.
@@ -88,11 +95,7 @@
     - `candid::pretty::candid::DocComments` struct, which is used to collect doc comments from Rust canister methods, in the `candid_derive::export_service` macro.
     - `candid::pretty::candid::compile_with_docs` function, which takes a `&DocComments` parameter.
 
-### candid_derive
-
-* Keeps argument names for Rust functions.
-
-### didc
+### didc 0.5.0
 
 * Breaking changes:
   + The `didc test` subcommand has been removed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
  "anyhow",
  "binread",
  "byteorder",
- "candid_derive 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "candid_derive 0.6.6",
  "hex",
  "ic_principal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128",
@@ -209,14 +209,14 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.14"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bincode",
  "binread",
  "byteorder",
- "candid_derive 0.6.6",
- "candid_parser 0.2.0-beta.4",
+ "candid_derive 0.11.0",
+ "candid_parser 0.2.1",
  "hex",
  "ic_principal 0.1.1",
  "leb128",
@@ -236,6 +236,8 @@ dependencies = [
 [[package]]
 name = "candid_derive"
 version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3de398570c386726e7a59d9887b68763c481477f9a043fb998a2e09d428df1a9"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.86",
@@ -245,9 +247,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de398570c386726e7a59d9887b68763c481477f9a043fb998a2e09d428df1a9"
+version = "0.11.0"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.86",
@@ -276,11 +276,11 @@ dependencies = [
 
 [[package]]
 name = "candid_parser"
-version = "0.2.0-beta.4"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arbitrary",
- "candid 0.10.14",
+ "candid 0.11.0",
  "codespan-reporting",
  "console",
  "convert_case",
@@ -479,10 +479,10 @@ dependencies = [
 
 [[package]]
 name = "didc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
- "candid_parser 0.2.0-beta.4",
+ "candid_parser 0.2.1",
  "clap",
  "console",
  "hex",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.10.14"
+version = "0.11.0"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]
@@ -15,7 +15,8 @@ keywords = ["internet-computer", "idl", "candid", "dfinity"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-candid_derive = { path = "../candid_derive", version = "=0.6.6" }
+# `candid` and `candid_derive` are kept in sync with the same version.
+candid_derive = { path = "../candid_derive", version = "=0.11.0" }
 ic_principal = { path = "../ic_principal", version = "0.1.0" }
 binread = { version = "2.2", features = ["debug_template"] }
 byteorder = "1.5.0"

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid_derive"
-version = "0.6.6"
+version = "0.11.0" # Sync with `candid` version
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid_parser"
-version = "0.2.0-beta.4"
+version = "0.2.1"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]
@@ -19,7 +19,7 @@ build = "build.rs"
 lalrpop = "0.20.0"
 
 [dependencies]
-candid = { path = "../candid", version = "0.10", features = ["all"] }
+candid = { path = "../candid", version = "0.11.0", features = ["all"] }
 codespan-reporting = "0.11"
 hex.workspace = true
 num-bigint.workspace = true

--- a/tools/didc/Cargo.toml
+++ b/tools/didc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didc"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["DFINITY Team"]
 edition = "2021"
 


### PR DESCRIPTION
Follow up of #653, #655 and #565.

- `candid`: 0.10.14 -> 0.11.0
- `candid_derive`: 0.6.6 -> 0.11.0
- `candid_parser`: 0.1.4 -> 0.2.1
- `didc`: 0.4.0 -> 0.5.0