### PR TITLE
fix(candid_parser): emit `Float32` for Candid `float32` in Motoko binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### candid_parser
+
+* Bug fixes:
+  + Motoko binding: emit `Float32` for Candid `float32` instead of panicking. `float32` support was added to Motoko in version 1.4.0.
+
 ## 2026-04-08
 
 ### didc 0.6.1

--- a/rust/candid_parser/src/bindings/motoko.rs
+++ b/rust/candid_parser/src/bindings/motoko.rs
@@ -133,7 +133,7 @@ fn pp_ty(ty: &Type) -> RcDoc<'_> {
         Int16 => str("Int16"),
         Int32 => str("Int32"),
         Int64 => str("Int64"),
-        Float32 => panic!("float32 not supported in Motoko"),
+        Float32 => str("Float32"),
         Float64 => str("Float"),
         Text => str("Text"),
         Reserved => str("Any"),

--- a/rust/candid_parser/tests/assets/float.did
+++ b/rust/candid_parser/tests/assets/float.did
@@ -1,0 +1,5 @@
+service : {
+  to_f32 : (float64) -> (float32);
+  to_f64 : (float32) -> (float64);
+  identity32 : (float32) -> (float32);
+}

--- a/rust/candid_parser/tests/assets/ok/float.d.ts
+++ b/rust/candid_parser/tests/assets/ok/float.d.ts
@@ -1,0 +1,11 @@
+import type { Principal } from '@icp-sdk/core/principal';
+import type { ActorMethod } from '@icp-sdk/core/agent';
+import type { IDL } from '@icp-sdk/core/candid';
+
+export interface _SERVICE {
+  'identity32' : ActorMethod<[number], number>,
+  'to_f32' : ActorMethod<[number], number>,
+  'to_f64' : ActorMethod<[number], number>,
+}
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/candid_parser/tests/assets/ok/float.did
+++ b/rust/candid_parser/tests/assets/ok/float.did
@@ -1,0 +1,5 @@
+service : {
+  identity32 : (float32) -> (float32);
+  to_f32 : (float64) -> (float32);
+  to_f64 : (float32) -> (float64);
+}

--- a/rust/candid_parser/tests/assets/ok/float.js
+++ b/rust/candid_parser/tests/assets/ok/float.js
@@ -1,0 +1,8 @@
+export const idlFactory = ({ IDL }) => {
+  return IDL.Service({
+    'identity32' : IDL.Func([IDL.Float32], [IDL.Float32], []),
+    'to_f32' : IDL.Func([IDL.Float64], [IDL.Float32], []),
+    'to_f64' : IDL.Func([IDL.Float32], [IDL.Float64], []),
+  });
+};
+export const init = ({ IDL }) => { return []; };

--- a/rust/candid_parser/tests/assets/ok/float.mo
+++ b/rust/candid_parser/tests/assets/ok/float.mo
@@ -1,0 +1,10 @@
+// This is a generated Motoko binding.
+// Please use `import service "ic:canister_id"` instead to call canisters on the IC if possible.
+
+module {
+  public type Self = actor {
+    identity32 : shared Float32 -> async Float32;
+    to_f32 : shared Float -> async Float32;
+    to_f64 : shared Float32 -> async Float;
+  }
+}

--- a/rust/candid_parser/tests/assets/ok/float.rs
+++ b/rust/candid_parser/tests/assets/ok/float.rs
@@ -1,0 +1,22 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+#![allow(dead_code, unused_imports)]
+use candid::{self, CandidType, Deserialize, Principal};
+use ic_cdk::api::call::CallResult as Result;
+
+pub struct Service(pub Principal);
+impl Service {
+  pub async fn identity32(&self, arg0: &f32) -> Result<(f32,)> {
+    ic_cdk::call(self.0, "identity32", (arg0,)).await
+  }
+  pub async fn to_f32(&self, arg0: &f64) -> Result<(f32,)> {
+    ic_cdk::call(self.0, "to_f32", (arg0,)).await
+  }
+  pub async fn to_f64(&self, arg0: &f32) -> Result<(f64,)> {
+    ic_cdk::call(self.0, "to_f64", (arg0,)).await
+  }
+}
+/// Canister ID: `aaaaa-aa`
+pub const CANISTER_ID : Principal = Principal::from_slice(&[]);
+pub const service : Service = Service(CANISTER_ID);
+

--- a/rust/candid_parser/tests/assets/ok/float.rs
+++ b/rust/candid_parser/tests/assets/ok/float.rs
@@ -4,6 +4,7 @@
 use candid::{self, CandidType, Deserialize, Principal};
 use ic_cdk::api::call::CallResult as Result;
 
+
 pub struct Service(pub Principal);
 impl Service {
   pub async fn identity32(&self, arg0: &f32) -> Result<(f32,)> {


### PR DESCRIPTION
## Summary

- Replace `panic!("float32 not supported in Motoko")` with `str("Float32")` in the Motoko binding generator.
- Add a `float.did` test fixture covering `float32`/`float64` round-trip methods.

## Why

Motoko added `Float32` in version 1.4.0 ([dfinity/motoko#5906](https://github.com/dfinity/motoko/pull/5906)), updating both the import and export IDL mappings. The spec (`design/IDL-Motoko.md`) is being updated in a companion PR. This brings `didc bind --target mo` in line with what `moc` already does when importing `.did` files directly.

Concretely, any `.did` file using `float32` (e.g. the IC management canister interface) would previously cause `didc bind --target mo` to panic at runtime.