### PR TITLE
fix: ignore inline comments or separated by newlines

### DIFF
--- a/rust/candid_parser/src/token.rs
+++ b/rust/candid_parser/src/token.rs
@@ -136,7 +136,6 @@ pub struct Tokenizer<'input> {
     lex: Lexer<'input, Token>,
     comment_buffer: Vec<String>,
     trivia: Option<TriviaMap>,
-    source: &'input str,
     last_comment_end: Option<usize>,
     last_token_line_end: Option<usize>,
 }
@@ -148,7 +147,6 @@ impl<'input> Tokenizer<'input> {
             lex,
             comment_buffer: vec![],
             trivia: None,
-            source: input,
             last_comment_end: None,
             last_token_line_end: None,
         }
@@ -160,7 +158,6 @@ impl<'input> Tokenizer<'input> {
             lex,
             comment_buffer: vec![],
             trivia: Some(trivia),
-            source: input,
             last_comment_end: None,
             last_token_line_end: None,
         }
@@ -168,11 +165,9 @@ impl<'input> Tokenizer<'input> {
 
     /// Count newlines between two positions in the source
     fn count_newlines_between(&self, start: usize, end: usize) -> usize {
-        if start < end && end <= self.source.len() {
-            self.source[start..end]
-                .chars()
-                .filter(|&c| c == '\n')
-                .count()
+        let source = self.lex.source();
+        if start < end && end <= source.len() {
+            source[start..end].chars().filter(|&c| c == '\n').count()
         } else {
             0
         }
@@ -195,10 +190,11 @@ impl<'input> Tokenizer<'input> {
 
     /// Find the end of the line containing the given position
     fn find_line_end(&self, pos: usize) -> usize {
-        self.source[pos..]
+        let source = self.lex.source();
+        source[pos..]
             .find('\n')
             .map(|offset| pos + offset)
-            .unwrap_or(self.source.len())
+            .unwrap_or(source.len())
     }
 }
 

--- a/rust/candid_parser/tests/assets/comment.did
+++ b/rust/candid_parser/tests/assets/comment.did
@@ -1,10 +1,19 @@
+// this comment should be ignored
+
+// this multi-line comment
+// should be ignored
+
+/* this block comment
+should be ignored
+*/
+
 // line comment
 /* gjkf
 jgfkg
 */
 //
 type id/**/ =/* gfj/*/**/*/
-*/ nat8;
+*/ nat8; // this comment should be ignored
 /*
 fgjgf
 //

--- a/rust/candid_parser/tests/test_doc_comments.rs
+++ b/rust/candid_parser/tests/test_doc_comments.rs
@@ -1,0 +1,127 @@
+use candid_parser::syntax::{Binding, Dec, IDLProg, IDLType, TypeField};
+
+#[test]
+fn test_doc_comments_separated_by_blank_line() {
+    // Test that comments separated by blank lines are not attached
+    let input = r#"
+// This comment is separated by a blank line
+// and should NOT be attached to the type
+
+type network = variant {
+  mainnet;
+  testnet;
+  regtest;
+};
+"#;
+
+    let prog: IDLProg = input.parse().unwrap();
+    let binding = extract_type_declaration(&prog.decs[0]);
+
+    assert_eq!(binding.id, "network");
+    assert!(
+        binding.docs.is_empty(),
+        "Comments separated by blank line should not be attached, but found: {:?}",
+        binding.docs
+    );
+}
+
+#[test]
+fn test_inline_comments_not_attached() {
+    // Test that inline comments are not attached to the next field
+    let input = r#"
+type network = variant {
+  mainnet;
+  testnet;  // Bitcoin testnet4.
+  regtest;
+};
+"#;
+
+    let prog: IDLProg = input.parse().unwrap();
+    let binding = extract_type_declaration(&prog.decs[0]);
+    assert_eq!(binding.id, "network");
+
+    // No field should have the inline comment
+    let fields = extract_variant_fields(&binding.typ);
+    assert_eq!(fields.len(), 3);
+    for field in fields {
+        assert!(
+            field.docs.is_empty(),
+            "Inline comment should not be attached to next field, but found: {:?} for field {}",
+            field.docs,
+            field.label
+        );
+    }
+}
+
+#[test]
+fn test_adjacent_comments_are_attached() {
+    // Test that adjacent comments (no blank line) are attached
+    let input = r#"
+// Doc comment for network
+type network = variant {
+  mainnet;
+  // Doc comment for testnet
+  testnet;
+  regtest;
+};
+"#;
+
+    let prog: IDLProg = input.parse().unwrap();
+    let binding = extract_type_declaration(&prog.decs[0]);
+
+    // Check that the network type has the doc comment attached
+    assert_eq!(binding.id, "network");
+    assert_eq!(
+        binding.docs.len(),
+        1,
+        "Adjacent comment should be attached to type"
+    );
+    assert_eq!(binding.docs[0], "Doc comment for network");
+
+    let fields = extract_variant_fields(&binding.typ);
+    assert_eq!(fields.len(), 3);
+
+    // Check that only the testnet field has the doc comment
+    for field in fields {
+        if format!("{}", field.label) == "testnet" {
+            assert_eq!(field.docs[0], "Doc comment for testnet");
+        } else {
+            assert!(field.docs.is_empty());
+        }
+    }
+}
+
+#[test]
+fn test_multiple_blank_lines() {
+    // Test that multiple blank lines prevent attachment
+    let input = r#"
+// Comment separated by multiple blank lines
+
+
+type my_type = nat;
+"#;
+
+    let prog: IDLProg = input.parse().unwrap();
+    let binding = extract_type_declaration(&prog.decs[0]);
+
+    assert_eq!(binding.id, "my_type");
+    assert!(
+        binding.docs.is_empty(),
+        "Comments separated by multiple blank lines should not be attached, but found: {:?}",
+        binding.docs
+    );
+}
+
+fn extract_type_declaration(dec: &Dec) -> &Binding {
+    if let Dec::TypD(binding) = dec {
+        return binding;
+    }
+    panic!("Expected a type declaration");
+}
+
+fn extract_variant_fields(typ: &IDLType) -> &[TypeField] {
+    if let IDLType::VariantT(fields) = typ {
+        return fields;
+    }
+    panic!("Expected a variant type");
+}


### PR DESCRIPTION
**Overview**
In the tokenizer, skips collecting inline comments and the comments that are separated from other comments/entities by newlines.
