### PR TITLE
fix: fixes pretty printing the concatenation of an empty list of documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Unreleased
 
 ### Candid
+
 * Non-breaking changes:
-  + Fixes a regression in pretty printing when concatenating an empty list of documents (#667)
+  + Fixes a regression in pretty printing when concatenating an empty list of documents
 
 ## 2025-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Candid
+* Non-breaking changes:
+  + Fixes a regression in pretty printing when concatenating an empty list of documents (#667)
+
 ## 2025-07-29
 
 ### Candid 0.10.16

--- a/rust/candid/src/pretty/utils.rs
+++ b/rust/candid/src/pretty/utils.rs
@@ -55,6 +55,10 @@ pub fn concat<'a, D>(docs: D, sep: &'a str) -> RcDoc<'a>
 where
     D: Iterator<Item = RcDoc<'a>>,
 {
+    let mut docs = docs.peekable();
+    if docs.peek().is_none() {
+        return RcDoc::nil();
+    }
     let singleline = RcDoc::intersperse(docs, RcDoc::text(sep).append(RcDoc::line()));
     let multiline = singleline.clone().append(sep);
     multiline.flat_alt(singleline)
@@ -84,4 +88,17 @@ pub fn quote_ident(id: &str) -> RcDoc {
         .append(format!("{}", id.escape_debug()))
         .append("'")
         .append(RcDoc::space())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn concat_empty() {
+        let t = concat(vec![].into_iter(), ",")
+            .pretty(LINE_WIDTH)
+            .to_string();
+        assert_eq!(t, "");
+    }
 }


### PR DESCRIPTION
Fixes #667

Alternative to #668, that doesn't constitute a breaking change