### PR TITLE
chore: fixes new clippy lints

### DIFF
--- a/rust/candid/src/pretty/candid.rs
+++ b/rust/candid/src/pretty/candid.rs
@@ -71,15 +71,15 @@ fn ident_string(id: &str) -> String {
     }
 }
 
-pub fn pp_text(id: &str) -> RcDoc {
+pub fn pp_text(id: &str) -> RcDoc<'_> {
     RcDoc::text(ident_string(id))
 }
 
-pub fn pp_ty(ty: &Type) -> RcDoc {
+pub fn pp_ty(ty: &Type) -> RcDoc<'_> {
     pp_ty_inner(ty.as_ref())
 }
 
-pub fn pp_ty_inner(ty: &TypeInner) -> RcDoc {
+pub fn pp_ty_inner(ty: &TypeInner) -> RcDoc<'_> {
     use TypeInner::*;
     match ty {
         Null => str("null"),
@@ -130,18 +130,18 @@ pub fn pp_docs<'a>(docs: &'a [String]) -> RcDoc<'a> {
 /// This function is kept for backward compatibility.
 ///
 /// It is recommended to use [`pp_label_raw`] instead, which accepts a [`Label`].
-pub fn pp_label(id: &SharedLabel) -> RcDoc {
+pub fn pp_label(id: &SharedLabel) -> RcDoc<'_> {
     pp_label_raw(id.as_ref())
 }
 
-pub fn pp_label_raw(id: &Label) -> RcDoc {
+pub fn pp_label_raw(id: &Label) -> RcDoc<'_> {
     match id {
         Label::Named(id) => pp_text(id),
         Label::Id(_) | Label::Unnamed(_) => RcDoc::as_string(id),
     }
 }
 
-pub(crate) fn pp_field(field: &Field, is_variant: bool) -> RcDoc {
+pub(crate) fn pp_field(field: &Field, is_variant: bool) -> RcDoc<'_> {
     let ty_doc = if is_variant && *field.ty == TypeInner::Null {
         RcDoc::nil()
     } else {
@@ -150,12 +150,12 @@ pub(crate) fn pp_field(field: &Field, is_variant: bool) -> RcDoc {
     pp_label_raw(&field.id).append(ty_doc)
 }
 
-fn pp_fields(fs: &[Field], is_variant: bool) -> RcDoc {
+fn pp_fields(fs: &[Field], is_variant: bool) -> RcDoc<'_> {
     let fields = fs.iter().map(|f| pp_field(f, is_variant));
     enclose_space("{", concat(fields, ";"), "}")
 }
 
-pub fn pp_function(func: &Function) -> RcDoc {
+pub fn pp_function(func: &Function) -> RcDoc<'_> {
     let args = pp_named_args(&func.args);
     let rets = pp_rets(&func.rets);
     let modes = pp_modes(&func.modes);
@@ -168,7 +168,7 @@ pub fn pp_function(func: &Function) -> RcDoc {
 /// Pretty-prints named arguments in the form of `(name1 : type1, name2 : type2)`.
 ///
 /// To print unnamed arguments, use [`pp_args`] instead.
-pub fn pp_named_args(args: &[ArgType]) -> RcDoc {
+pub fn pp_named_args(args: &[ArgType]) -> RcDoc<'_> {
     let args = args.iter().map(|arg| {
         if let Some(name) = &arg.name {
             pp_text(name).append(kwd(" :")).append(pp_ty(&arg.typ))
@@ -183,24 +183,24 @@ pub fn pp_named_args(args: &[ArgType]) -> RcDoc {
 /// Pretty-prints arguments in the form of `(type1, type2)`.
 ///
 /// To print named arguments, use [`pp_named_args`] instead.
-pub fn pp_args(args: &[Type]) -> RcDoc {
+pub fn pp_args(args: &[Type]) -> RcDoc<'_> {
     let doc = concat(args.iter().map(pp_ty), ",");
     enclose("(", doc, ")")
 }
 
 /// Pretty-prints return types in the form of `(type1, type2)`.
-pub fn pp_rets(args: &[Type]) -> RcDoc {
+pub fn pp_rets(args: &[Type]) -> RcDoc<'_> {
     pp_args(args)
 }
 
-pub fn pp_mode(mode: &FuncMode) -> RcDoc {
+pub fn pp_mode(mode: &FuncMode) -> RcDoc<'_> {
     match mode {
         FuncMode::Oneway => RcDoc::text("oneway"),
         FuncMode::Query => RcDoc::text("query"),
         FuncMode::CompositeQuery => RcDoc::text("composite_query"),
     }
 }
-pub fn pp_modes(modes: &[FuncMode]) -> RcDoc {
+pub fn pp_modes(modes: &[FuncMode]) -> RcDoc<'_> {
     RcDoc::concat(modes.iter().map(|m| RcDoc::space().append(pp_mode(m))))
 }
 
@@ -223,7 +223,7 @@ fn pp_service<'a>(serv: &'a [(String, Type)], docs: Option<&'a DocComments>) -> 
     enclose_space("{", doc, "}")
 }
 
-fn pp_defs(env: &TypeEnv) -> RcDoc {
+fn pp_defs(env: &TypeEnv) -> RcDoc<'_> {
     lines(env.to_sorted_iter().map(|(id, ty)| {
         kwd("type")
             .append(ident(id.as_str()))
@@ -523,7 +523,7 @@ pub mod value {
         }
     }
 
-    fn pp_field(depth: usize, field: &IDLField, is_variant: bool) -> RcDoc {
+    fn pp_field(depth: usize, field: &IDLField, is_variant: bool) -> RcDoc<'_> {
         let val_doc = if is_variant && field.val == IDLValue::Null {
             RcDoc::nil()
         } else {
@@ -532,7 +532,7 @@ pub mod value {
         pp_label_raw(&field.id).append(val_doc)
     }
 
-    fn pp_fields(depth: usize, fields: &[IDLField]) -> RcDoc {
+    fn pp_fields(depth: usize, fields: &[IDLField]) -> RcDoc<'_> {
         let fs = concat(fields.iter().map(|f| pp_field(depth, f, false)), ";");
         enclose_space("{", fs, "}")
     }
@@ -545,7 +545,7 @@ pub mod value {
             format!("\\{v:02x}")
         }
     }
-    pub fn pp_value(depth: usize, v: &IDLValue) -> RcDoc {
+    pub fn pp_value(depth: usize, v: &IDLValue) -> RcDoc<'_> {
         use IDLValue::*;
         if depth == 0 {
             return RcDoc::as_string(format!("{v:?}"));
@@ -579,7 +579,7 @@ pub mod value {
         }
     }
 
-    pub fn pp_args(args: &IDLArgs) -> RcDoc {
+    pub fn pp_args(args: &IDLArgs) -> RcDoc<'_> {
         let args = args
             .args
             .iter()

--- a/rust/candid/src/pretty/utils.rs
+++ b/rust/candid/src/pretty/utils.rs
@@ -71,19 +71,19 @@ where
     RcDoc::concat(docs.map(|doc| doc.append(RcDoc::hardline())))
 }
 
-pub fn kwd<U: std::fmt::Display + ?Sized>(str: &U) -> RcDoc {
+pub fn kwd<U: std::fmt::Display + ?Sized>(str: &U) -> RcDoc<'_> {
     RcDoc::as_string(str).append(RcDoc::space())
 }
 
-pub fn str(str: &str) -> RcDoc {
+pub fn str(str: &str) -> RcDoc<'_> {
     RcDoc::text(str)
 }
 
-pub fn ident(id: &str) -> RcDoc {
+pub fn ident(id: &str) -> RcDoc<'_> {
     kwd(id)
 }
 
-pub fn quote_ident(id: &str) -> RcDoc {
+pub fn quote_ident(id: &str) -> RcDoc<'_> {
     str("'")
         .append(format!("{}", id.escape_debug()))
         .append("'")

--- a/rust/candid_parser/src/bindings/javascript.rs
+++ b/rust/candid_parser/src/bindings/javascript.rs
@@ -91,7 +91,7 @@ static KEYWORDS: [&str; 64] = [
     "with",
     "yield",
 ];
-pub(crate) fn ident(id: &str) -> RcDoc {
+pub(crate) fn ident(id: &str) -> RcDoc<'_> {
     if KEYWORDS.contains(&id) {
         str(id).append("_")
     } else {
@@ -99,7 +99,7 @@ pub(crate) fn ident(id: &str) -> RcDoc {
     }
 }
 
-fn pp_ty(ty: &Type) -> RcDoc {
+fn pp_ty(ty: &Type) -> RcDoc<'_> {
     use TypeInner::*;
     match ty.as_ref() {
         Null => str("IDL.Null"),
@@ -139,7 +139,7 @@ fn pp_ty(ty: &Type) -> RcDoc {
     }
 }
 
-fn pp_label(id: &SharedLabel) -> RcDoc {
+fn pp_label(id: &SharedLabel) -> RcDoc<'_> {
     match &**id {
         Label::Named(str) => quote_ident(str),
         Label::Id(n) | Label::Unnamed(n) => str("_")
@@ -149,18 +149,18 @@ fn pp_label(id: &SharedLabel) -> RcDoc {
     }
 }
 
-fn pp_field(field: &Field) -> RcDoc {
+fn pp_field(field: &Field) -> RcDoc<'_> {
     pp_label(&field.id)
         .append(kwd(":"))
         .append(pp_ty(&field.ty))
 }
 
-fn pp_fields(fs: &[Field]) -> RcDoc {
+fn pp_fields(fs: &[Field]) -> RcDoc<'_> {
     let fields = concat(fs.iter().map(pp_field), ",");
     enclose_space("({", fields, "})")
 }
 
-fn pp_function(func: &Function) -> RcDoc {
+fn pp_function(func: &Function) -> RcDoc<'_> {
     let args = pp_args(&func.args);
     let rets = pp_rets(&func.rets);
     let modes = pp_modes(&func.modes);
@@ -168,17 +168,17 @@ fn pp_function(func: &Function) -> RcDoc {
     enclose("(", doc, ")").nest(INDENT_SPACE)
 }
 
-fn pp_args(args: &[ArgType]) -> RcDoc {
+fn pp_args(args: &[ArgType]) -> RcDoc<'_> {
     let doc = concat(args.iter().map(|arg| pp_ty(&arg.typ)), ",");
     enclose("[", doc, "]")
 }
 
-fn pp_rets(args: &[Type]) -> RcDoc {
+fn pp_rets(args: &[Type]) -> RcDoc<'_> {
     let doc = concat(args.iter().map(pp_ty), ",");
     enclose("[", doc, "]")
 }
 
-fn pp_modes(modes: &[candid::types::FuncMode]) -> RcDoc {
+fn pp_modes(modes: &[candid::types::FuncMode]) -> RcDoc<'_> {
     let doc = concat(
         modes
             .iter()
@@ -188,7 +188,7 @@ fn pp_modes(modes: &[candid::types::FuncMode]) -> RcDoc {
     enclose("[", doc, "]")
 }
 
-fn pp_service(serv: &[(String, Type)]) -> RcDoc {
+fn pp_service(serv: &[(String, Type)]) -> RcDoc<'_> {
     let doc = concat(
         serv.iter()
             .map(|(id, func)| quote_ident(id).append(kwd(":")).append(pp_ty(func))),
@@ -298,7 +298,7 @@ pub mod value {
             _ => false,
         }
     }
-    fn pp_label(id: &Label) -> RcDoc {
+    fn pp_label(id: &Label) -> RcDoc<'_> {
         match id {
             Label::Named(str) => quote_ident(str),
             Label::Id(n) | Label::Unnamed(n) => str("_")
@@ -307,17 +307,17 @@ pub mod value {
                 .append(RcDoc::space()),
         }
     }
-    fn pp_field(field: &IDLField) -> RcDoc {
+    fn pp_field(field: &IDLField) -> RcDoc<'_> {
         pp_label(&field.id)
             .append(": ")
             .append(pp_value(&field.val))
     }
 
-    fn pp_fields(fields: &[IDLField]) -> RcDoc {
+    fn pp_fields(fields: &[IDLField]) -> RcDoc<'_> {
         concat(fields.iter().map(pp_field), ",")
     }
 
-    pub fn pp_value(v: &IDLValue) -> RcDoc {
+    pub fn pp_value(v: &IDLValue) -> RcDoc<'_> {
         use IDLValue::*;
         match v {
             Number(_) | Int(_) | Nat(_) | Int64(_) | Nat64(_) => {
@@ -362,7 +362,7 @@ pub mod value {
         }
     }
 
-    pub fn pp_args(args: &IDLArgs) -> RcDoc {
+    pub fn pp_args(args: &IDLArgs) -> RcDoc<'_> {
         let body = concat(args.args.iter().map(pp_value), ",");
         enclose("[", body, "]")
     }

--- a/rust/candid_parser/src/bindings/motoko.rs
+++ b/rust/candid_parser/src/bindings/motoko.rs
@@ -78,7 +78,7 @@ static KEYWORDS: [&str; 48] = [
     "while",
     "with",
 ];
-fn escape(id: &str, is_method: bool) -> RcDoc {
+fn escape(id: &str, is_method: bool) -> RcDoc<'_> {
     if KEYWORDS.contains(&id) {
         str(id).append("_")
     } else if is_valid_as_id(id) {
@@ -118,7 +118,7 @@ fn pp_ty_rich<'a>(ty: &'a Type, syntax: Option<&'a IDLType>) -> RcDoc<'a> {
     }
 }
 
-fn pp_ty(ty: &Type) -> RcDoc {
+fn pp_ty(ty: &Type) -> RcDoc<'_> {
     use TypeInner::*;
     match ty.as_ref() {
         Null => str("Null"),
@@ -151,7 +151,7 @@ fn pp_ty(ty: &Type) -> RcDoc {
     }
 }
 
-fn pp_label(id: &SharedLabel) -> RcDoc {
+fn pp_label(id: &SharedLabel) -> RcDoc<'_> {
     match &**id {
         Label::Named(str) => escape(str, false),
         Label::Id(n) | Label::Unnamed(n) => str("_")
@@ -161,7 +161,7 @@ fn pp_label(id: &SharedLabel) -> RcDoc {
     }
 }
 
-fn pp_function(func: &Function) -> RcDoc {
+fn pp_function(func: &Function) -> RcDoc<'_> {
     let args = pp_args(&func.args);
     let rets = pp_rets(&func.rets);
     match func.modes.as_slice() {
@@ -185,7 +185,7 @@ fn pp_function(func: &Function) -> RcDoc {
     }
     .nest(INDENT_SPACE)
 }
-fn pp_args(args: &[ArgType]) -> RcDoc {
+fn pp_args(args: &[ArgType]) -> RcDoc<'_> {
     match args {
         [ty] => {
             let typ = if is_tuple(&ty.typ) {
@@ -212,7 +212,7 @@ fn pp_args(args: &[ArgType]) -> RcDoc {
     }
 }
 
-fn pp_rets(args: &[Type]) -> RcDoc {
+fn pp_rets(args: &[Type]) -> RcDoc<'_> {
     match args {
         [ty] => {
             if is_tuple(ty) {

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -131,7 +131,7 @@ static KEYWORDS: [&str; 51] = [
     "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro",
     "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
 ];
-fn ident_(id: &str, case: Option<Case>) -> (RcDoc, bool) {
+fn ident_(id: &str, case: Option<Case>) -> (RcDoc<'_>, bool) {
     if id.is_empty()
         || id.starts_with(|c: char| !c.is_ascii_alphabetic() && c != '_')
         || id.chars().any(|c| !c.is_ascii_alphanumeric() && c != '_')
@@ -152,7 +152,7 @@ fn ident_(id: &str, case: Option<Case>) -> (RcDoc, bool) {
         (RcDoc::text(id), is_rename)
     }
 }
-fn ident(id: &str, case: Option<Case>) -> RcDoc {
+fn ident(id: &str, case: Option<Case>) -> RcDoc<'_> {
     ident_(id, case).0
 }
 fn pp_vis<'a>(vis: &Option<String>) -> RcDoc<'a> {
@@ -1032,7 +1032,7 @@ impl<'b> NominalState<'_, 'b> {
                     if let Some(syntax) = syntax {
                         self.generated_types.insert(new_var.clone(), syntax);
                     }
-                    TypeInner::Var(new_var.into())
+                    TypeInner::Var(new_var)
                 }
             }
             TypeInner::Variant(fs) => {
@@ -1078,7 +1078,7 @@ impl<'b> NominalState<'_, 'b> {
                     if let Some(syntax) = syntax {
                         self.generated_types.insert(new_var.clone(), syntax);
                     }
-                    TypeInner::Var(new_var.into())
+                    TypeInner::Var(new_var)
                 }
             }
             TypeInner::Func(func) => match path.last() {

--- a/rust/candid_parser/src/bindings/typescript.rs
+++ b/rust/candid_parser/src/bindings/typescript.rs
@@ -99,7 +99,7 @@ fn pp_inline_service<'a>() -> RcDoc<'a> {
     str("Principal")
 }
 
-fn pp_label(id: &SharedLabel) -> RcDoc {
+fn pp_label(id: &SharedLabel) -> RcDoc<'_> {
     match &**id {
         Label::Named(str) => quote_ident(str),
         Label::Id(n) | Label::Unnamed(n) => str("_")

--- a/rust/candid_parser/src/syntax/pretty.rs
+++ b/rust/candid_parser/src/syntax/pretty.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 
-fn pp_ty(ty: &IDLType) -> RcDoc {
+fn pp_ty(ty: &IDLType) -> RcDoc<'_> {
     use IDLType::*;
     match ty {
         PrimT(PrimType::Null) => str("null"),
@@ -42,7 +42,7 @@ fn pp_ty(ty: &IDLType) -> RcDoc {
     }
 }
 
-fn pp_field(field: &TypeField, is_variant: bool) -> RcDoc {
+fn pp_field(field: &TypeField, is_variant: bool) -> RcDoc<'_> {
     let docs = pp_docs(&field.docs);
     let ty_doc = if is_variant && field.typ == IDLType::PrimT(PrimType::Null) {
         RcDoc::nil()
@@ -52,16 +52,16 @@ fn pp_field(field: &TypeField, is_variant: bool) -> RcDoc {
     docs.append(pp_label_raw(&field.label)).append(ty_doc)
 }
 
-fn pp_fields(fs: &[TypeField], is_variant: bool) -> RcDoc {
+fn pp_fields(fs: &[TypeField], is_variant: bool) -> RcDoc<'_> {
     let fields = fs.iter().map(|f| pp_field(f, is_variant));
     enclose_space("{", concat(fields, ";"), "}")
 }
 
-fn pp_opt(ty: &IDLType) -> RcDoc {
+fn pp_opt(ty: &IDLType) -> RcDoc<'_> {
     kwd("opt").append(pp_ty(ty))
 }
 
-fn pp_vec(ty: &IDLType) -> RcDoc {
+fn pp_vec(ty: &IDLType) -> RcDoc<'_> {
     if matches!(ty, IDLType::PrimT(PrimType::Nat8)) {
         str("blob")
     } else {
@@ -69,7 +69,7 @@ fn pp_vec(ty: &IDLType) -> RcDoc {
     }
 }
 
-fn pp_record(fs: &[TypeField], is_tuple: bool) -> RcDoc {
+fn pp_record(fs: &[TypeField], is_tuple: bool) -> RcDoc<'_> {
     if is_tuple {
         let tuple = concat(fs.iter().map(|f| pp_ty(&f.typ)), ";");
         kwd("record").append(enclose_space("{", tuple, "}"))
@@ -78,15 +78,15 @@ fn pp_record(fs: &[TypeField], is_tuple: bool) -> RcDoc {
     }
 }
 
-fn pp_variant(fs: &[TypeField]) -> RcDoc {
+fn pp_variant(fs: &[TypeField]) -> RcDoc<'_> {
     kwd("variant").append(pp_fields(fs, true))
 }
 
-fn pp_function(func: &FuncType) -> RcDoc {
+fn pp_function(func: &FuncType) -> RcDoc<'_> {
     kwd("func").append(pp_method(func))
 }
 
-fn pp_method(func: &FuncType) -> RcDoc {
+fn pp_method(func: &FuncType) -> RcDoc<'_> {
     let args = pp_args(&func.args);
     let rets = pp_rets(&func.rets);
     let modes = pp_modes(&func.modes);
@@ -96,7 +96,7 @@ fn pp_method(func: &FuncType) -> RcDoc {
         .nest(INDENT_SPACE)
 }
 
-fn pp_args(args: &[IDLArgType]) -> RcDoc {
+fn pp_args(args: &[IDLArgType]) -> RcDoc<'_> {
     let args = args.iter().map(|arg| {
         if let Some(name) = &arg.name {
             pp_text(name).append(kwd(" :")).append(pp_ty(&arg.typ))
@@ -108,16 +108,16 @@ fn pp_args(args: &[IDLArgType]) -> RcDoc {
     enclose("(", doc, ")")
 }
 
-fn pp_rets(rets: &[IDLType]) -> RcDoc {
+fn pp_rets(rets: &[IDLType]) -> RcDoc<'_> {
     let doc = concat(rets.iter().map(pp_ty), ",");
     enclose("(", doc, ")")
 }
 
-fn pp_service(methods: &[Binding]) -> RcDoc {
+fn pp_service(methods: &[Binding]) -> RcDoc<'_> {
     kwd("service").append(pp_service_methods(methods))
 }
 
-fn pp_service_methods(methods: &[Binding]) -> RcDoc {
+fn pp_service_methods(methods: &[Binding]) -> RcDoc<'_> {
     let methods = methods.iter().map(|b| {
         let docs = pp_docs(&b.docs);
         let func_doc = match b.typ {
@@ -142,7 +142,7 @@ fn pp_class<'a>(args: &'a [IDLArgType], t: &'a IDLType) -> RcDoc<'a> {
     }
 }
 
-fn pp_defs(prog: &IDLMergedProg) -> RcDoc {
+fn pp_defs<'a>(prog: &'a IDLMergedProg) -> RcDoc<'a> {
     lines(prog.bindings().map(|b| {
         let docs = pp_docs(&b.docs);
         docs.append(kwd("type"))
@@ -153,7 +153,7 @@ fn pp_defs(prog: &IDLMergedProg) -> RcDoc {
     }))
 }
 
-fn pp_actor(actor: &IDLActorType) -> RcDoc {
+fn pp_actor<'a>(actor: &'a IDLActorType) -> RcDoc<'a> {
     let docs = pp_docs(&actor.docs);
     let service_doc = match actor.typ {
         IDLType::ServT(ref serv) => pp_service_methods(serv),

--- a/rust/candid_parser/src/syntax/pretty.rs
+++ b/rust/candid_parser/src/syntax/pretty.rs
@@ -142,7 +142,7 @@ fn pp_class<'a>(args: &'a [IDLArgType], t: &'a IDLType) -> RcDoc<'a> {
     }
 }
 
-fn pp_defs<'a>(prog: &'a IDLMergedProg) -> RcDoc<'a> {
+fn pp_defs(prog: &IDLMergedProg) -> RcDoc<'_> {
     lines(prog.bindings().map(|b| {
         let docs = pp_docs(&b.docs);
         docs.append(kwd("type"))
@@ -153,7 +153,7 @@ fn pp_defs<'a>(prog: &'a IDLMergedProg) -> RcDoc<'a> {
     }))
 }
 
-fn pp_actor<'a>(actor: &'a IDLActorType) -> RcDoc<'a> {
+fn pp_actor(actor: &IDLActorType) -> RcDoc<'_> {
     let docs = pp_docs(&actor.docs);
     let service_doc = match actor.typ {
         IDLType::ServT(ref serv) => pp_service_methods(serv),

--- a/rust/candid_parser/tests/value.rs
+++ b/rust/candid_parser/tests/value.rs
@@ -7,6 +7,7 @@ use candid::{
     Decode,
 };
 use candid_parser::{parse_idl_args, syntax::IDLProg, typing::check_prog};
+use std::slice;
 
 #[test]
 fn test_parser() {
@@ -130,7 +131,7 @@ fn test_variant() {
     ));
     let bytes = hex("4449444c016b02b3d3c9017fe6fdd5017f010000");
     test_decode(&bytes, &value);
-    let encoded = IDLArgs::new(&[value.clone()]).to_bytes().unwrap();
+    let encoded = IDLArgs::new(slice::from_ref(&value)).to_bytes().unwrap();
     test_decode(&encoded, &value);
 }
 
@@ -153,7 +154,7 @@ fn check(v: IDLValue, bytes: &str) {
 }
 
 fn test_encode(v: &IDLValue, expected: &[u8]) {
-    let args = IDLArgs::new(&[v.clone()]);
+    let args = IDLArgs::new(slice::from_ref(v));
     let encoded = args.to_bytes().unwrap();
     assert_eq!(
         encoded, expected,

--- a/tools/didc-js/wasm-package/src/core.rs
+++ b/tools/didc-js/wasm-package/src/core.rs
@@ -1,3 +1,5 @@
+use core::slice;
+
 use crate::{types::EncodeType, validation::Validate};
 use candid::{
     types::{Type, TypeInner},
@@ -63,7 +65,7 @@ pub fn encode(args: EncodeArgs) -> Result<String, LibraryError> {
                     })?;
 
             idl_args
-                .to_bytes_with_types(&idl.env, &[type_def.clone()])
+                .to_bytes_with_types(&idl.env, slice::from_ref(type_def))
                 .map_err(|e| LibraryError::IdlArgsToBytesFailed {
                     reason: format!("Could not encode input to bytes {}", e),
                 })?


### PR DESCRIPTION
Looks like a recent bump of the Rust version on CI introduced new Clippy lints that make CI fail on #668 

This PR fixes those lint errors on the `next` branch.