### PR TITLE
fix: subtyping and coercion rules for optional types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix: subtyping and coercion rules for optional types
 * fix: coercion of values into nested optional types
 * fix: values of types `reserved` at any context do not coerce into values of type `null`
 * fix: missing record fields of type `null` in the textual format are decoded into a default value

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -953,12 +953,12 @@ An optional value coerces at an option type, if the constituent value has a suit
 ----------------------------------------
 opt <v> : opt <t> ~> opt <v'> : opt <t'>
 
-not (<v> : <t> ~> _ : <t'>)
+not (exists <w>. <v> : <t> ~> <w> : <t'>)
 ----------------------------------------
 opt <v> : opt <t> ~> null : opt <t'>
 ```
 
-Coercing a non-null, non-optional and non-reserved type at an option type treats it as an optional value, if it can be decoded successfully:
+Coercing a non-null, non-optional and non-reserved type at an option type treats it as an optional value, if it can be decoded successfully at the content type:
 ```
 not (null <: <t>)
 not (<v'> = null)
@@ -979,7 +979,7 @@ not (<v> = null)
 <v> : reserved ~> null : opt <t'>
 
 not (null <: <t>)
-not (<v> : <t> ~> _ : <t'>)
+not (exists <w>. <v> : <t> ~> <w> : <t'>)
 ----------------------------
 <v> : <t> ~> null : opt <t'>
 ```

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -961,15 +961,9 @@ opt <v> : opt <t> ~> null : opt <t'>
 Coercing a non-null, non-optional and non-reserved type at an option type treats it as an optional value, if it can be decoded successfully at the content type:
 ```
 not (null <: <t>)
-not (<v'> = null)
 <v> : <t> ~> <v'> : <t'>
 --------------------------------
 <v> : <t> ~> opt <v'> : opt <t'>
-
-not (null <: <t>)
-<v> : <t> ~> null : <t'>
-----------------------------
-<v> : <t> ~> null : opt <t'>
 ```
 
 Any other value goes to `null`:

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -812,7 +812,7 @@ opt <datatype> <: opt <datatype'>
 
 not (null <: <datatype>)
 not (<datatype> <: <datatype'>)
----------------------------------
+-------------------------------
 <datatype> <: opt <datatype'>
 ```
 *Note:* These rules are necessary in the presence of the unusual record and variant rules shown below. Without them, certain upgrades may generally be valid one step at a time, but not taken together, which could cause problems for clients catching up with multiple upgrades.

--- a/spec/Candid.md
+++ b/spec/Candid.md
@@ -785,37 +785,40 @@ An option type can be specialised via its constituent type.
 opt <datatype> <: opt <datatype'>
 ```
 
-Furthermore, an option type can be specialised to `null`:
+Furthermore, an option type can be specialised to `null` and `reserved`:
 ```
 ------------------------
 null <: opt <datatype>
+
+--------------------------
+reserved <: opt <datatype>
 ```
 
 It can also be specialised to its constituent type, unless that type is itself optional:
 
 ```
-not (null <: <datatype'>)
+not (null <: <datatype>)
 <datatype> <: <datatype'>
 -----------------------------
 <datatype> <: opt <datatype'>
 ```
-The premise means that the rule does not apply when the constituent type is itself `null`, an option or `reserved`. That restriction is necessary so that there is no ambiguity. For example, otherwise there would be two ways to interpret `null` when going from `opt nat` to `opt opt nat`, either as `null` or as `?null`.
+The premise means that the rule does not apply when the constituent type is itself `null`, an option or `reserved`. That restriction is necessary so that there is no ambiguity. For example, otherwise there would be two ways to interpret `null` when going from `opt nat` to `opt opt nat`, either as `null` or as `opt null`.
 
 Finally, in order to maintain *transitivity* of subtyping, two unusual rules allow, in fact, *any* type to be regarded as a subtype of an option.
 ```
-not (<datatype> <: opt <datatype'>)
----------------------------------
-opt <datatype> <: opt <datatype'>
-
-not (null <: <datatype'>)
 not (<datatype> <: <datatype'>)
 ---------------------------------
 opt <datatype> <: opt <datatype'>
+
+not (null <: <datatype>)
+not (<datatype> <: <datatype'>)
+---------------------------------
+<datatype> <: opt <datatype'>
 ```
 *Note:* These rules are necessary in the presence of the unusual record and variant rules shown below. Without them, certain upgrades may generally be valid one step at a time, but not taken together, which could cause problems for clients catching up with multiple upgrades.
 For example, given a record type `record {666 : nat}` it is valid to remove the field `666` by the rule below and evolve the type to `record { 666 : opt nat }` and then to `record {}`.
 A later step might legally re-add a field of the same name but with a different type, producing, e.g.,`record {666 : opt text}`.
-A client having missed some of the  intermediate steps will have to upgrade directly to the newest version of the type.
+A client having missed some of the intermediate steps will have to upgrade directly to the newest version of the type.
 If the type cannot be decoded, its value will be treated as `null`.
 
 In practice, users are strongly discouraged to ever remove a record field or a variant tag and later re-add it with a different meaning. Instead of removing an optional record/variant field, it should be replaced with `opt empty` or `reserved`, to prevent re-use of that field.
@@ -958,24 +961,25 @@ opt <v> : opt <t> ~> null : opt <t'>
 Coercing a non-null, non-optional and non-reserved type at an option type treats it as an optional value, if it can be decoded successfully:
 ```
 not (null <: <t>)
-not (null <: <t'>)
+not (<v'> = null)
 <v> : <t> ~> <v'> : <t'>
 --------------------------------
 <v> : <t> ~> opt <v'> : opt <t'>
+
+not (null <: <t>)
+<v> : <t> ~> null : <t'>
+----------------------------
+<v> : <t> ~> null : opt <t'>
 ```
 
 Any other value goes to `null`:
 ```
+not (<v> = null)
 ---------------------------------
 <v> : reserved ~> null : opt <t'>
 
-not (null <: <t'>)
-not (<v> : <t> ~> _ : <t'>)
---------------------------------
-<v> : <t> ~> null : opt <t'>
-
-null <: <t'>
 not (null <: <t>)
+not (<v> : <t> ~> _ : <t'>)
 ----------------------------
 <v> : <t> ~> null : opt <t'>
 ```


### PR DESCRIPTION
This PR fixes the specification of subtyping and coercion rules for optional types.

The changes to the specification are implemented in a separate [PR](https://github.com/dfinity/candid/pull/679).

# Subtyping rules

## Subtyping fix 1

The specification claims that the rules allow "*any* type to be regarded
as a subtype of an option".

Hence, the pre-condition of the rule
```
not (<datatype> <: opt <datatype'>)

---------------------------------

opt <datatype> <: opt <datatype'>
```
is always false and this rule can be dropped.

## Subtyping fix 2

The existing subtyping rule
```
not (null <: <datatype'>)

<datatype> <: <datatype'>

-----------------------------

<datatype> <: opt <datatype'>
```
should be fixed to
```
not (null <: <datatype>)

<datatype> <: <datatype'>

-----------------------------

<datatype> <: opt <datatype'>
```
according to the specification "It can also be specialised to its
constituent type, unless that type is itself optional". Also the fact
that `nat <: opt opt nat` cannot be derived otherwise.

## Subtyping fix 3

The pre-condition `not (null <: <datatype'>)` in the existing
subtyping rule

```
not (null <: <datatype'>)

not (<datatype> <: <datatype'>)

---------------------------------

opt <datatype> <: opt <datatype'>
```
effectively only forbids `null` as `<datatype'>` because every other
`<datatype'>` such that `null <: <datatype'>` would also satisfy
`<datatype> <: <datatype'>` and thus violate the other
pre-condition. Since the corresponding coercion rule coerces to `null` in
this case anyway, we should enable `null` as `<datatype'>` in this rule
(as otherwise a separate rule to cover this case is needed with the same
coercion rule). Hence, the updated rule should read
```
not (<datatype> <: <datatype'>)

---------------------------------

opt <datatype> <: opt <datatype'>
```

## Subtyping fix 4

Analogously to the existing rule
```

----------------------

null <: opt <datatype>
```
we need to add a new rule
```

--------------------------

reserved <: opt <datatype>
```
otherwise the type `reserved` is not a subtype of an option (contrary to
the claim that every type is a subtype of an option).

## Subtyping fix 5

The specification claims that the rules allow "any type to be regarded
as a subtype of an option". Hence, we need to add the rule
```
not (null <: <datatype>)

not (<datatype> <: <datatype'>)

-----------------------------

<datatype> <: opt <datatype'>
```
otherwise the type `nat` is not a subtype of `opt nat64`.

## Fixed subtyping rules

The final set of subtyping rules for optional types is
```
----------------------

null <: opt <datatype>
```

```

--------------------------

reserved <: opt <datatype>
```

```
<datatype> <: <datatype'>

---------------------------------

opt <datatype> <: opt <datatype'>
```

```
not (<datatype> <: <datatype'>)

---------------------------------

opt <datatype> <: opt <datatype'>
```

```
not (null <: <datatype>)

<datatype> <: <datatype'>

-----------------------------

<datatype> <: opt <datatype'>
```

```
not (null <: <datatype>)

not (<datatype> <: <datatype'>)

-----------------------------

<datatype> <: opt <datatype'>
```
and it is easy to see that these rules are non-overlapping and
correspond to coercion rules.

# Coercion rules

## Coercion fix 1

The rule
```

---------------------------------

<v> : reserved ~> null : opt <t'>
```
is overlapping with
```
null <: <t>

-----------------------------

null : <t> ~> null : opt <t'>
```
and thus the former should be fixed to
```
not (<v> = null)

-----------------------------

<v> : reserved ~> null : opt <t'>
```

## Coercion fix 2

The coercion rule
```
not (null <: <t>)

not (null <: <t'>)

<v> : <t> ~> <v'> : <t'>

--------------------------------

<v> : <t> ~> opt <v'> : opt <t'>
```
has a pre-condition `not (null <: <t'>)` that does not correspond to
any pre-condition in the corresponding subtyping rule (the fixed rule in
the section "Subtyping fix 2") and prevents coercion of `nat` into `opt opt nat`
(for instance). Hence, we drop the pre-condition and the updated
rule is
```
not (null <: <t>)

<v> : <t> ~> <v'> : <t'>

--------------------------------

<v> : <t> ~> opt <v'> : opt <t'>
```

## Coercion fix 3

The rule
```
not (null <: <t'>)

not (exists <w>. <v> : <t> ~> <w> : <t'>)

--------------------------------

<v> : <t> ~> null : opt <t'>
```
allows `opt 5 : opt nat` to coerce to `null : opt nat` which does not make
sense as it loses data (`opt 5`) that could be preserved. This rule should
be extended with an additional pre-condition `not (null <: <t>)` since
there are separate coercion rules for such cases.

## Coercion fix 4

The rule
```
null <: <t'>

not (null <: <t>)

----------------------------

<v> : <t> ~> null : opt <t'>
```
allows `5 : nat` to coerce to `null : opt opt nat` which does not make
sense. This rule should be extended with an additional pre-condition
```
not (exists <w>. <v> : <t> ~> <w> : <t'>)
```
to only coerce to `null : opt <t'>` if coercion to `<t'>` failed.

## Coercion fix 5

But now we easily see that the two rules
```
not (null <: <t>)

not (null <: <t'>)

not (exists <w>. <v> : <t> ~> <w> : <t'>)

--------------------------------

<v> : <t> ~> null : opt <t'>
```
and
```
not (null <: <t>)

null <: <t'>

not (exists <w>. <v> : <t> ~> <w> : <t'>)

----------------------------

<v> : <t> ~> null : opt <t'>
```
can be merged into a single rule
```
not (null <: <t>)

not (exists <w>. <v> : <t> ~> <w> : <t'>)

--------------------------------

<v> : <t> ~> null : opt <t'>
```

## Fixed coercion rules

The final set of coercion rules is
```
not (<v> = null)

---------------------------------

<v> : reserved ~> null : opt <t'>
```

```
null <: <t>

-----------------------------

null : <t> ~> null : opt <t'>
```

```
<v> : <t> ~> <v'> : <t'>

----------------------------------------

opt <v> : opt <t> ~> opt <v'> : opt <t'>
```

```
not (exists <w>. <v> : <t> ~> <w> : <t'>)

----------------------------------------

opt <v> : opt <t> ~> null : opt <t'>
```

```
not (null <: <t>)

<v> : <t> ~> <v'> : <t'>

--------------------------------

<v> : <t> ~> opt <v'> : opt <t'>
```

```
not (null <: <t>)

not (exists <w>. <v> : <t> ~> <w> : <t'>)

--------------------------------

<v> : <t> ~> null : opt <t'>
```
and it is easy to see that these rules are non-overlapping and
correspond to subtyping rules.