### PR TITLE
feat: cdk v0.18 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "pretty",
  "rand",
  "serde",
+ "serde_json",
  "test-generator",
  "thiserror",
  "toml",

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -32,6 +32,7 @@ lalrpop-util = "0.20.0"
 logos = "0.14"
 convert_case = "0.6"
 handlebars = "6.0"
+serde_json = "1.0.74"
 toml = { version = "0.8", default-features = false, features = ["parse"] }
 
 arbitrary = { workspace = true, optional = true }

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -719,6 +719,7 @@ fn test_{test_name}() {{
         let res = Method {
             name,
             original_name: id.to_string(),
+            args_len: args.len(),
             args: args
                 .into_iter()
                 .map(|(id, t)| (id, t.pretty(LINE_WIDTH).to_string()))
@@ -788,6 +789,7 @@ pub struct Output {
 pub struct Method {
     pub name: String,
     pub original_name: String,
+    pub args_len: usize,
     pub args: Vec<(String, String)>,
     pub rets: Vec<String>,
     pub mode: String,

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -9,6 +9,7 @@ use candid::types::{
 };
 use candid::{pretty::utils::*, types::ArgType};
 use convert_case::{Case, Casing};
+use handlebars::handlebars_helper;
 use pretty::RcDoc;
 use serde::Serialize;
 use std::borrow::Cow;
@@ -719,7 +720,6 @@ fn test_{test_name}() {{
         let res = Method {
             name,
             original_name: id.to_string(),
-            args_len: args.len(),
             args: args
                 .into_iter()
                 .map(|(id, t)| (id, t.pretty(LINE_WIDTH).to_string()))
@@ -789,7 +789,6 @@ pub struct Output {
 pub struct Method {
     pub name: String,
     pub original_name: String,
-    pub args_len: usize,
     pub args: Vec<(String, String)>,
     pub rets: Vec<String>,
     pub mode: String,
@@ -865,6 +864,7 @@ pub fn output_handlebar(output: Output, config: ExternalConfig, template: &str) 
         tests: output.tests,
         actor_docs: output.actor_docs,
     };
+    handlebars_helper!(len: |xs: Vec<serde_json::Value>| xs.len());
     hbs.render_template(template, &data).unwrap()
 }
 pub struct Config(ConfigTree<BindingConfig>);

--- a/rust/candid_parser/src/bindings/rust.rs
+++ b/rust/candid_parser/src/bindings/rust.rs
@@ -899,6 +899,7 @@ pub fn compile(
 ) -> (String, Vec<String>) {
     let source = match external.0.get("target").map(|s| s.as_str()) {
         Some("canister_call") | None => Cow::Borrowed(include_str!("rust_call.hbs")),
+        Some("canister_call_legacy") => Cow::Borrowed(include_str!("rust_call_legacy.hbs")),
         Some("agent") => Cow::Borrowed(include_str!("rust_agent.hbs")),
         Some("stub") => {
             let metadata = crate::utils::get_metadata(env, actor);

--- a/rust/candid_parser/src/bindings/rust_call.hbs
+++ b/rust/candid_parser/src/bindings/rust_call.hbs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use {{candid_crate}}::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 {{type_defs}}
 {{#if methods}}
@@ -16,7 +16,7 @@ impl {{PascalCase service_name}} {
   {{../../doc_comment_prefix}}{{this}}
   {{/each}}
   pub async fn {{this.name}}(&self{{#each this.args}}, {{this.0}}: &{{this.1}}{{/each}}) -> Result<({{#each this.rets}}{{this}},{{/each}})> {
-    ic_cdk::call(self.0, "{{escape_debug this.original_name}}", ({{#each this.args}}{{this.0}},{{/each}})).await
+    Ok(Call::bounded_wait(self.0, "{{escape_debug this.original_name}}").with_args(&({{#each this.args}}{{this.0}},{{/each}})).await?.candid()?)
   }
   {{/each}}
 }

--- a/rust/candid_parser/src/bindings/rust_call.hbs
+++ b/rust/candid_parser/src/bindings/rust_call.hbs
@@ -15,8 +15,8 @@ impl {{PascalCase service_name}} {
   {{#each this.docs}}
   {{../../doc_comment_prefix}}{{this}}
   {{/each}}
-  pub async fn {{this.name}}(&self{{#each this.args}}, {{this.0}}: &{{this.1}}{{/each}}) -> Result<({{#each this.rets}}{{this}},{{/each}})> {
-    Ok(Call::bounded_wait(self.0, "{{escape_debug this.original_name}}"){{#if (eq this.args_len 0)}}{{else}}{{#if (eq this.args_len 1)}}.with_arg({{this.args.0.0}}){{else}}.with_args(&({{#each this.args}}{{this.0}}{{#unless @last}}, {{/unless}}{{/each}})){{/if}}{{/if}}.await?.candid()?)
+  pub async fn {{this.name}}(&self{{#each this.args}}, {{this.0}}: &{{this.1}}{{/each}}) -> Result<{{#if (eq (len this.rets) 1)}}{{this.rets.0}}{{else}}({{#each this.rets}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}){{/if}}> {
+    Ok(Call::bounded_wait(self.0, "{{escape_debug this.original_name}}"){{#if (eq (len this.args) 0)}}{{else}}{{#if (eq (len this.args) 1)}}.with_arg({{this.args.0.0}}){{else}}.with_args(&({{#each this.args}}{{this.0}}{{#unless @last}}, {{/unless}}{{/each}})){{/if}}{{/if}}.await?.candid()?)
   }
   {{/each}}
 }

--- a/rust/candid_parser/src/bindings/rust_call.hbs
+++ b/rust/candid_parser/src/bindings/rust_call.hbs
@@ -16,7 +16,7 @@ impl {{PascalCase service_name}} {
   {{../../doc_comment_prefix}}{{this}}
   {{/each}}
   pub async fn {{this.name}}(&self{{#each this.args}}, {{this.0}}: &{{this.1}}{{/each}}) -> Result<({{#each this.rets}}{{this}},{{/each}})> {
-    Ok(Call::bounded_wait(self.0, "{{escape_debug this.original_name}}").with_args(&({{#each this.args}}{{this.0}},{{/each}})).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "{{escape_debug this.original_name}}"){{#if (eq this.args_len 0)}}{{else}}{{#if (eq this.args_len 1)}}.with_arg({{this.args.0.0}}){{else}}.with_args(&({{#each this.args}}{{this.0}}{{#unless @last}}, {{/unless}}{{/each}})){{/if}}{{/if}}.await?.candid()?)
   }
   {{/each}}
 }

--- a/rust/candid_parser/src/bindings/rust_call_legacy.hbs
+++ b/rust/candid_parser/src/bindings/rust_call_legacy.hbs
@@ -1,0 +1,31 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+#![allow(dead_code, unused_imports)]
+use {{candid_crate}}::{self, CandidType, Deserialize, Principal};
+use ic_cdk::api::call::CallResult as Result;
+
+{{type_defs}}
+{{#if methods}}
+{{#each actor_docs}}
+{{../doc_comment_prefix}}{{this}}
+{{/each}}
+pub struct {{PascalCase service_name}}(pub Principal);
+impl {{PascalCase service_name}} {
+  {{#each methods}}
+  {{#each this.docs}}
+  {{../../doc_comment_prefix}}{{this}}
+  {{/each}}
+  pub async fn {{this.name}}(&self{{#each this.args}}, {{this.0}}: &{{this.1}}{{/each}}) -> Result<({{#each this.rets}}{{this}},{{/each}})> {
+    ic_cdk::call(self.0, "{{escape_debug this.original_name}}", ({{#each this.args}}{{this.0}},{{/each}})).await
+  }
+  {{/each}}
+}
+{{#if canister_id}}
+{{doc_comment_prefix}}Canister ID: `{{canister_id}}`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[{{principal_slice canister_id}}]);
+pub const {{snake_case service_name}} : {{PascalCase service_name}} = {{PascalCase service_name}}(CANISTER_ID);
+{{/if}}
+{{/if}}
+{{#if tests}}
+{{tests}}
+{{/if}}

--- a/rust/candid_parser/tests/assets/ok/actor.rs
+++ b/rust/candid_parser/tests/assets/ok/actor.rs
@@ -13,19 +13,19 @@ pub struct O(pub Option<Box<O>>);
 pub struct Service(pub Principal);
 impl Service {
   pub async fn f(&self, arg0: &candid::Nat) -> Result<(H,)> {
-    Ok(Call::bounded_wait(self.0, "f").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "f").with_arg(arg0).await?.candid()?)
   }
   pub async fn g(&self, arg0: &i8) -> Result<(i8,)> {
-    Ok(Call::bounded_wait(self.0, "g").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "g").with_arg(arg0).await?.candid()?)
   }
   pub async fn h(&self, arg0: &i8) -> Result<(i8,)> {
-    Ok(Call::bounded_wait(self.0, "h").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "h").with_arg(arg0).await?.candid()?)
   }
   pub async fn h_2(&self, arg0: &F) -> Result<(F,)> {
-    Ok(Call::bounded_wait(self.0, "h2").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "h2").with_arg(arg0).await?.candid()?)
   }
   pub async fn o(&self, arg0: &O) -> Result<(O,)> {
-    Ok(Call::bounded_wait(self.0, "o").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "o").with_arg(arg0).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/actor.rs
+++ b/rust/candid_parser/tests/assets/ok/actor.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 candid::define_function!(pub F : (i8) -> (i8));
 candid::define_function!(pub H : (F) -> (F));
@@ -13,19 +13,19 @@ pub struct O(pub Option<Box<O>>);
 pub struct Service(pub Principal);
 impl Service {
   pub async fn f(&self, arg0: &candid::Nat) -> Result<(H,)> {
-    ic_cdk::call(self.0, "f", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "f").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn g(&self, arg0: &i8) -> Result<(i8,)> {
-    ic_cdk::call(self.0, "g", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "g").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn h(&self, arg0: &i8) -> Result<(i8,)> {
-    ic_cdk::call(self.0, "h", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "h").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn h_2(&self, arg0: &F) -> Result<(F,)> {
-    ic_cdk::call(self.0, "h2", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "h2").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn o(&self, arg0: &O) -> Result<(O,)> {
-    ic_cdk::call(self.0, "o", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "o").with_args(&(arg0,)).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/actor.rs
+++ b/rust/candid_parser/tests/assets/ok/actor.rs
@@ -12,19 +12,19 @@ pub struct O(pub Option<Box<O>>);
 
 pub struct Service(pub Principal);
 impl Service {
-  pub async fn f(&self, arg0: &candid::Nat) -> Result<(H,)> {
+  pub async fn f(&self, arg0: &candid::Nat) -> Result<H> {
     Ok(Call::bounded_wait(self.0, "f").with_arg(arg0).await?.candid()?)
   }
-  pub async fn g(&self, arg0: &i8) -> Result<(i8,)> {
+  pub async fn g(&self, arg0: &i8) -> Result<i8> {
     Ok(Call::bounded_wait(self.0, "g").with_arg(arg0).await?.candid()?)
   }
-  pub async fn h(&self, arg0: &i8) -> Result<(i8,)> {
+  pub async fn h(&self, arg0: &i8) -> Result<i8> {
     Ok(Call::bounded_wait(self.0, "h").with_arg(arg0).await?.candid()?)
   }
-  pub async fn h_2(&self, arg0: &F) -> Result<(F,)> {
+  pub async fn h_2(&self, arg0: &F) -> Result<F> {
     Ok(Call::bounded_wait(self.0, "h2").with_arg(arg0).await?.candid()?)
   }
-  pub async fn o(&self, arg0: &O) -> Result<(O,)> {
+  pub async fn o(&self, arg0: &O) -> Result<O> {
     Ok(Call::bounded_wait(self.0, "o").with_arg(arg0).await?.candid()?)
   }
 }

--- a/rust/candid_parser/tests/assets/ok/comment.rs
+++ b/rust/candid_parser/tests/assets/ok/comment.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 /// line comment
 /// 

--- a/rust/candid_parser/tests/assets/ok/cyclic.rs
+++ b/rust/candid_parser/tests/assets/ok/cyclic.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 pub type C = Box<A>;
 pub type B = Option<C>;
@@ -15,7 +15,7 @@ pub type X = Y;
 pub struct Service(pub Principal);
 impl Service {
   pub async fn f(&self, arg0: &A, arg1: &B, arg2: &C, arg3: &X, arg4: &Y, arg5: &Z) -> Result<()> {
-    ic_cdk::call(self.0, "f", (arg0,arg1,arg2,arg3,arg4,arg5,)).await
+    Ok(Call::bounded_wait(self.0, "f").with_args(&(arg0,arg1,arg2,arg3,arg4,arg5,)).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/cyclic.rs
+++ b/rust/candid_parser/tests/assets/ok/cyclic.rs
@@ -15,7 +15,7 @@ pub type X = Y;
 pub struct Service(pub Principal);
 impl Service {
   pub async fn f(&self, arg0: &A, arg1: &B, arg2: &C, arg3: &X, arg4: &Y, arg5: &Z) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "f").with_args(&(arg0,arg1,arg2,arg3,arg4,arg5,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "f").with_args(&(arg0, arg1, arg2, arg3, arg4, arg5)).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/empty.rs
+++ b/rust/candid_parser/tests/assets/ok/empty.rs
@@ -17,13 +17,13 @@ pub enum HRet { #[serde(rename="a")] A(Box<T>), #[serde(rename="b")] B{} }
 
 pub struct Service(pub Principal);
 impl Service {
-  pub async fn f(&self, arg0: &FArg) -> Result<(FRet,)> {
+  pub async fn f(&self, arg0: &FArg) -> Result<FRet> {
     Ok(Call::bounded_wait(self.0, "f").with_arg(arg0).await?.candid()?)
   }
-  pub async fn g(&self, arg0: &T) -> Result<(GRet,)> {
+  pub async fn g(&self, arg0: &T) -> Result<GRet> {
     Ok(Call::bounded_wait(self.0, "g").with_arg(arg0).await?.candid()?)
   }
-  pub async fn h(&self, arg0: &(T, candid::Empty)) -> Result<(HRet,)> {
+  pub async fn h(&self, arg0: &(T, candid::Empty)) -> Result<HRet> {
     Ok(Call::bounded_wait(self.0, "h").with_arg(arg0).await?.candid()?)
   }
 }

--- a/rust/candid_parser/tests/assets/ok/empty.rs
+++ b/rust/candid_parser/tests/assets/ok/empty.rs
@@ -18,13 +18,13 @@ pub enum HRet { #[serde(rename="a")] A(Box<T>), #[serde(rename="b")] B{} }
 pub struct Service(pub Principal);
 impl Service {
   pub async fn f(&self, arg0: &FArg) -> Result<(FRet,)> {
-    Ok(Call::bounded_wait(self.0, "f").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "f").with_arg(arg0).await?.candid()?)
   }
   pub async fn g(&self, arg0: &T) -> Result<(GRet,)> {
-    Ok(Call::bounded_wait(self.0, "g").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "g").with_arg(arg0).await?.candid()?)
   }
   pub async fn h(&self, arg0: &(T, candid::Empty)) -> Result<(HRet,)> {
-    Ok(Call::bounded_wait(self.0, "h").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "h").with_arg(arg0).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/empty.rs
+++ b/rust/candid_parser/tests/assets/ok/empty.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 #[derive(CandidType, Deserialize)]
 pub struct FArg {}
@@ -18,13 +18,13 @@ pub enum HRet { #[serde(rename="a")] A(Box<T>), #[serde(rename="b")] B{} }
 pub struct Service(pub Principal);
 impl Service {
   pub async fn f(&self, arg0: &FArg) -> Result<(FRet,)> {
-    ic_cdk::call(self.0, "f", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "f").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn g(&self, arg0: &T) -> Result<(GRet,)> {
-    ic_cdk::call(self.0, "g", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "g").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn h(&self, arg0: &(T, candid::Empty)) -> Result<(HRet,)> {
-    ic_cdk::call(self.0, "h", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "h").with_args(&(arg0,)).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/escape.rs
+++ b/rust/candid_parser/tests/assets/ok/escape.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 #[derive(CandidType, Deserialize)]
 pub struct T {
@@ -19,7 +19,7 @@ pub struct T {
 pub struct Service(pub Principal);
 impl Service {
   pub async fn _2635468193_(&self, arg0: &T) -> Result<()> {
-    ic_cdk::call(self.0, "\n\'\"\'\'\"\"\r\t", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "\n\'\"\'\'\"\"\r\t").with_args(&(arg0,)).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/escape.rs
+++ b/rust/candid_parser/tests/assets/ok/escape.rs
@@ -19,7 +19,7 @@ pub struct T {
 pub struct Service(pub Principal);
 impl Service {
   pub async fn _2635468193_(&self, arg0: &T) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "\n\'\"\'\'\"\"\r\t").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "\n\'\"\'\'\"\"\r\t").with_arg(arg0).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/example.rs
+++ b/rust/candid_parser/tests/assets/ok/example.rs
@@ -154,26 +154,26 @@ impl Service {
   pub async fn f_1(&self, arg0: &List, test: &serde_bytes::ByteBuf, arg2: &Option<bool>) -> Result<()> {
     Ok(Call::bounded_wait(self.0, "f1").with_args(&(arg0, test, arg2)).await?.candid()?)
   }
-  pub async fn G11(&self, id: &CanisterId, list: &MyList, is_okay: &Option<MyList>, arg3: &Nested) -> Result<(i128,Broker,NestedRes,)> {
+  pub async fn G11(&self, id: &CanisterId, list: &MyList, is_okay: &Option<MyList>, arg3: &Nested) -> Result<(i128, Broker, NestedRes)> {
     Ok(Call::bounded_wait(self.0, "g1").with_args(&(id, list, is_okay, arg3)).await?.candid()?)
   }
-  pub async fn h(&self, arg0: &Vec<Option<String>>, arg1: &HArg1, arg2: &Option<MyList>) -> Result<(HRet,)> {
+  pub async fn h(&self, arg0: &Vec<Option<String>>, arg1: &HArg1, arg2: &Option<MyList>) -> Result<HRet> {
     Ok(Call::bounded_wait(self.0, "h").with_args(&(arg0, arg1, arg2)).await?.candid()?)
   }
   /// Doc comment for i method of service
-  pub async fn i(&self, arg0: &MyList, arg1: &FArg1) -> Result<(Option<MyList>,Res,)> {
+  pub async fn i(&self, arg0: &MyList, arg1: &FArg1) -> Result<(Option<MyList>, Res)> {
     Ok(Call::bounded_wait(self.0, "i").with_args(&(arg0, arg1)).await?.candid()?)
   }
-  pub async fn x(&self, arg0: &A, arg1: &B) -> Result<(Option<A>,Option<B>,std::result::Result<XRet2Ok, Error>,)> {
+  pub async fn x(&self, arg0: &A, arg1: &B) -> Result<(Option<A>, Option<B>, std::result::Result<XRet2Ok, Error>)> {
     Ok(Call::bounded_wait(self.0, "x").with_args(&(arg0, arg1)).await?.candid()?)
   }
-  pub async fn y(&self, arg0: &NestedRecords) -> Result<((NestedRecords, MyVariant),)> {
+  pub async fn y(&self, arg0: &NestedRecords) -> Result<(NestedRecords, MyVariant)> {
     Ok(Call::bounded_wait(self.0, "y").with_arg(arg0).await?.candid()?)
   }
   pub async fn f(&self, server: &S) -> Result<()> {
     Ok(Call::bounded_wait(self.0, "f").with_arg(server).await?.candid()?)
   }
-  pub async fn g(&self, arg0: &List) -> Result<(B,Tree,Stream,)> {
+  pub async fn g(&self, arg0: &List) -> Result<(B, Tree, Stream)> {
     Ok(Call::bounded_wait(self.0, "g").with_arg(arg0).await?.candid()?)
   }
   /// Doc comment for imported bbbbb service method

--- a/rust/candid_parser/tests/assets/ok/example.rs
+++ b/rust/candid_parser/tests/assets/ok/example.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 #[derive(CandidType, Deserialize, Debug)]
 pub(crate) struct Node { pub(crate) head: u128, pub(crate) tail: Box<List> }
@@ -152,33 +152,33 @@ pub struct Service(pub Principal);
 impl Service {
   /// Doc comment for f1 method of service
   pub async fn f_1(&self, arg0: &List, test: &serde_bytes::ByteBuf, arg2: &Option<bool>) -> Result<()> {
-    ic_cdk::call(self.0, "f1", (arg0,test,arg2,)).await
+    Ok(Call::bounded_wait(self.0, "f1").with_args(&(arg0,test,arg2,)).await?.candid()?)
   }
   pub async fn G11(&self, id: &CanisterId, list: &MyList, is_okay: &Option<MyList>, arg3: &Nested) -> Result<(i128,Broker,NestedRes,)> {
-    ic_cdk::call(self.0, "g1", (id,list,is_okay,arg3,)).await
+    Ok(Call::bounded_wait(self.0, "g1").with_args(&(id,list,is_okay,arg3,)).await?.candid()?)
   }
   pub async fn h(&self, arg0: &Vec<Option<String>>, arg1: &HArg1, arg2: &Option<MyList>) -> Result<(HRet,)> {
-    ic_cdk::call(self.0, "h", (arg0,arg1,arg2,)).await
+    Ok(Call::bounded_wait(self.0, "h").with_args(&(arg0,arg1,arg2,)).await?.candid()?)
   }
   /// Doc comment for i method of service
   pub async fn i(&self, arg0: &MyList, arg1: &FArg1) -> Result<(Option<MyList>,Res,)> {
-    ic_cdk::call(self.0, "i", (arg0,arg1,)).await
+    Ok(Call::bounded_wait(self.0, "i").with_args(&(arg0,arg1,)).await?.candid()?)
   }
   pub async fn x(&self, arg0: &A, arg1: &B) -> Result<(Option<A>,Option<B>,std::result::Result<XRet2Ok, Error>,)> {
-    ic_cdk::call(self.0, "x", (arg0,arg1,)).await
+    Ok(Call::bounded_wait(self.0, "x").with_args(&(arg0,arg1,)).await?.candid()?)
   }
   pub async fn y(&self, arg0: &NestedRecords) -> Result<((NestedRecords, MyVariant),)> {
-    ic_cdk::call(self.0, "y", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "y").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn f(&self, server: &S) -> Result<()> {
-    ic_cdk::call(self.0, "f", (server,)).await
+    Ok(Call::bounded_wait(self.0, "f").with_args(&(server,)).await?.candid()?)
   }
   pub async fn g(&self, arg0: &List) -> Result<(B,Tree,Stream,)> {
-    ic_cdk::call(self.0, "g", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "g").with_args(&(arg0,)).await?.candid()?)
   }
   /// Doc comment for imported bbbbb service method
   pub async fn bbbbb(&self, arg0: &B) -> Result<()> {
-    ic_cdk::call(self.0, "bbbbb", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "bbbbb").with_args(&(arg0,)).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/example.rs
+++ b/rust/candid_parser/tests/assets/ok/example.rs
@@ -152,33 +152,33 @@ pub struct Service(pub Principal);
 impl Service {
   /// Doc comment for f1 method of service
   pub async fn f_1(&self, arg0: &List, test: &serde_bytes::ByteBuf, arg2: &Option<bool>) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "f1").with_args(&(arg0,test,arg2,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "f1").with_args(&(arg0, test, arg2)).await?.candid()?)
   }
   pub async fn G11(&self, id: &CanisterId, list: &MyList, is_okay: &Option<MyList>, arg3: &Nested) -> Result<(i128,Broker,NestedRes,)> {
-    Ok(Call::bounded_wait(self.0, "g1").with_args(&(id,list,is_okay,arg3,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "g1").with_args(&(id, list, is_okay, arg3)).await?.candid()?)
   }
   pub async fn h(&self, arg0: &Vec<Option<String>>, arg1: &HArg1, arg2: &Option<MyList>) -> Result<(HRet,)> {
-    Ok(Call::bounded_wait(self.0, "h").with_args(&(arg0,arg1,arg2,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "h").with_args(&(arg0, arg1, arg2)).await?.candid()?)
   }
   /// Doc comment for i method of service
   pub async fn i(&self, arg0: &MyList, arg1: &FArg1) -> Result<(Option<MyList>,Res,)> {
-    Ok(Call::bounded_wait(self.0, "i").with_args(&(arg0,arg1,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "i").with_args(&(arg0, arg1)).await?.candid()?)
   }
   pub async fn x(&self, arg0: &A, arg1: &B) -> Result<(Option<A>,Option<B>,std::result::Result<XRet2Ok, Error>,)> {
-    Ok(Call::bounded_wait(self.0, "x").with_args(&(arg0,arg1,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "x").with_args(&(arg0, arg1)).await?.candid()?)
   }
   pub async fn y(&self, arg0: &NestedRecords) -> Result<((NestedRecords, MyVariant),)> {
-    Ok(Call::bounded_wait(self.0, "y").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "y").with_arg(arg0).await?.candid()?)
   }
   pub async fn f(&self, server: &S) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "f").with_args(&(server,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "f").with_arg(server).await?.candid()?)
   }
   pub async fn g(&self, arg0: &List) -> Result<(B,Tree,Stream,)> {
-    Ok(Call::bounded_wait(self.0, "g").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "g").with_arg(arg0).await?.candid()?)
   }
   /// Doc comment for imported bbbbb service method
   pub async fn bbbbb(&self, arg0: &B) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "bbbbb").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "bbbbb").with_arg(arg0).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/fieldnat.rs
+++ b/rust/candid_parser/tests/assets/ok/fieldnat.rs
@@ -32,22 +32,22 @@ impl Service {
   pub async fn bab(&self, two: &candid::Int, arg1: &candid::Nat) -> Result<()> {
     Ok(Call::bounded_wait(self.0, "bab").with_args(&(two, arg1)).await?.candid()?)
   }
-  pub async fn bar(&self, arg0: &BarArg) -> Result<(BarRet,)> {
+  pub async fn bar(&self, arg0: &BarArg) -> Result<BarRet> {
     Ok(Call::bounded_wait(self.0, "bar").with_arg(arg0).await?.candid()?)
   }
-  pub async fn bas(&self, arg0: &(candid::Int, candid::Int)) -> Result<((String, candid::Nat),)> {
+  pub async fn bas(&self, arg0: &(candid::Int, candid::Int)) -> Result<(String, candid::Nat)> {
     Ok(Call::bounded_wait(self.0, "bas").with_arg(arg0).await?.candid()?)
   }
-  pub async fn baz(&self, arg0: &BazArg) -> Result<(BazRet,)> {
+  pub async fn baz(&self, arg0: &BazArg) -> Result<BazRet> {
     Ok(Call::bounded_wait(self.0, "baz").with_arg(arg0).await?.candid()?)
   }
-  pub async fn bba(&self, arg0: &Tuple) -> Result<(NonTuple,)> {
+  pub async fn bba(&self, arg0: &Tuple) -> Result<NonTuple> {
     Ok(Call::bounded_wait(self.0, "bba").with_arg(arg0).await?.candid()?)
   }
-  pub async fn bib(&self, arg0: &(candid::Int)) -> Result<(BibRet,)> {
+  pub async fn bib(&self, arg0: &(candid::Int)) -> Result<BibRet> {
     Ok(Call::bounded_wait(self.0, "bib").with_arg(arg0).await?.candid()?)
   }
-  pub async fn foo(&self, arg0: &FooArg) -> Result<(FooRet,)> {
+  pub async fn foo(&self, arg0: &FooArg) -> Result<FooRet> {
     Ok(Call::bounded_wait(self.0, "foo").with_arg(arg0).await?.candid()?)
   }
 }

--- a/rust/candid_parser/tests/assets/ok/fieldnat.rs
+++ b/rust/candid_parser/tests/assets/ok/fieldnat.rs
@@ -30,25 +30,25 @@ pub struct FooRet { pub _2_: candid::Int, pub _2: candid::Int }
 pub struct Service(pub Principal);
 impl Service {
   pub async fn bab(&self, two: &candid::Int, arg1: &candid::Nat) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "bab").with_args(&(two,arg1,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "bab").with_args(&(two, arg1)).await?.candid()?)
   }
   pub async fn bar(&self, arg0: &BarArg) -> Result<(BarRet,)> {
-    Ok(Call::bounded_wait(self.0, "bar").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "bar").with_arg(arg0).await?.candid()?)
   }
   pub async fn bas(&self, arg0: &(candid::Int, candid::Int)) -> Result<((String, candid::Nat),)> {
-    Ok(Call::bounded_wait(self.0, "bas").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "bas").with_arg(arg0).await?.candid()?)
   }
   pub async fn baz(&self, arg0: &BazArg) -> Result<(BazRet,)> {
-    Ok(Call::bounded_wait(self.0, "baz").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "baz").with_arg(arg0).await?.candid()?)
   }
   pub async fn bba(&self, arg0: &Tuple) -> Result<(NonTuple,)> {
-    Ok(Call::bounded_wait(self.0, "bba").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "bba").with_arg(arg0).await?.candid()?)
   }
   pub async fn bib(&self, arg0: &(candid::Int)) -> Result<(BibRet,)> {
-    Ok(Call::bounded_wait(self.0, "bib").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "bib").with_arg(arg0).await?.candid()?)
   }
   pub async fn foo(&self, arg0: &FooArg) -> Result<(FooRet,)> {
-    Ok(Call::bounded_wait(self.0, "foo").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "foo").with_arg(arg0).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/fieldnat.rs
+++ b/rust/candid_parser/tests/assets/ok/fieldnat.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 #[derive(CandidType, Deserialize)]
 pub struct BarArg { #[serde(rename="2")] pub _50_: candid::Int }
@@ -30,25 +30,25 @@ pub struct FooRet { pub _2_: candid::Int, pub _2: candid::Int }
 pub struct Service(pub Principal);
 impl Service {
   pub async fn bab(&self, two: &candid::Int, arg1: &candid::Nat) -> Result<()> {
-    ic_cdk::call(self.0, "bab", (two,arg1,)).await
+    Ok(Call::bounded_wait(self.0, "bab").with_args(&(two,arg1,)).await?.candid()?)
   }
   pub async fn bar(&self, arg0: &BarArg) -> Result<(BarRet,)> {
-    ic_cdk::call(self.0, "bar", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "bar").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn bas(&self, arg0: &(candid::Int, candid::Int)) -> Result<((String, candid::Nat),)> {
-    ic_cdk::call(self.0, "bas", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "bas").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn baz(&self, arg0: &BazArg) -> Result<(BazRet,)> {
-    ic_cdk::call(self.0, "baz", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "baz").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn bba(&self, arg0: &Tuple) -> Result<(NonTuple,)> {
-    ic_cdk::call(self.0, "bba", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "bba").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn bib(&self, arg0: &(candid::Int)) -> Result<(BibRet,)> {
-    ic_cdk::call(self.0, "bib", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "bib").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn foo(&self, arg0: &FooArg) -> Result<(FooRet,)> {
-    ic_cdk::call(self.0, "foo", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "foo").with_args(&(arg0,)).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/inline_methods.rs
+++ b/rust/candid_parser/tests/assets/ok/inline_methods.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 candid::define_function!(pub Fn : (candid::Nat) -> (candid::Nat) query);
 candid::define_function!(pub HighOrderFnInlineArg1 : (candid::Nat) -> (
@@ -25,25 +25,25 @@ pub struct RInline { pub x: candid::Nat, pub r#fn: RInlineFn }
 pub struct Service(pub Principal);
 impl Service {
   pub async fn add_two(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
-    ic_cdk::call(self.0, "add_two", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "add_two").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn r#fn(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
-    ic_cdk::call(self.0, "fn", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "fn").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn high_order_fn(&self, arg0: &candid::Nat, arg1: &Fn) -> Result<(candid::Nat,)> {
-    ic_cdk::call(self.0, "high_order_fn", (arg0,arg1,)).await
+    Ok(Call::bounded_wait(self.0, "high_order_fn").with_args(&(arg0,arg1,)).await?.candid()?)
   }
   pub async fn high_order_fn_inline(&self, arg0: &candid::Nat, arg1: &HighOrderFnInlineArg1) -> Result<(candid::Nat,)> {
-    ic_cdk::call(self.0, "high_order_fn_inline", (arg0,arg1,)).await
+    Ok(Call::bounded_wait(self.0, "high_order_fn_inline").with_args(&(arg0,arg1,)).await?.candid()?)
   }
   pub async fn high_order_fn_via_id(&self, arg0: &candid::Nat, arg1: &Gn) -> Result<(Fn,)> {
-    ic_cdk::call(self.0, "high_order_fn_via_id", (arg0,arg1,)).await
+    Ok(Call::bounded_wait(self.0, "high_order_fn_via_id").with_args(&(arg0,arg1,)).await?.candid()?)
   }
   pub async fn high_order_fn_via_record(&self, arg0: &R) -> Result<(candid::Nat,)> {
-    ic_cdk::call(self.0, "high_order_fn_via_record", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "high_order_fn_via_record").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn high_order_fn_via_record_inline(&self, arg0: &RInline) -> Result<(candid::Nat,)> {
-    ic_cdk::call(self.0, "high_order_fn_via_record_inline", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "high_order_fn_via_record_inline").with_args(&(arg0,)).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/inline_methods.rs
+++ b/rust/candid_parser/tests/assets/ok/inline_methods.rs
@@ -24,25 +24,25 @@ pub struct RInline { pub x: candid::Nat, pub r#fn: RInlineFn }
 
 pub struct Service(pub Principal);
 impl Service {
-  pub async fn add_two(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
+  pub async fn add_two(&self, arg0: &candid::Nat) -> Result<candid::Nat> {
     Ok(Call::bounded_wait(self.0, "add_two").with_arg(arg0).await?.candid()?)
   }
-  pub async fn r#fn(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
+  pub async fn r#fn(&self, arg0: &candid::Nat) -> Result<candid::Nat> {
     Ok(Call::bounded_wait(self.0, "fn").with_arg(arg0).await?.candid()?)
   }
-  pub async fn high_order_fn(&self, arg0: &candid::Nat, arg1: &Fn) -> Result<(candid::Nat,)> {
+  pub async fn high_order_fn(&self, arg0: &candid::Nat, arg1: &Fn) -> Result<candid::Nat> {
     Ok(Call::bounded_wait(self.0, "high_order_fn").with_args(&(arg0, arg1)).await?.candid()?)
   }
-  pub async fn high_order_fn_inline(&self, arg0: &candid::Nat, arg1: &HighOrderFnInlineArg1) -> Result<(candid::Nat,)> {
+  pub async fn high_order_fn_inline(&self, arg0: &candid::Nat, arg1: &HighOrderFnInlineArg1) -> Result<candid::Nat> {
     Ok(Call::bounded_wait(self.0, "high_order_fn_inline").with_args(&(arg0, arg1)).await?.candid()?)
   }
-  pub async fn high_order_fn_via_id(&self, arg0: &candid::Nat, arg1: &Gn) -> Result<(Fn,)> {
+  pub async fn high_order_fn_via_id(&self, arg0: &candid::Nat, arg1: &Gn) -> Result<Fn> {
     Ok(Call::bounded_wait(self.0, "high_order_fn_via_id").with_args(&(arg0, arg1)).await?.candid()?)
   }
-  pub async fn high_order_fn_via_record(&self, arg0: &R) -> Result<(candid::Nat,)> {
+  pub async fn high_order_fn_via_record(&self, arg0: &R) -> Result<candid::Nat> {
     Ok(Call::bounded_wait(self.0, "high_order_fn_via_record").with_arg(arg0).await?.candid()?)
   }
-  pub async fn high_order_fn_via_record_inline(&self, arg0: &RInline) -> Result<(candid::Nat,)> {
+  pub async fn high_order_fn_via_record_inline(&self, arg0: &RInline) -> Result<candid::Nat> {
     Ok(Call::bounded_wait(self.0, "high_order_fn_via_record_inline").with_arg(arg0).await?.candid()?)
   }
 }

--- a/rust/candid_parser/tests/assets/ok/inline_methods.rs
+++ b/rust/candid_parser/tests/assets/ok/inline_methods.rs
@@ -25,25 +25,25 @@ pub struct RInline { pub x: candid::Nat, pub r#fn: RInlineFn }
 pub struct Service(pub Principal);
 impl Service {
   pub async fn add_two(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
-    Ok(Call::bounded_wait(self.0, "add_two").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "add_two").with_arg(arg0).await?.candid()?)
   }
   pub async fn r#fn(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
-    Ok(Call::bounded_wait(self.0, "fn").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "fn").with_arg(arg0).await?.candid()?)
   }
   pub async fn high_order_fn(&self, arg0: &candid::Nat, arg1: &Fn) -> Result<(candid::Nat,)> {
-    Ok(Call::bounded_wait(self.0, "high_order_fn").with_args(&(arg0,arg1,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "high_order_fn").with_args(&(arg0, arg1)).await?.candid()?)
   }
   pub async fn high_order_fn_inline(&self, arg0: &candid::Nat, arg1: &HighOrderFnInlineArg1) -> Result<(candid::Nat,)> {
-    Ok(Call::bounded_wait(self.0, "high_order_fn_inline").with_args(&(arg0,arg1,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "high_order_fn_inline").with_args(&(arg0, arg1)).await?.candid()?)
   }
   pub async fn high_order_fn_via_id(&self, arg0: &candid::Nat, arg1: &Gn) -> Result<(Fn,)> {
-    Ok(Call::bounded_wait(self.0, "high_order_fn_via_id").with_args(&(arg0,arg1,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "high_order_fn_via_id").with_args(&(arg0, arg1)).await?.candid()?)
   }
   pub async fn high_order_fn_via_record(&self, arg0: &R) -> Result<(candid::Nat,)> {
-    Ok(Call::bounded_wait(self.0, "high_order_fn_via_record").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "high_order_fn_via_record").with_arg(arg0).await?.candid()?)
   }
   pub async fn high_order_fn_via_record_inline(&self, arg0: &RInline) -> Result<(candid::Nat,)> {
-    Ok(Call::bounded_wait(self.0, "high_order_fn_via_record_inline").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "high_order_fn_via_record_inline").with_arg(arg0).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/keyword.rs
+++ b/rust/candid_parser/tests/assets/ok/keyword.rs
@@ -45,13 +45,13 @@ impl Service {
   pub async fn oneway(&self) -> Result<()> {
     Ok(Call::bounded_wait(self.0, "Oneway").await?.candid()?)
   }
-  pub async fn f(&self, arg0: &O) -> Result<(O,)> {
+  pub async fn f(&self, arg0: &O) -> Result<O> {
     Ok(Call::bounded_wait(self.0, "f_").with_arg(arg0).await?.candid()?)
   }
-  pub async fn field(&self, arg0: &FieldArg) -> Result<(FieldRet,)> {
+  pub async fn field(&self, arg0: &FieldArg) -> Result<FieldRet> {
     Ok(Call::bounded_wait(self.0, "field").with_arg(arg0).await?.candid()?)
   }
-  pub async fn fieldnat(&self, arg0: &FieldnatArg) -> Result<((candid::Int),)> {
+  pub async fn fieldnat(&self, arg0: &FieldnatArg) -> Result<(candid::Int)> {
     Ok(Call::bounded_wait(self.0, "fieldnat").with_arg(arg0).await?.candid()?)
   }
   pub async fn oneway(&self, arg0: &u8) -> Result<()> {
@@ -60,16 +60,16 @@ impl Service {
   pub async fn oneway(&self, arg0: &u8) -> Result<()> {
     Ok(Call::bounded_wait(self.0, "oneway_").with_arg(arg0).await?.candid()?)
   }
-  pub async fn query(&self, arg0: &serde_bytes::ByteBuf) -> Result<(serde_bytes::ByteBuf,)> {
+  pub async fn query(&self, arg0: &serde_bytes::ByteBuf) -> Result<serde_bytes::ByteBuf> {
     Ok(Call::bounded_wait(self.0, "query").with_arg(arg0).await?.candid()?)
   }
-  pub async fn r#return(&self, arg0: &O) -> Result<(O,)> {
+  pub async fn r#return(&self, arg0: &O) -> Result<O> {
     Ok(Call::bounded_wait(self.0, "return").with_arg(arg0).await?.candid()?)
   }
   pub async fn service(&self, server: &Return) -> Result<()> {
     Ok(Call::bounded_wait(self.0, "service").with_arg(server).await?.candid()?)
   }
-  pub async fn tuple(&self, arg0: &(candid::Int, serde_bytes::ByteBuf, String)) -> Result<((candid::Int, u8),)> {
+  pub async fn tuple(&self, arg0: &(candid::Int, serde_bytes::ByteBuf, String)) -> Result<(candid::Int, u8)> {
     Ok(Call::bounded_wait(self.0, "tuple").with_arg(arg0).await?.candid()?)
   }
   pub async fn variant(&self, arg0: &VariantArg) -> Result<()> {

--- a/rust/candid_parser/tests/assets/ok/keyword.rs
+++ b/rust/candid_parser/tests/assets/ok/keyword.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 #[derive(CandidType, Deserialize)]
 pub struct O(pub Option<Box<O>>);
@@ -43,37 +43,37 @@ pub enum VariantArg { A, B, C, D(f64) }
 pub struct Service(pub Principal);
 impl Service {
   pub async fn oneway(&self) -> Result<()> {
-    ic_cdk::call(self.0, "Oneway", ()).await
+    Ok(Call::bounded_wait(self.0, "Oneway").with_args(&()).await?.candid()?)
   }
   pub async fn f(&self, arg0: &O) -> Result<(O,)> {
-    ic_cdk::call(self.0, "f_", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "f_").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn field(&self, arg0: &FieldArg) -> Result<(FieldRet,)> {
-    ic_cdk::call(self.0, "field", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "field").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn fieldnat(&self, arg0: &FieldnatArg) -> Result<((candid::Int),)> {
-    ic_cdk::call(self.0, "fieldnat", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "fieldnat").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn oneway(&self, arg0: &u8) -> Result<()> {
-    ic_cdk::call(self.0, "oneway", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "oneway").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn oneway(&self, arg0: &u8) -> Result<()> {
-    ic_cdk::call(self.0, "oneway_", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "oneway_").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn query(&self, arg0: &serde_bytes::ByteBuf) -> Result<(serde_bytes::ByteBuf,)> {
-    ic_cdk::call(self.0, "query", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "query").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn r#return(&self, arg0: &O) -> Result<(O,)> {
-    ic_cdk::call(self.0, "return", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "return").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn service(&self, server: &Return) -> Result<()> {
-    ic_cdk::call(self.0, "service", (server,)).await
+    Ok(Call::bounded_wait(self.0, "service").with_args(&(server,)).await?.candid()?)
   }
   pub async fn tuple(&self, arg0: &(candid::Int, serde_bytes::ByteBuf, String)) -> Result<((candid::Int, u8),)> {
-    ic_cdk::call(self.0, "tuple", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "tuple").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn variant(&self, arg0: &VariantArg) -> Result<()> {
-    ic_cdk::call(self.0, "variant", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "variant").with_args(&(arg0,)).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/keyword.rs
+++ b/rust/candid_parser/tests/assets/ok/keyword.rs
@@ -43,37 +43,37 @@ pub enum VariantArg { A, B, C, D(f64) }
 pub struct Service(pub Principal);
 impl Service {
   pub async fn oneway(&self) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "Oneway").with_args(&()).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "Oneway").await?.candid()?)
   }
   pub async fn f(&self, arg0: &O) -> Result<(O,)> {
-    Ok(Call::bounded_wait(self.0, "f_").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "f_").with_arg(arg0).await?.candid()?)
   }
   pub async fn field(&self, arg0: &FieldArg) -> Result<(FieldRet,)> {
-    Ok(Call::bounded_wait(self.0, "field").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "field").with_arg(arg0).await?.candid()?)
   }
   pub async fn fieldnat(&self, arg0: &FieldnatArg) -> Result<((candid::Int),)> {
-    Ok(Call::bounded_wait(self.0, "fieldnat").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "fieldnat").with_arg(arg0).await?.candid()?)
   }
   pub async fn oneway(&self, arg0: &u8) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "oneway").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "oneway").with_arg(arg0).await?.candid()?)
   }
   pub async fn oneway(&self, arg0: &u8) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "oneway_").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "oneway_").with_arg(arg0).await?.candid()?)
   }
   pub async fn query(&self, arg0: &serde_bytes::ByteBuf) -> Result<(serde_bytes::ByteBuf,)> {
-    Ok(Call::bounded_wait(self.0, "query").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "query").with_arg(arg0).await?.candid()?)
   }
   pub async fn r#return(&self, arg0: &O) -> Result<(O,)> {
-    Ok(Call::bounded_wait(self.0, "return").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "return").with_arg(arg0).await?.candid()?)
   }
   pub async fn service(&self, server: &Return) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "service").with_args(&(server,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "service").with_arg(server).await?.candid()?)
   }
   pub async fn tuple(&self, arg0: &(candid::Int, serde_bytes::ByteBuf, String)) -> Result<((candid::Int, u8),)> {
-    Ok(Call::bounded_wait(self.0, "tuple").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "tuple").with_arg(arg0).await?.candid()?)
   }
   pub async fn variant(&self, arg0: &VariantArg) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "variant").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "variant").with_arg(arg0).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/recursion.rs
+++ b/rust/candid_parser/tests/assets/ok/recursion.rs
@@ -34,7 +34,7 @@ impl Service {
   pub async fn f(&self, server: &S) -> Result<()> {
     Ok(Call::bounded_wait(self.0, "f").with_arg(server).await?.candid()?)
   }
-  pub async fn g(&self, arg0: &List) -> Result<(B,Tree,Stream,)> {
+  pub async fn g(&self, arg0: &List) -> Result<(B, Tree, Stream)> {
     Ok(Call::bounded_wait(self.0, "g").with_arg(arg0).await?.candid()?)
   }
 }

--- a/rust/candid_parser/tests/assets/ok/recursion.rs
+++ b/rust/candid_parser/tests/assets/ok/recursion.rs
@@ -32,10 +32,10 @@ candid::define_service!(pub S : {
 pub struct Service(pub Principal);
 impl Service {
   pub async fn f(&self, server: &S) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "f").with_args(&(server,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "f").with_arg(server).await?.candid()?)
   }
   pub async fn g(&self, arg0: &List) -> Result<(B,Tree,Stream,)> {
-    Ok(Call::bounded_wait(self.0, "g").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "g").with_arg(arg0).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/recursion.rs
+++ b/rust/candid_parser/tests/assets/ok/recursion.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 candid::define_function!(pub T : (S) -> ());
 #[derive(CandidType, Deserialize)]
@@ -32,10 +32,10 @@ candid::define_service!(pub S : {
 pub struct Service(pub Principal);
 impl Service {
   pub async fn f(&self, server: &S) -> Result<()> {
-    ic_cdk::call(self.0, "f", (server,)).await
+    Ok(Call::bounded_wait(self.0, "f").with_args(&(server,)).await?.candid()?)
   }
   pub async fn g(&self, arg0: &List) -> Result<(B,Tree,Stream,)> {
-    ic_cdk::call(self.0, "g", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "g").with_args(&(arg0,)).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/recursive_class.rs
+++ b/rust/candid_parser/tests/assets/ok/recursive_class.rs
@@ -9,7 +9,7 @@ candid::define_service!(pub S : { "next" : candid::func!(() -> (S)) });
 pub struct Service(pub Principal);
 impl Service {
   pub async fn next(&self) -> Result<(S,)> {
-    Ok(Call::bounded_wait(self.0, "next").with_args(&()).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "next").await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/recursive_class.rs
+++ b/rust/candid_parser/tests/assets/ok/recursive_class.rs
@@ -2,14 +2,14 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 candid::define_service!(pub S : { "next" : candid::func!(() -> (S)) });
 
 pub struct Service(pub Principal);
 impl Service {
   pub async fn next(&self) -> Result<(S,)> {
-    ic_cdk::call(self.0, "next", ()).await
+    Ok(Call::bounded_wait(self.0, "next").with_args(&()).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/recursive_class.rs
+++ b/rust/candid_parser/tests/assets/ok/recursive_class.rs
@@ -8,7 +8,7 @@ candid::define_service!(pub S : { "next" : candid::func!(() -> (S)) });
 
 pub struct Service(pub Principal);
 impl Service {
-  pub async fn next(&self) -> Result<(S,)> {
+  pub async fn next(&self) -> Result<S> {
     Ok(Call::bounded_wait(self.0, "next").await?.candid()?)
   }
 }

--- a/rust/candid_parser/tests/assets/ok/service.rs
+++ b/rust/candid_parser/tests/assets/ok/service.rs
@@ -17,16 +17,16 @@ pub enum AsVariantRet {
 
 pub struct Service(pub Principal);
 impl Service {
-  pub async fn as_array(&self) -> Result<(Vec<Service2>,Vec<Func>,)> {
+  pub async fn as_array(&self) -> Result<(Vec<Service2>, Vec<Func>)> {
     Ok(Call::bounded_wait(self.0, "asArray").await?.candid()?)
   }
-  pub async fn as_principal(&self) -> Result<(Service2,Func,)> {
+  pub async fn as_principal(&self) -> Result<(Service2, Func)> {
     Ok(Call::bounded_wait(self.0, "asPrincipal").await?.candid()?)
   }
-  pub async fn as_record(&self) -> Result<((Service2, Option<Service>, Func),)> {
+  pub async fn as_record(&self) -> Result<(Service2, Option<Service>, Func)> {
     Ok(Call::bounded_wait(self.0, "asRecord").await?.candid()?)
   }
-  pub async fn as_variant(&self) -> Result<(AsVariantRet,)> {
+  pub async fn as_variant(&self) -> Result<AsVariantRet> {
     Ok(Call::bounded_wait(self.0, "asVariant").await?.candid()?)
   }
 }

--- a/rust/candid_parser/tests/assets/ok/service.rs
+++ b/rust/candid_parser/tests/assets/ok/service.rs
@@ -18,16 +18,16 @@ pub enum AsVariantRet {
 pub struct Service(pub Principal);
 impl Service {
   pub async fn as_array(&self) -> Result<(Vec<Service2>,Vec<Func>,)> {
-    Ok(Call::bounded_wait(self.0, "asArray").with_args(&()).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "asArray").await?.candid()?)
   }
   pub async fn as_principal(&self) -> Result<(Service2,Func,)> {
-    Ok(Call::bounded_wait(self.0, "asPrincipal").with_args(&()).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "asPrincipal").await?.candid()?)
   }
   pub async fn as_record(&self) -> Result<((Service2, Option<Service>, Func),)> {
-    Ok(Call::bounded_wait(self.0, "asRecord").with_args(&()).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "asRecord").await?.candid()?)
   }
   pub async fn as_variant(&self) -> Result<(AsVariantRet,)> {
-    Ok(Call::bounded_wait(self.0, "asVariant").with_args(&()).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "asVariant").await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/service.rs
+++ b/rust/candid_parser/tests/assets/ok/service.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 candid::define_function!(pub Func : () -> (Service));
 candid::define_service!(pub Service : { "f" : Func::ty() });
@@ -18,16 +18,16 @@ pub enum AsVariantRet {
 pub struct Service(pub Principal);
 impl Service {
   pub async fn as_array(&self) -> Result<(Vec<Service2>,Vec<Func>,)> {
-    ic_cdk::call(self.0, "asArray", ()).await
+    Ok(Call::bounded_wait(self.0, "asArray").with_args(&()).await?.candid()?)
   }
   pub async fn as_principal(&self) -> Result<(Service2,Func,)> {
-    ic_cdk::call(self.0, "asPrincipal", ()).await
+    Ok(Call::bounded_wait(self.0, "asPrincipal").with_args(&()).await?.candid()?)
   }
   pub async fn as_record(&self) -> Result<((Service2, Option<Service>, Func),)> {
-    ic_cdk::call(self.0, "asRecord", ()).await
+    Ok(Call::bounded_wait(self.0, "asRecord").with_args(&()).await?.candid()?)
   }
   pub async fn as_variant(&self) -> Result<(AsVariantRet,)> {
-    ic_cdk::call(self.0, "asVariant", ()).await
+    Ok(Call::bounded_wait(self.0, "asVariant").with_args(&()).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/unicode.rs
+++ b/rust/candid_parser/tests/assets/ok/unicode.rs
@@ -2,7 +2,7 @@
 // You may want to manually adjust some of the types.
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Deserialize, Principal};
-use ic_cdk::api::call::CallResult as Result;
+use ic_cdk::call::{Call, CallResult as Result};
 
 #[derive(CandidType, Deserialize)]
 pub struct A {
@@ -30,16 +30,16 @@ pub enum B {
 pub struct Service(pub Principal);
 impl Service {
   pub async fn _0_(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
-    ic_cdk::call(self.0, "", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn _356566390_(&self) -> Result<()> {
-    ic_cdk::call(self.0, "✈️  🚗 ⛱️ ", ()).await
+    Ok(Call::bounded_wait(self.0, "✈️  🚗 ⛱️ ").with_args(&()).await?.candid()?)
   }
   pub async fn _3300066460_(&self, arg0: &A) -> Result<(B,)> {
-    ic_cdk::call(self.0, "函数名", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "函数名").with_args(&(arg0,)).await?.candid()?)
   }
   pub async fn _2669435454_(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
-    ic_cdk::call(self.0, "👀", (arg0,)).await
+    Ok(Call::bounded_wait(self.0, "👀").with_args(&(arg0,)).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/unicode.rs
+++ b/rust/candid_parser/tests/assets/ok/unicode.rs
@@ -30,16 +30,16 @@ pub enum B {
 pub struct Service(pub Principal);
 impl Service {
   pub async fn _0_(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
-    Ok(Call::bounded_wait(self.0, "").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "").with_arg(arg0).await?.candid()?)
   }
   pub async fn _356566390_(&self) -> Result<()> {
-    Ok(Call::bounded_wait(self.0, "✈️  🚗 ⛱️ ").with_args(&()).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "✈️  🚗 ⛱️ ").await?.candid()?)
   }
   pub async fn _3300066460_(&self, arg0: &A) -> Result<(B,)> {
-    Ok(Call::bounded_wait(self.0, "函数名").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "函数名").with_arg(arg0).await?.candid()?)
   }
   pub async fn _2669435454_(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
-    Ok(Call::bounded_wait(self.0, "👀").with_args(&(arg0,)).await?.candid()?)
+    Ok(Call::bounded_wait(self.0, "👀").with_arg(arg0).await?.candid()?)
   }
 }
 /// Canister ID: `aaaaa-aa`

--- a/rust/candid_parser/tests/assets/ok/unicode.rs
+++ b/rust/candid_parser/tests/assets/ok/unicode.rs
@@ -29,16 +29,16 @@ pub enum B {
 
 pub struct Service(pub Principal);
 impl Service {
-  pub async fn _0_(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
+  pub async fn _0_(&self, arg0: &candid::Nat) -> Result<candid::Nat> {
     Ok(Call::bounded_wait(self.0, "").with_arg(arg0).await?.candid()?)
   }
   pub async fn _356566390_(&self) -> Result<()> {
     Ok(Call::bounded_wait(self.0, "✈️  🚗 ⛱️ ").await?.candid()?)
   }
-  pub async fn _3300066460_(&self, arg0: &A) -> Result<(B,)> {
+  pub async fn _3300066460_(&self, arg0: &A) -> Result<B> {
     Ok(Call::bounded_wait(self.0, "函数名").with_arg(arg0).await?.candid()?)
   }
-  pub async fn _2669435454_(&self, arg0: &candid::Nat) -> Result<(candid::Nat,)> {
+  pub async fn _2669435454_(&self, arg0: &candid::Nat) -> Result<candid::Nat> {
     Ok(Call::bounded_wait(self.0, "👀").with_arg(arg0).await?.candid()?)
   }
 }

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -32,7 +32,7 @@ enum Command {
     Bind {
         /// Specifies did file for code generation
         input: PathBuf,
-        #[clap(short, long, value_parser = ["js", "ts", "did", "mo", "rs", "rs-agent", "rs-stub"])]
+        #[clap(short, long, value_parser = ["js", "ts", "did", "mo", "rs", "rs-legacy", "rs-agent", "rs-stub"])]
         /// Specifies target language
         target: String,
         #[clap(short, long)]
@@ -235,6 +235,15 @@ fn main() -> Result<()> {
                         .map(|x| x.clone().try_into().unwrap())
                         .unwrap_or(ExternalConfig::default());
                     let config = Config::new(configs);
+                    let (res, unused) = compile(&config, &env, &actor, &prog, external);
+                    warn_unused(&unused);
+                    res
+                },
+                "rs-legacy" => {
+                    use candid_parser::bindings::rust::{compile, Config, ExternalConfig};
+                    let config = Config::new(configs);
+                    let mut external = ExternalConfig::default();
+                    external.0.insert("target".to_string(), "canister_call_legacy".to_string());
                     let (res, unused) = compile(&config, &env, &actor, &prog, external);
                     warn_unused(&unused);
                     res

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -238,12 +238,14 @@ fn main() -> Result<()> {
                     let (res, unused) = compile(&config, &env, &actor, &prog, external);
                     warn_unused(&unused);
                     res
-                },
+                }
                 "rs-legacy" => {
                     use candid_parser::bindings::rust::{compile, Config, ExternalConfig};
                     let config = Config::new(configs);
                     let mut external = ExternalConfig::default();
-                    external.0.insert("target".to_string(), "canister_call_legacy".to_string());
+                    external
+                        .0
+                        .insert("target".to_string(), "canister_call_legacy".to_string());
                     let (res, unused) = compile(&config, &env, &actor, &prog, external);
                     warn_unused(&unused);
                     res


### PR DESCRIPTION
### Update Candid Rust bindings for ic-cdk v0.18
- Switches generated inter-canister calls from `ic_cdk::call(...)` to the new builder-pattern API:
```
Ok(Call::bounded_wait(self.0, "...").await?.candid()?)
Ok(Call::bounded_wait(self.0, "...").with_arg(...).await?.candid()?)
Ok(Call::bounded_wait(self.0, "...").with_args(&(...)).await?.candid()?)
```
- Removes deprecated `ic_cdk::api::call` usage.

See the ic-cdk v0.18 [migration guide](https://github.com/dfinity/cdk-rs/blob/main/ic-cdk/V18_GUIDE.md) for details.