### PR TITLE
fix: escape `*/` to prevent premature JS doc comment termination

### DIFF
--- a/rust/candid_parser/src/bindings/typescript.rs
+++ b/rust/candid_parser/src/bindings/typescript.rs
@@ -246,14 +246,19 @@ fn pp_service<'a>(
     enclose_space("{", concat(methods, ","), "}")
 }
 
+/// Escapes doc comment content to prevent comment injection attacks.
+/// Replaces `*/` with `*\/` to prevent premature comment termination.
+fn escape_doc_comment(line: &str) -> String {
+    line.replace("*/", r"*\/")
+}
+
 fn pp_docs<'a>(docs: &'a [String]) -> RcDoc<'a> {
     if docs.is_empty() {
         RcDoc::nil()
     } else {
-        let docs = lines(
-            docs.iter()
-                .map(|line| RcDoc::text(DOC_COMMENT_LINE_PREFIX).append(line)),
-        );
+        let docs = lines(docs.iter().map(|line| {
+            RcDoc::text(DOC_COMMENT_LINE_PREFIX).append(RcDoc::text(escape_doc_comment(line)))
+        }));
         RcDoc::text(DOC_COMMENT_PREFIX)
             .append(RcDoc::hardline())
             .append(docs)

--- a/rust/candid_parser/tests/assets/malicious_doc.did
+++ b/rust/candid_parser/tests/assets/malicious_doc.did
@@ -1,0 +1,13 @@
+// */ import { malicious } from 'attacker'; console.log('injected!'); /*
+// Normal doc line
+// Another */ attempt /* to inject
+type MaliciousType = record {
+  // Doc comment for field with */ malicious code /* in it
+  field : text
+};
+
+// Service with */ malicious */ doc
+service : {
+  // Method with */ in doc comment
+  get : () -> (MaliciousType) query
+}

--- a/rust/candid_parser/tests/assets/ok/malicious_doc.d.ts
+++ b/rust/candid_parser/tests/assets/ok/malicious_doc.d.ts
@@ -1,0 +1,26 @@
+import type { Principal } from '@dfinity/principal';
+import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
+
+/**
+ * *\/ import { malicious } from 'attacker'; console.log('injected!'); /*
+ * Normal doc line
+ * Another *\/ attempt /* to inject
+ */
+export interface MaliciousType {
+  /**
+   * Doc comment for field with *\/ malicious code /* in it
+   */
+  'field' : string,
+}
+/**
+ * Service with *\/ malicious *\/ doc
+ */
+export interface _SERVICE {
+  /**
+   * Method with *\/ in doc comment
+   */
+  'get' : ActorMethod<[], MaliciousType>,
+}
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/malicious_doc.did
+++ b/rust/candid_parser/tests/assets/ok/malicious_doc.did
@@ -1,0 +1,12 @@
+// */ import { malicious } from 'attacker'; console.log('injected!'); /*
+// Normal doc line
+// Another */ attempt /* to inject
+type MaliciousType = record {
+  // Doc comment for field with */ malicious code /* in it
+  field : text;
+};
+// Service with */ malicious */ doc
+service : {
+  // Method with */ in doc comment
+  get : () -> (MaliciousType) query;
+}

--- a/rust/candid_parser/tests/assets/ok/malicious_doc.js
+++ b/rust/candid_parser/tests/assets/ok/malicious_doc.js
@@ -1,0 +1,5 @@
+export const idlFactory = ({ IDL }) => {
+  const MaliciousType = IDL.Record({ 'field' : IDL.Text });
+  return IDL.Service({ 'get' : IDL.Func([], [MaliciousType], ['query']) });
+};
+export const init = ({ IDL }) => { return []; };

--- a/rust/candid_parser/tests/assets/ok/malicious_doc.mo
+++ b/rust/candid_parser/tests/assets/ok/malicious_doc.mo
@@ -1,0 +1,17 @@
+// This is a generated Motoko binding.
+// Please use `import service "ic:canister_id"` instead to call canisters on the IC if possible.
+
+module {
+  /// */ import { malicious } from 'attacker'; console.log('injected!'); /*
+  /// Normal doc line
+  /// Another */ attempt /* to inject
+  public type MaliciousType = {
+    /// Doc comment for field with */ malicious code /* in it
+    field : Text;
+  };
+  /// Service with */ malicious */ doc
+  public type Self = actor {
+    /// Method with */ in doc comment
+    get : shared query () -> async MaliciousType;
+  }
+}

--- a/rust/candid_parser/tests/assets/ok/malicious_doc.rs
+++ b/rust/candid_parser/tests/assets/ok/malicious_doc.rs
@@ -1,0 +1,27 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+#![allow(dead_code, unused_imports)]
+use candid::{self, CandidType, Deserialize, Principal};
+use ic_cdk::api::call::CallResult as Result;
+
+/// */ import { malicious } from 'attacker'; console.log('injected!'); /*
+/// Normal doc line
+/// Another */ attempt /* to inject
+#[derive(CandidType, Deserialize)]
+pub struct MaliciousType {
+  /// Doc comment for field with */ malicious code /* in it
+  pub field: String,
+}
+
+/// Service with */ malicious */ doc
+pub struct Service(pub Principal);
+impl Service {
+  /// Method with */ in doc comment
+  pub async fn get(&self) -> Result<(MaliciousType,)> {
+    ic_cdk::call(self.0, "get", ()).await
+  }
+}
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
+pub const service : Service = Service(CANISTER_ID);
+


### PR DESCRIPTION
**Overview**
Cherry-pick of https://github.com/dfinity/icp-js-bindgen/pull/102.
