### PR TITLE
fix: coercion of values into nested optional types

### DIFF
--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -839,16 +839,8 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
             }
             (_, TypeInner::Opt(t2)) => {
                 self.expect_type = self.table.trace_type(t2)?;
-                if !matches!(
-                    self.expect_type.as_ref(),
-                    TypeInner::Null | TypeInner::Reserved | TypeInner::Opt(_)
-                ) {
-                    check_recursion! {
-                        self.recoverable_visit_some(visitor)
-                    }
-                } else {
-                    self.deserialize_ignored_any(serde::de::IgnoredAny)?;
-                    visitor.visit_none()
+                check_recursion! {
+                    self.recoverable_visit_some(visitor)
                 }
             }
             (_, _) => check!(false),

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -191,21 +191,34 @@ fn test_option() {
     });
     let expected = A { canister_id: None };
     test_decode(&bytes, &expected);
-    // Deserialize `null : null` to `opt null`, `opt opt null`, and `opt opt null`.
+    // Deserialize `null : null` to `opt null`, `opt opt null`, and `opt opt opt null`.
     let null: () = ();
     let bytes = encode(&null);
     let none_null: Option<()> = None;
     test_decode(&bytes, &none_null);
     let none_none_null: Option<Option<()>> = None;
     test_decode(&bytes, &none_none_null);
-    // Deserialize `null : reserved` to `opt reserved`, `opt opt reserved`, and `opt opt reserved`.
+    let none_none_none_null: Option<Option<Option<()>>> = None;
+    test_decode(&bytes, &none_none_none_null);
+    // Deserialize `5 : nat64` to `opt null`, `opt opt null`, and `opt opt opt null`.
+    let nat64: u64 = 5;
+    let bytes = encode(&nat64);
+    let none_null: Option<()> = None;
+    test_decode(&bytes, &none_null);
+    let some_none_null: Option<Option<()>> = Some(None);
+    test_decode(&bytes, &some_none_null);
+    let some_some_none_null: Option<Option<Option<()>>> = Some(Some(None));
+    test_decode(&bytes, &some_some_none_null);
+    // Deserialize `null : reserved` to `opt reserved`, `opt opt reserved`, and `opt opt opt reserved`.
     let reserved: Reserved = Reserved;
     let bytes = encode(&reserved);
     let none_reserved: Option<Reserved> = None;
     test_decode(&bytes, &none_reserved);
     let none_none_reserved: Option<Option<Reserved>> = None;
     test_decode(&bytes, &none_none_reserved);
-    // Deserialize `5 : nat64` to `opt reserved`, `opt opt reserved`, and `opt opt reserved`.
+    let none_none_none_reserved: Option<Option<Option<Reserved>>> = None;
+    test_decode(&bytes, &none_none_none_reserved);
+    // Deserialize `5 : nat64` to `opt reserved`, `opt opt reserved`, and `opt opt opt reserved`.
     let nat64: u64 = 5;
     let bytes = encode(&nat64);
     let some_reserved: Option<Reserved> = Some(Reserved);


### PR DESCRIPTION
This PR fixes coercion of values into nested optional types.

Before the fix from this PR, `5 : nat64` would coerce to `opt 5 : opt na64` (as expected) and `null : opt opt nat64` (unexpected). This PR fixes the unexpected result to be `opt opt 5 : opt opt nat64` (as expected).

Before the fix from this PR, `5 : int` would coerce to `null : opt opt nat`. This PR fixes the result to be `opt null : opt opt nat`. The motivation for this change is to enable using optional types as follows:
- outer option characterizes if a value (of any type) is provided;
- inner option expresses to optimistically deserialize the actual value into the given type (without failing to deserialize and without losing the information if a value of any type is provided).

This PR also adds multiple test cases covering the change to coercion (including coercion to nested optional types over `null` and `reserved`).