### PR TITLE
chore: Release 2025-07-29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Unreleased
 
-### Candid
+## 2025-07-29
+
+### Candid 0.10.16
 
 * Non-breaking changes:
   + Makes the warning message for the special opt subtyping rule more explicit in the `candid::types::subtype::subtype` and `candid::types::subtype::subtype_with_config` functions.
   + Added `pp_label_raw` in `pretty::candid` module.
 
-### candid_parser
+### candid_parser 0.2.0
 
 * Breaking changes:
   + The `candid_parser::types` module has been renamed to `candid_parser::syntax`.
@@ -82,11 +84,12 @@
     - `candid::pretty::candid::DocComments` struct, which is used to collect doc comments from Rust canister methods, in the `candid_derive::export_service` macro.
     - `candid::pretty::candid::compile_with_docs` function, which takes a `&DocComments` parameter.
 
-### candid_derive
+### candid_derive 0.10.16
 
+* Starting this release, candid_derive is versioned in lockstep with candid.
 * Keeps argument names for Rust functions.
 
-### didc
+### didc 0.5.0
 
 * Breaking changes:
   + The `didc test` subcommand has been removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   + Makes the warning message for the special opt subtyping rule more explicit in the `candid::types::subtype::subtype` and `candid::types::subtype::subtype_with_config` functions.
   + Added `pp_label_raw` in `pretty::candid` module.
 
-### candid_parser 0.2.0
+### candid_parser 0.2.1
 
 * Breaking changes:
   + The `candid_parser::types` module has been renamed to `candid_parser::syntax`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
  "binread",
  "byteorder",
  "candid_derive 0.10.16",
- "candid_parser 0.2.0-beta.4",
+ "candid_parser 0.2.1",
  "hex",
  "ic_principal 0.1.1",
  "leb128",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "candid_parser"
-version = "0.2.0-beta.4"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -482,7 +482,7 @@ name = "didc"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "candid_parser 0.2.0-beta.4",
+ "candid_parser 0.2.1",
  "clap",
  "console",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
  "anyhow",
  "binread",
  "byteorder",
- "candid_derive 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "candid_derive 0.6.6",
  "hex",
  "ic_principal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128",
@@ -209,13 +209,13 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.14"
+version = "0.10.16"
 dependencies = [
  "anyhow",
  "bincode",
  "binread",
  "byteorder",
- "candid_derive 0.6.6",
+ "candid_derive 0.10.16",
  "candid_parser 0.2.0-beta.4",
  "hex",
  "ic_principal 0.1.1",
@@ -236,6 +236,8 @@ dependencies = [
 [[package]]
 name = "candid_derive"
 version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3de398570c386726e7a59d9887b68763c481477f9a043fb998a2e09d428df1a9"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.86",
@@ -245,9 +247,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de398570c386726e7a59d9887b68763c481477f9a043fb998a2e09d428df1a9"
+version = "0.10.16"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.86",
@@ -280,7 +280,7 @@ version = "0.2.0-beta.4"
 dependencies = [
  "anyhow",
  "arbitrary",
- "candid 0.10.14",
+ "candid 0.10.16",
  "codespan-reporting",
  "console",
  "convert_case",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "didc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "candid_parser 0.2.0-beta.4",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "candid"
-version = "0.10.14"
+# sync with the version in `candid_derive/Cargo.toml`
+version = "0.10.16"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]
@@ -15,7 +16,7 @@ keywords = ["internet-computer", "idl", "candid", "dfinity"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-candid_derive = { path = "../candid_derive", version = "=0.6.6" }
+candid_derive = { path = "../candid_derive", version = "=0.10.16" }
 ic_principal = { path = "../ic_principal", version = "0.1.0" }
 binread = { version = "2.2", features = ["debug_template"] }
 byteorder = "1.5.0"

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "candid_derive"
-version = "0.6.6"
+# sync with the version in `candid/Cargo.toml`
+version = "0.10.16"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid_parser"
-version = "0.2.0-beta.4"
+version = "0.2.1"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]
@@ -38,10 +38,7 @@ arbitrary = { workspace = true, optional = true }
 fake = { version = "2.4", optional = true }
 rand = { version = "0.8", optional = true }
 num-traits = { workspace = true, optional = true }
-dialoguer = { version = "0.11", default-features = false, features = [
-    "editor",
-    "completion",
-], optional = true }
+dialoguer = { version = "0.11", default-features = false, features = ["editor", "completion"], optional = true }
 ctrlc = { version = "3.4", optional = true }
 console = { workspace = true, optional = true }
 

--- a/tools/didc/Cargo.toml
+++ b/tools/didc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didc"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["DFINITY Team"]
 edition = "2021"
 


### PR DESCRIPTION
candid: 0.10.14 -> 0.10.16
candid_derive: 0.6.6 -> 0.10.16
candid_parser: 0.1.4 -> 0.2.1
didc: 0.4.0 -> 0.5.0