### PR TITLE
build: update crates versions to fix rust/bench builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.12"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "bincode",
@@ -288,7 +288,7 @@ version = "0.2.0-beta.4"
 dependencies = [
  "anyhow",
  "arbitrary",
- "candid 0.10.12",
+ "candid 0.10.14",
  "codespan-reporting",
  "console",
  "convert_case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,12 @@ anyhow = "1.0"
 rand = "0.8"
 arbitrary = "1.3"
 console = "0.15"
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = 0 }
+uninlined_format_args = { level = "allow", priority = 1 }
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(wasm_bindgen_unstable_test_coverage)',
+] }

--- a/rust/bench/Cargo.lock
+++ b/rust/bench/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +159,8 @@ dependencies = [
  "binread",
  "byteorder",
  "candid_derive",
+ "foldhash",
+ "hashbrown 0.15.4",
  "hex",
  "ic_principal",
  "leb128",
@@ -398,6 +406,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +453,17 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hex"
@@ -511,7 +536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid"
-version = "0.10.12"
+version = "0.10.14"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]
@@ -69,3 +69,6 @@ required-features = ["bignum"]
 features = ["all"]
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -24,3 +24,6 @@ quote = "1.0.7"
 syn = { version = "2.0", features = ["visit", "full"] }
 proc-macro2 = "1.0.19"
 lazy_static = "1.4.0"
+
+[lints]
+workspace = true

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -38,7 +38,10 @@ arbitrary = { workspace = true, optional = true }
 fake = { version = "2.4", optional = true }
 rand = { version = "0.8", optional = true }
 num-traits = { workspace = true, optional = true }
-dialoguer = { version = "0.11", default-features = false, features = ["editor", "completion"], optional = true }
+dialoguer = { version = "0.11", default-features = false, features = [
+    "editor",
+    "completion",
+], optional = true }
 ctrlc = { version = "3.4", optional = true }
 console = { workspace = true, optional = true }
 
@@ -58,3 +61,6 @@ all = ["random", "assist"]
 features = ["all"]
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/rust/ic_principal/Cargo.toml
+++ b/rust/ic_principal/Cargo.toml
@@ -35,3 +35,6 @@ arbitrary = ['dep:arbitrary', 'serde']
 convert = ['dep:crc32fast', 'dep:data-encoding', 'dep:thiserror']
 self_authenticating = ['dep:sha2']
 serde = ['dep:serde', 'convert']
+
+[lints]
+workspace = true


### PR DESCRIPTION
**Overview**
Pick changes to `Cargo.toml` files from #661 to make rust/bench crate build properly.

**Considerations**
Bench and lint will be fixed in #661.
