### PR TITLE
refactor: pretty printing combinator for lists/tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+
+### Candid
+
+* Breaking changes:
+  + Removed the `candid::pretty::concat` function
+  + `candid::pretty::enclose` and `candid::pretty:enclose_space` don't collapse the separators on empty documents anymore
+
 ## 2025-07-29
 
 ### Candid 0.10.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 
 * Non-breaking changes:
   + Supports parsing the arguments' names for `func` and `service` (init args).
->>>>>>> origin/next
 
 ## 2025-08-04
 
@@ -413,7 +412,7 @@ The source code of this tool has been removed, as it was deprecated in [PR#405](
 * Bump ic-types to 0.3
 * `candid::utils::service_compatible` to check for upgrade compatibility of two service types
 
-## 2021-12-20 
+## 2021-12-20
 
 ### Rust (0.7.9)
 
@@ -439,7 +438,7 @@ The source code of this tool has been removed, as it was deprecated in [PR#405](
 
 ### Rust (0.7.5 -- 0.7.7)
 
-* Support import when parsing did files with `check_file` function 
+* Support import when parsing did files with `check_file` function
 * Fix TypeScript binding for reference types
 
 ### Candid UI
@@ -458,7 +457,7 @@ The source code of this tool has been removed, as it was deprecated in [PR#405](
 * Add `#[candid_path("path_to_candid")]` helper attribute to the candid derive macro
 * Update `ic-types` to 0.2.0
 
-## 2021-06-03 
+## 2021-06-03
 
 ### Spec
 
@@ -498,7 +497,7 @@ The source code of this tool has been removed, as it was deprecated in [PR#405](
 * Fix TypeScript binding for tuple
 * Rust support for Func and Service value
 
-## 2021-03-17 
+## 2021-03-17
 
 ### Rust (0.6.18)
 
@@ -649,7 +648,7 @@ The source code of this tool has been removed, as it was deprecated in [PR#405](
 
 * No longer requires the shortest LEB128 number in deserialization [#79](https://github.com/dfinity/candid/pull/79)
 
-### Rust 
+### Rust
 
 * Parser improvements:
   + Floats in fractional number, no e-notation yet

--- a/rust/candid/src/pretty/utils.rs
+++ b/rust/candid/src/pretty/utils.rs
@@ -1,45 +1,26 @@
-use pretty::RcDoc;
+use pretty::{RcAllocator, RcDoc};
 
 pub const INDENT_SPACE: isize = 2;
 pub const LINE_WIDTH: usize = 80;
 
-fn is_empty(doc: &RcDoc) -> bool {
-    use pretty::Doc::*;
-    match &**doc {
-        Nil => true,
-        FlatAlt(t1, t2) => is_empty(t2) || is_empty(t1),
-        Union(t1, t2) => is_empty(t1) && is_empty(t2),
-        Group(t) | Nest(_, t) | Annotated((), t) => is_empty(t),
-        _ => false,
-    }
-}
-
 pub fn enclose<'a>(left: &'a str, doc: RcDoc<'a>, right: &'a str) -> RcDoc<'a> {
-    if is_empty(&doc) {
-        RcDoc::text(left).append(right)
-    } else {
-        RcDoc::text(left)
-            .append(RcDoc::line_())
-            .append(doc)
-            .nest(INDENT_SPACE)
-            .append(RcDoc::line_())
-            .append(right)
-            .group()
-    }
+    RcDoc::text(left)
+        .append(RcDoc::line_())
+        .append(doc)
+        .nest(INDENT_SPACE)
+        .append(RcDoc::line_())
+        .append(right)
+        .group()
 }
 
 pub fn enclose_space<'a>(left: &'a str, doc: RcDoc<'a>, right: &'a str) -> RcDoc<'a> {
-    if is_empty(&doc) {
-        RcDoc::text(left).append(right)
-    } else {
-        RcDoc::text(left)
-            .append(RcDoc::line())
-            .append(doc)
-            .nest(INDENT_SPACE)
-            .append(RcDoc::line())
-            .append(right)
-            .group()
-    }
+    RcDoc::text(left)
+        .append(RcDoc::line())
+        .append(doc)
+        .nest(INDENT_SPACE)
+        .append(RcDoc::line())
+        .append(right)
+        .group()
 }
 
 /// Intersperse the separator between each item in `docs`.
@@ -48,16 +29,6 @@ where
     D: Iterator<Item = RcDoc<'a>>,
 {
     RcDoc::intersperse(docs, RcDoc::text(sep).append(RcDoc::line()))
-}
-
-/// Append the separator to each item in `docs`. If it is displayed in a single line, omit the last separator.
-pub fn concat<'a, D>(docs: D, sep: &'a str) -> RcDoc<'a>
-where
-    D: Iterator<Item = RcDoc<'a>>,
-{
-    let singleline = RcDoc::intersperse(docs, RcDoc::text(sep).append(RcDoc::line()));
-    let multiline = singleline.clone().append(sep);
-    multiline.flat_alt(singleline)
 }
 
 pub fn lines<'a, D>(docs: D) -> RcDoc<'a>
@@ -84,4 +55,122 @@ pub fn quote_ident(id: &str) -> RcDoc {
         .append(format!("{}", id.escape_debug()))
         .append("'")
         .append(RcDoc::space())
+}
+
+/// Separate each item in `docs` with the separator `sep`, and enclose the result in `open` and `close`.
+/// When placed on multiple lines, the last element gets a trailing separator.
+pub fn sep_enclose<'a, D, S, O, C>(docs: D, sep: S, open: O, close: C) -> RcDoc<'a>
+where
+    D: IntoIterator<Item = RcDoc<'a>>,
+    S: pretty::Pretty<'a, RcAllocator>,
+    O: pretty::Pretty<'a, RcAllocator>,
+    C: pretty::Pretty<'a, RcAllocator>,
+{
+    let sep = sep.pretty(&RcAllocator);
+    let elems = RcDoc::intersperse(docs, sep.clone().append(RcDoc::line()));
+    open.pretty(&RcAllocator)
+        .into_doc()
+        .append(RcDoc::line_())
+        .append(elems)
+        .append(sep.flat_alt(RcDoc::nil()))
+        .nest(INDENT_SPACE)
+        .append(RcDoc::line_())
+        .append(close.pretty(&RcAllocator))
+        .group()
+}
+
+/// Like `sep_enclose`, but inserts a space between the opening delimiter and the first element,
+/// and between the last element and the closing delimiter when placed on a single line.
+pub fn sep_enclose_space<'a, D, S, O, C>(docs: D, sep: S, open: O, close: C) -> RcDoc<'a>
+where
+    D: IntoIterator<Item = RcDoc<'a>>,
+    S: pretty::Pretty<'a, RcAllocator>,
+    O: pretty::Pretty<'a, RcAllocator>,
+    C: pretty::Pretty<'a, RcAllocator>,
+{
+    let mut docs = docs.into_iter().peekable();
+    if docs.peek().is_none() {
+        return open.pretty(&RcAllocator).append(close).into_doc();
+    }
+    let open = open
+        .pretty(&RcAllocator)
+        .append(RcDoc::nil().flat_alt(RcDoc::space()));
+    let close = RcDoc::nil().flat_alt(RcDoc::space()).append(close);
+    sep_enclose(docs, sep, open, close)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enclose_empty() {
+        let t = sep_enclose(vec![], ",", "(", ")")
+            .pretty(LINE_WIDTH)
+            .to_string();
+        assert_eq!(t, "()");
+    }
+
+    #[test]
+    fn enclose_single_line() {
+        let printed = sep_enclose(vec![str("a"), str("b")], ",", "(", ")")
+            .pretty(LINE_WIDTH)
+            .to_string();
+        assert_eq!(printed, "(a, b)");
+    }
+
+    #[test]
+    fn enclose_multiline() {
+        let docs: Vec<RcDoc> = vec![
+            str("Very long line to make sure we get a multiline document"),
+            str("Very long line to make sure we get a multiline document"),
+        ];
+        let printed = sep_enclose(docs, ",", "(", ")").pretty(20).to_string();
+        assert_eq!(
+            printed,
+            "
+(
+  Very long line to make sure we get a multiline document,
+  Very long line to make sure we get a multiline document,
+)
+"
+            .trim()
+        );
+    }
+
+    #[test]
+    fn enclose_empty_space() {
+        let t = sep_enclose_space(vec![], ",", "(", ")")
+            .pretty(LINE_WIDTH)
+            .to_string();
+        assert_eq!(t, "()");
+    }
+
+    #[test]
+    fn enclose_single_line_space() {
+        let printed = sep_enclose_space(vec![str("a"), str("b")], ",", "(", ")")
+            .pretty(LINE_WIDTH)
+            .to_string();
+        assert_eq!(printed, "( a, b )");
+    }
+
+    #[test]
+    fn enclose_multiline_space() {
+        let docs: Vec<RcDoc> = vec![
+            str("Very long line to make sure we get a multiline document"),
+            str("Very long line to make sure we get a multiline document"),
+        ];
+        let printed = sep_enclose_space(docs, ",", "(", ")")
+            .pretty(20)
+            .to_string();
+        assert_eq!(
+            printed,
+            "
+(
+  Very long line to make sure we get a multiline document,
+  Very long line to make sure we get a multiline document,
+)"
+            .trim()
+        );
+    }
 }

--- a/rust/candid_parser/src/bindings/javascript.rs
+++ b/rust/candid_parser/src/bindings/javascript.rs
@@ -175,7 +175,7 @@ fn pp_rets(args: &[Type]) -> RcDoc<'_> {
     sep_enclose(args.iter().map(pp_ty), ",", "[", "]")
 }
 
-fn pp_modes(modes: &[candid::types::FuncMode]) -> RcDoc {
+fn pp_modes(modes: &[candid::types::FuncMode]) -> RcDoc<'_> {
     let ms = modes
         .iter()
         .map(|m| str("'").append(pp_mode(m)).append("'"));

--- a/rust/candid_parser/src/bindings/motoko.rs
+++ b/rust/candid_parser/src/bindings/motoko.rs
@@ -194,10 +194,7 @@ fn pp_args(args: &[Type]) -> RcDoc {
                 pp_ty(ty)
             }
         }
-        _ => {
-            let doc = concat(args.iter().map(pp_ty), ",");
-            enclose("(", doc, ")")
-        }
+        _ => sep_enclose(args.iter().map(pp_ty), ",", "(", ")"),
     }
 }
 
@@ -219,12 +216,11 @@ fn pp_service<'a>(serv: &'a [(String, Type)], syntax: Option<&'a [syntax::Bindin
             .append(" : ")
             .append(pp_ty_rich(func, syntax_field_ty))
     });
-    kwd("actor").append(enclose_space("{", concat(methods, ";"), "}"))
+    kwd("actor").append(sep_enclose_space(methods, ";", "{", "}"))
 }
 
 fn pp_tuple<'a>(fields: &'a [Field]) -> RcDoc<'a> {
-    let tuple = concat(fields.iter().map(|f| pp_ty(&f.ty)), ",");
-    enclose("(", tuple, ")")
+    sep_enclose(fields.iter().map(|f| pp_ty(&f.ty)), ",", "(", ")")
 }
 
 fn pp_vec<'a>(inner: &'a Type, syntax: Option<&'a IDLType>) -> RcDoc<'a> {
@@ -260,7 +256,7 @@ fn pp_record<'a>(fields: &'a [Field], syntax: Option<&'a [syntax::TypeField]>) -
             .append(" : ")
             .append(pp_ty_rich(&field.ty, syntax_field))
     });
-    enclose_space("{", concat(fields, ";"), "}")
+    sep_enclose_space(fields, ";", "{", "}")
 }
 
 fn pp_variant<'a>(fields: &'a [Field], syntax: Option<&'a [syntax::TypeField]>) -> RcDoc<'a> {
@@ -277,7 +273,7 @@ fn pp_variant<'a>(fields: &'a [Field], syntax: Option<&'a [syntax::TypeField]>) 
             doc
         }
     });
-    enclose_space("{", concat(fields, ";"), "}")
+    sep_enclose_space(fields, ";", "{", "}")
 }
 
 fn pp_class<'a>((args, ty): (&'a [Type], &'a Type), syntax: Option<&'a IDLType>) -> RcDoc<'a> {

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -427,8 +427,7 @@ fn test_{test_name}() {{
                     docs.append(self.pp_record_field(f, need_vis, is_ref))
                 })
                 .collect();
-            let fields = concat(fields.into_iter(), ",");
-            enclose_space("{", fields, "}")
+            sep_enclose_space(fields, ",", "{", "}")
         };
         if let Some(old) = old {
             self.state.pop_state(old, StateElem::TypeStr("record"));
@@ -491,7 +490,7 @@ fn test_{test_name}() {{
             let (docs, syntax_field) = find_field(syntax, &f.id);
             docs.append(self.pp_variant_field(f, syntax_field))
         });
-        let res = enclose_space("{", concat(fields, ","), "}");
+        let res = sep_enclose_space(fields, ",", "{", "}");
         self.state.pop_state(old, StateElem::TypeStr("variant"));
         res
     }
@@ -609,7 +608,7 @@ fn test_{test_name}() {{
             self.state.pop_state(old, StateElem::Label(&lab));
             res
         });
-        enclose("(", concat(tys.into_iter(), ","), ")")
+        sep_enclose(tys, ",", "(", ")")
     }
     fn pp_rets<'b>(&mut self, rets: &'b [Type]) -> RcDoc<'b> {
         self.pp_args(rets, "ret")
@@ -643,7 +642,7 @@ fn test_{test_name}() {{
                 .append(kwd("\" :"))
                 .append(func_doc)
         });
-        let res = enclose_space("{", concat(methods, ";"), "}");
+        let res = sep_enclose_space(methods, ";", "{", "}");
         self.state.pop_state(old, lab);
         res
     }

--- a/rust/candid_parser/src/bindings/typescript.rs
+++ b/rust/candid_parser/src/bindings/typescript.rs
@@ -161,17 +161,14 @@ fn pp_record<'a>(
     is_ref: bool,
 ) -> RcDoc<'a> {
     if is_tuple_fields(fields) {
-        let tuple = concat(fields.iter().map(|f| pp_ty(env, &f.ty, is_ref)), ",");
-        enclose("[", tuple, "]")
+        let fs = fields.iter().map(|f| pp_ty(env, &f.ty, is_ref));
+        sep_enclose(fs, ",", "[", "]")
     } else {
-        let fields = concat(
-            fields.iter().map(|f| {
-                let (docs, syntax_field) = find_field(syntax, &f.id);
-                docs.append(pp_field(env, f, syntax_field, is_ref))
-            }),
-            ",",
-        );
-        enclose_space("{", fields, "}")
+        let fields = fields.iter().map(|f| {
+            let (docs, syntax_field) = find_field(syntax, &f.id);
+            docs.append(pp_field(env, f, syntax_field, is_ref))
+        });
+        sep_enclose_space(fields, ",", "{", "}")
     }
 }
 
@@ -207,13 +204,14 @@ fn pp_opt<'a>(
 
 fn pp_function<'a>(env: &'a TypeEnv, func: &'a Function) -> RcDoc<'a> {
     let args = func.args.iter().map(|arg| pp_ty(env, arg, true));
-    let args = enclose("[", concat(args, ","), "]");
+    let args = sep_enclose(args, ",", "[", "]");
     let rets = match func.rets.len() {
         0 => str("undefined"),
         1 => pp_ty(env, &func.rets[0], true),
-        _ => enclose(
+        _ => sep_enclose(
+            func.rets.iter().map(|ty| pp_ty(env, ty, true)),
+            ",",
             "[",
-            concat(func.rets.iter().map(|ty| pp_ty(env, ty, true)), ","),
             "]",
         ),
     };
@@ -243,7 +241,7 @@ fn pp_service<'a>(
         };
         docs.append(quote_ident(id)).append(kwd(":")).append(func)
     });
-    enclose_space("{", concat(methods, ","), "}")
+    sep_enclose_space(methods, ",", "{", "}")
 }
 
 fn pp_docs<'a>(docs: &'a [String]) -> RcDoc<'a> {

--- a/rust/candid_parser/src/syntax/pretty.rs
+++ b/rust/candid_parser/src/syntax/pretty.rs
@@ -3,7 +3,7 @@ use pretty::RcDoc;
 use crate::{
     pretty::{
         candid::{pp_docs, pp_label_raw, pp_modes, pp_text},
-        utils::{concat, enclose, enclose_space, ident, kwd, lines, str, INDENT_SPACE, LINE_WIDTH},
+        utils::{ident, kwd, lines, sep_enclose, sep_enclose_space, str, INDENT_SPACE, LINE_WIDTH},
     },
     syntax::{Binding, FuncType, IDLActorType, IDLMergedProg, IDLType, PrimType, TypeField},
 };
@@ -52,7 +52,7 @@ fn pp_field(field: &TypeField, is_variant: bool) -> RcDoc {
 
 fn pp_fields(fs: &[TypeField], is_variant: bool) -> RcDoc {
     let fields = fs.iter().map(|f| pp_field(f, is_variant));
-    enclose_space("{", concat(fields, ";"), "}")
+    sep_enclose_space(fields, ";", "{", "}")
 }
 
 fn pp_opt(ty: &IDLType) -> RcDoc {
@@ -69,8 +69,8 @@ fn pp_vec(ty: &IDLType) -> RcDoc {
 
 fn pp_record(fs: &[TypeField], is_tuple: bool) -> RcDoc {
     if is_tuple {
-        let tuple = concat(fs.iter().map(|f| pp_ty(&f.typ)), ";");
-        kwd("record").append(enclose_space("{", tuple, "}"))
+        let fs = fs.iter().map(|f| pp_ty(&f.typ));
+        kwd("record").append(sep_enclose_space(fs, ";", "{", "}"))
     } else {
         kwd("record").append(pp_fields(fs, false))
     }
@@ -95,8 +95,7 @@ fn pp_method(func: &FuncType) -> RcDoc {
 }
 
 fn pp_args(args: &[IDLType]) -> RcDoc {
-    let doc = concat(args.iter().map(pp_ty), ",");
-    enclose("(", doc, ")")
+    sep_enclose(args.iter().map(pp_ty), ",", "(", ")")
 }
 
 fn pp_rets(rets: &[IDLType]) -> RcDoc {
@@ -119,8 +118,7 @@ fn pp_service_methods(methods: &[Binding]) -> RcDoc {
             .append(kwd(" :"))
             .append(func_doc)
     });
-    let doc = concat(methods, ";");
-    enclose_space("{", doc, "}")
+    sep_enclose_space(methods, ";", "{", "}")
 }
 
 fn pp_class<'a>(args: &'a [IDLType], t: &'a IDLType) -> RcDoc<'a> {

--- a/rust/candid_parser/tests/assets/ok/class.rs
+++ b/rust/candid_parser/tests/assets/ok/class.rs
@@ -4,7 +4,7 @@
 use candid::{self, CandidType, Deserialize, Principal};
 
 #[derive(CandidType, Deserialize)]
-pub struct List(pub Option<(candid::Int,Box<List>,)>);
+pub struct List(pub Option<(candid::Int, Box<List>)>);
 #[derive(CandidType, Deserialize)]
 pub struct Profile { pub age: u8, pub name: String }
 

--- a/rust/candid_parser/tests/assets/ok/empty.rs
+++ b/rust/candid_parser/tests/assets/ok/empty.rs
@@ -9,7 +9,7 @@ pub struct FArg {}
 #[derive(CandidType, Deserialize)]
 pub enum FRet {}
 #[derive(CandidType, Deserialize)]
-pub struct T (pub Box<T>,);
+pub struct T (pub Box<T>);
 #[derive(CandidType, Deserialize)]
 pub enum GRet { #[serde(rename="a")] A(Box<T>) }
 #[derive(CandidType, Deserialize)]
@@ -23,7 +23,7 @@ impl Service {
   pub async fn g(&self, arg0: &T) -> Result<(GRet,)> {
     ic_cdk::call(self.0, "g", (arg0,)).await
   }
-  pub async fn h(&self, arg0: &(T,candid::Empty,)) -> Result<(HRet,)> {
+  pub async fn h(&self, arg0: &(T, candid::Empty)) -> Result<(HRet,)> {
     ic_cdk::call(self.0, "h", (arg0,)).await
   }
 }

--- a/rust/candid_parser/tests/assets/ok/example.rs
+++ b/rust/candid_parser/tests/assets/ok/example.rs
@@ -44,7 +44,7 @@ pub(crate) struct Nested {
   pub(crate) _0_: u128,
   pub(crate) _1_: u128,
   /// Doc comment for nested record
-  pub(crate) _2_: (u128,candid::Int,),
+  pub(crate) _2_: (u128, candid::Int),
   pub(crate) _3_: Nested3,
   pub(crate) _40_: u128,
   pub(crate) _41_: Nested41,
@@ -60,7 +60,7 @@ candid::define_service!(pub(crate) Broker : {
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) struct NestedResErrOk { pub(crate) content: String }
 pub(crate) type NestedRes = std::result::Result<
-  my::Result<(), ()>, another::Result<NestedResErrOk, (candid::Int,)>
+  my::Result<(), ()>, another::Result<NestedResErrOk, (candid::Int)>
 >;
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) enum HArg1 { A(u128), B(Option<String>) }
@@ -76,13 +76,13 @@ pub(crate) struct ResErr {
   pub(crate) error: String,
 }
 /// Doc comment for res type
-pub(crate) type Res = std::result::Result<(candid::Int,u128,), ResErr>;
+pub(crate) type Res = std::result::Result<(candid::Int, u128), ResErr>;
 candid::define_function!(pub(crate) F : (MyList, FArg1) -> (
     Option<MyList>,
     Res,
   ));
 #[derive(CandidType, Deserialize, Debug)]
-pub(crate) struct B (pub(crate) candid::Int,pub(crate) u128,);
+pub(crate) struct B (pub(crate) candid::Int, pub(crate) u128);
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) enum A { #[serde(rename="a")] A, #[serde(rename="b")] B(B) }
 #[derive(CandidType, Deserialize, Debug)]
@@ -167,7 +167,7 @@ impl Service {
   pub async fn x(&self, arg0: &A, arg1: &B) -> Result<(Option<A>,Option<B>,std::result::Result<XRet2Ok, Error>,)> {
     ic_cdk::call(self.0, "x", (arg0,arg1,)).await
   }
-  pub async fn y(&self, arg0: &NestedRecords) -> Result<((NestedRecords,MyVariant,),)> {
+  pub async fn y(&self, arg0: &NestedRecords) -> Result<((NestedRecords, MyVariant),)> {
     ic_cdk::call(self.0, "y", (arg0,)).await
   }
   pub async fn f(&self, server: &S) -> Result<()> {

--- a/rust/candid_parser/tests/assets/ok/fieldnat.rs
+++ b/rust/candid_parser/tests/assets/ok/fieldnat.rs
@@ -17,7 +17,7 @@ pub struct BazArg {
 #[derive(CandidType, Deserialize)]
 pub struct BazRet {}
 #[derive(CandidType, Deserialize)]
-pub struct Tuple (pub String,pub String,);
+pub struct Tuple (pub String, pub String);
 #[derive(CandidType, Deserialize)]
 pub struct NonTuple { pub _1_: String, pub _2_: String }
 #[derive(CandidType, Deserialize)]
@@ -35,7 +35,7 @@ impl Service {
   pub async fn bar(&self, arg0: &BarArg) -> Result<(BarRet,)> {
     ic_cdk::call(self.0, "bar", (arg0,)).await
   }
-  pub async fn bas(&self, arg0: &(candid::Int,candid::Int,)) -> Result<((String,candid::Nat,),)> {
+  pub async fn bas(&self, arg0: &(candid::Int, candid::Int)) -> Result<((String, candid::Nat),)> {
     ic_cdk::call(self.0, "bas", (arg0,)).await
   }
   pub async fn baz(&self, arg0: &BazArg) -> Result<(BazRet,)> {
@@ -44,7 +44,7 @@ impl Service {
   pub async fn bba(&self, arg0: &Tuple) -> Result<(NonTuple,)> {
     ic_cdk::call(self.0, "bba", (arg0,)).await
   }
-  pub async fn bib(&self, arg0: &(candid::Int,)) -> Result<(BibRet,)> {
+  pub async fn bib(&self, arg0: &(candid::Int)) -> Result<(BibRet,)> {
     ic_cdk::call(self.0, "bib", (arg0,)).await
   }
   pub async fn foo(&self, arg0: &FooArg) -> Result<(FooRet,)> {

--- a/rust/candid_parser/tests/assets/ok/keyword.rs
+++ b/rust/candid_parser/tests/assets/ok/keyword.rs
@@ -51,7 +51,7 @@ impl Service {
   pub async fn field(&self, arg0: &FieldArg) -> Result<(FieldRet,)> {
     ic_cdk::call(self.0, "field", (arg0,)).await
   }
-  pub async fn fieldnat(&self, arg0: &FieldnatArg) -> Result<((candid::Int,),)> {
+  pub async fn fieldnat(&self, arg0: &FieldnatArg) -> Result<((candid::Int),)> {
     ic_cdk::call(self.0, "fieldnat", (arg0,)).await
   }
   pub async fn oneway(&self, arg0: &u8) -> Result<()> {
@@ -69,7 +69,7 @@ impl Service {
   pub async fn service(&self, server: &Return) -> Result<()> {
     ic_cdk::call(self.0, "service", (server,)).await
   }
-  pub async fn tuple(&self, arg0: &(candid::Int,serde_bytes::ByteBuf,String,)) -> Result<((candid::Int,u8,),)> {
+  pub async fn tuple(&self, arg0: &(candid::Int, serde_bytes::ByteBuf, String)) -> Result<((candid::Int, u8),)> {
     ic_cdk::call(self.0, "tuple", (arg0,)).await
   }
   pub async fn variant(&self, arg0: &VariantArg) -> Result<()> {

--- a/rust/candid_parser/tests/assets/ok/service.rs
+++ b/rust/candid_parser/tests/assets/ok/service.rs
@@ -23,7 +23,7 @@ impl Service {
   pub async fn as_principal(&self) -> Result<(Service2,Func,)> {
     ic_cdk::call(self.0, "asPrincipal", ()).await
   }
-  pub async fn as_record(&self) -> Result<((Service2,Option<Service>,Func,),)> {
+  pub async fn as_record(&self) -> Result<((Service2, Option<Service>, Func),)> {
     ic_cdk::call(self.0, "asRecord", ()).await
   }
   pub async fn as_variant(&self) -> Result<(AsVariantRet,)> {


### PR DESCRIPTION
Gets rid of the dodgy `is_empty` function that performed full traversals of documents to tell if they were empty.

Fixes #667 
