### PR TITLE
fix: fail decoding of reserved into null

### DIFF
--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -74,7 +74,7 @@ impl<'de> IDLDeserialize<'de> {
                 TypeInner::Opt(_) | TypeInner::Reserved | TypeInner::Null
             ) {
                 self.de.expect_type = expected_type;
-                self.de.wire_type = TypeInner::Reserved.into();
+                self.de.wire_type = TypeInner::Null.into();
                 return T::deserialize(&mut self.de);
             } else if self.de.config.full_error_message
                 || text_size(&expected_type, MAX_TYPE_LEN).is_ok()
@@ -754,8 +754,7 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
     {
         self.unroll_type()?;
         check!(
-            *self.expect_type == TypeInner::Null
-                && matches!(*self.wire_type, TypeInner::Null | TypeInner::Reserved),
+            *self.expect_type == TypeInner::Null && matches!(*self.wire_type, TypeInner::Null),
             "unit"
         );
         self.add_cost(1)?;
@@ -1125,7 +1124,7 @@ impl<'de> de::SeqAccess<'de> for Compound<'_, 'de> {
                 self.de.wire_type = wire
                     .pop_front()
                     .map(|f| f.ty)
-                    .unwrap_or_else(|| TypeInner::Reserved.into());
+                    .unwrap_or_else(|| TypeInner::Null.into());
                 seed.deserialize(&mut *self.de).map(Some)
             }
             _ => Err(Error::subtype("expect vector or tuple")),
@@ -1175,7 +1174,7 @@ impl<'de> de::MapAccess<'de> for Compound<'_, 'de> {
                                     ),
                                     format!("field {field} is not optional field")
                                 );
-                                self.de.wire_type = TypeInner::Reserved.into();
+                                self.de.wire_type = TypeInner::Null.into();
                             }
                             Ordering::Greater => {
                                 self.de.set_field_name(Label::Named("_".to_owned()).into());
@@ -1192,7 +1191,7 @@ impl<'de> de::MapAccess<'de> for Compound<'_, 'de> {
                     (Some(e), None) => {
                         self.de.set_field_name(e.id.clone());
                         self.de.expect_type = expect.pop_front().unwrap().ty;
-                        self.de.wire_type = TypeInner::Reserved.into();
+                        self.de.wire_type = TypeInner::Null.into();
                     }
                     (None, None) => return Ok(None),
                 }

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -759,7 +759,7 @@ fn test_multiargs() {
     let tuple = Decode!(
         &bytes,
         Vec<(Int, &str)>,
-        (Int, String, Option<u64>),
+        (Int, String, ()),
         Option<i32>,
         (),
         candid::Reserved

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -759,7 +759,7 @@ fn test_multiargs() {
     let tuple = Decode!(
         &bytes,
         Vec<(Int, &str)>,
-        (Int, String),
+        (Int, String, Option<u64>),
         Option<i32>,
         (),
         candid::Reserved

--- a/test/construct.test.did
+++ b/test/construct.test.did
@@ -205,6 +205,23 @@ assert blob "DIDL\07\6c\07\c3\e3\aa\02\01\d3\e3\aa\02\7e\d5\e3\aa\02\02\db\e3\aa
 
 assert blob "DIDL\07\6c\07\c3\e3\aa\02\01\d3\e3\aa\02\7e\d5\e3\aa\02\02\db\e3\aa\02\01\a2\e5\aa\02\04\bb\f1\aa\02\06\86\8e\b7\02\75\6c\02\d3\e3\aa\02\7e\86\8e\b7\02\75\6b\02\d1\a7\cf\02\7f\f1\f3\92\8e\04\03\6c\02\a0\d2\ac\a8\04\7c\90\ed\da\e7\04\02\6e\05\6c\02\a0\d2\ac\a8\04\7c\90\ed\da\e7\04\04\6b\02\d3\e3\aa\02\7f\86\8e\b7\02\7f\01\00\01\0b\00\00\00\01\00\00\0a\00\00\00\01\14\00\00\2a\00\00\00" !: (record { foo: int; new_field: bool }) "new record field";
 
+// parsing reserved as null
+assert blob "DIDL\00\01\70" == "(null)" : (reserved) "reserved";
+assert blob "DIDL\00\01\70"            !: (null) "parsing reserved as null";
+assert blob "DIDL\01\6c\01\00\70\01\00" == "(record { 0 = null })" : (record { 0 : reserved }) "record with reserved field";
+assert blob "DIDL\01\6c\01\00\70\01\00"                           !: (record { 0 : null }) "parsing record with reserved field as record with null field";
+assert blob "DIDL\01\6b\01\00\70\01\00\00" == "(variant { 0 = null })" : (variant { 0 : reserved }) "variant with reserved field";
+assert blob "DIDL\01\6b\01\00\70\01\00\00"                            !: (variant { 0 : null }) "parsing variant with reserved field as variant with null field";
+assert blob "DIDL\01\6d\70\01\00\01" == "(vec { null })" : (vec reserved) "vector with reserved elements";
+assert blob "DIDL\01\6d\70\01\00\01"                    !: (vec null) "parsing vector with reserved elements as vector with null elements";
+assert blob "DIDL\01\6e\70\01\00\01" == "(opt null)" : (opt reserved) "optional reserved element";
+assert blob "DIDL\01\6e\70\01\00\01" == "(null)"     : (opt null) "parsing optional reserved element as optional null element";
+
+// missing data
+assert blob "DIDL\00\02\7d\7d\05\06" == "(5, 6)" : (nat, nat, opt nat) "parsing a top-level tuple into a longer top-level tuple";
+assert blob "DIDL\01\6c\01\00\7d\01\00\05" == "(record { 0 = 5 })" : (record { 1 : opt nat }) "parsing record with extra field that is less than the expected field";
+assert blob "DIDL\01\6c\01\01\7d\01\00\05" == "(record { 1 = 5 })" : (record { 0 : opt nat }) "parsing record with extra field that is greater than the expected field";
+
 // Future types
 // This uses 0x67 for the “future type”; bump (well, decrement) once that
 // becomes a concrete future type

--- a/test/construct.test.did
+++ b/test/construct.test.did
@@ -218,7 +218,7 @@ assert blob "DIDL\01\6e\70\01\00\01" == "(opt null)" : (opt reserved) "optional 
 assert blob "DIDL\01\6e\70\01\00\01" == "(null)"     : (opt null) "parsing optional reserved element as optional null element";
 
 // missing data
-assert blob "DIDL\00\02\7d\7d\05\06" == "(5, 6)" : (nat, nat, opt nat) "parsing a top-level tuple into a longer top-level tuple";
+assert blob "DIDL\00\02\7d\7d\05\06" == "(5, 6)" : (nat, nat, null) "parsing a top-level tuple into a longer top-level tuple";
 assert blob "DIDL\01\6c\01\00\7d\01\00\05" == "(record { 0 = 5 })" : (record { 1 : opt nat }) "parsing record with extra field that is less than the expected field";
 assert blob "DIDL\01\6c\01\01\7d\01\00\05" == "(record { 1 = 5 })" : (record { 0 : opt nat }) "parsing record with extra field that is greater than the expected field";
 


### PR DESCRIPTION
This PR makes decoding of a value of type `reserved` into type `null` always fail, consistently with the subtyping relation (`reserved` is not a subtype of `null`).

So far,
```
$ didc encode '(variant { foo = null })' -t '(variant { foo : reserved })' | didc decode -t '(variant { foo : null })'
Error: input: 4449444c016b01868eb70270010000_
table: type table0 = variant { 5_097_222 : reserved }
wire_type: reserved, expect_type: null

Caused by:
    0: Fail to decode argument 0 from table0 to variant { foo }
    1: Subtyping error: unit_variant
```
fails, but
```
$ didc encode '(null)' -t '(reserved)' | didc decode -t '(null)'
(null : null)
$ didc encode '(record { foo = null })' -t '(record { foo : reserved })' | didc decode -t '(record { foo : null })'
(record { foo = null : null })
```
both succeed. This behavior is inconsistent and this PR makes all such cases fail.

Additionally, the wire type of missing data is now set to `null` (instead of `reserved`) so that it can be successfully decoded to `null` as expected type.