### PR TITLE
perf: avoid copying concatenated type tables

### DIFF
--- a/rust/candid/src/ser.rs
+++ b/rust/candid/src/ser.rs
@@ -427,7 +427,9 @@ impl TypeSerialize {
     #[doc(hidden)]
     pub fn serialize(&mut self) -> Result<()> {
         leb128_encode(&mut self.result, self.type_table.len() as u64)?;
-        self.result.append(&mut self.type_table.concat());
+        for entry in &self.type_table {
+            self.result.extend_from_slice(entry);
+        }
 
         leb128_encode(&mut self.result, self.args.len() as u64)?;
         let mut ty_encode = Vec::new();


### PR DESCRIPTION
**Overview**
Performance improvement

**Requirements**
None

**Solution**
Write serialized type-table entries directly into the output buffer instead of materializing an intermediate concatenated Vec.

**Considerations**
I expect only performance improvement and full forward and backward compatibility
