### PR TITLE
fix: decode missing record fields of type null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* fix: missing record fields of type `null` in the textual format are decoded into a default value
+
 ## 2025-10-02
 
 ### candid_parser 0.2.2

--- a/rust/candid/src/types/value.rs
+++ b/rust/candid/src/types/value.rs
@@ -248,6 +248,7 @@ impl IDLValue {
                         .get(id.as_ref())
                         .cloned()
                         .or_else(|| match env.trace_type(ty).unwrap().as_ref() {
+                            TypeInner::Null => Some(&IDLValue::Null),
                             TypeInner::Opt(_) => Some(&IDLValue::None),
                             TypeInner::Reserved => Some(&IDLValue::Reserved),
                             _ => None,

--- a/test/construct.test.did
+++ b/test/construct.test.did
@@ -79,6 +79,7 @@ assert "(record { whatever = 0 })"  == "(record {})"                            
 assert blob "DIDL\01\6c\01\01\7c\01\00\2a"                                       !: (record {2:int}) "record: missing field";
 assert blob "DIDL\01\6c\01\01\7c\01\00\2a" == "(record { 2 = null })"             : (record {2:opt int}) "record: missing opt field";
 assert blob "DIDL\01\6c\00\01\00" == "(record { 2 = null })"                      : (record {2:null}) "record: missing null field";
+assert blob "DIDL\01\6c\00\01\00" == "(record { })"                               : (record {2:null}) "record: missing null field also in textual format";
 assert blob "DIDL\01\6c\02\00\7c\01\7e\01\00\2a\01" == "(record {42; true})"      : (record {int; bool}) "record: tuple";
 assert blob "DIDL\01\6c\02\00\7c\01\7e\01\00\2a\01" == "(record {1 = true})"      : (record {1:bool}) "record: ignore fields";
 assert blob "DIDL\01\6c\02\00\7c\01\7e\01\00\2a\01"                              !: (record {bool; int}) "record: type mismatch";


### PR DESCRIPTION
This PR fixes decoding of missing record fields of type `null` in the textual format, i.e., the following now works:
```
$ didc encode '(record {})' -t '(record { 0 : null })'
4449444c016c01007f0100
```