### PR TITLE
feat(candid_parser)!: parse and preserve named function arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2026-06-23
+
+### Candid 0.10.30
+
+* Non-breaking changes:
+  + Add `pretty::utils::sep_enclose` and `sep_enclose_space`: list/tuple pretty-printing combinators that separate items and enclose them in delimiters, emitting a trailing separator on multi-line layouts.
+  + Add `TypeEnv::to_sorted_iter()` to iterate bindings in a deterministic, key-sorted order.
+
+### candid_parser 0.4.0
+
+* Breaking changes:
+  + Parse and preserve **named function arguments and results**. The AST now carries argument names so consumers (e.g. binding generators) can emit meaningful parameter names:
+    - New `syntax::IDLArgType { typ: IDLType, name: Option<String> }` with `IDLArgType::new` / `IDLArgType::new_with_name`. Purely numeric names are normalized to `None`.
+    - `syntax::FuncType::{args, rets}`, `syntax::IDLType::ClassT`, `syntax::IDLTypes::args`, and `syntax::IDLInitArgs::args` now hold `Vec<IDLArgType>` instead of `Vec<IDLType>`.
+    - The pretty-printer now round-trips argument names (e.g. `(from : principal)`).
+  + Type checking is unchanged: names are dropped when lowering to `candid::types::Function`, so the `candid` crate is unaffected.
+
 ## 2026-05-27
 
 ### Candid 0.10.29

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,14 +209,14 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.29"
+version = "0.10.30"
 dependencies = [
  "anyhow",
  "bincode",
  "binread",
  "byteorder",
- "candid_derive 0.10.29",
- "candid_parser 0.3.2",
+ "candid_derive 0.10.30",
+ "candid_parser 0.4.0",
  "hex",
  "ic_principal 0.1.3",
  "leb128",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.29"
+version = "0.10.30"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.86",
@@ -276,11 +276,11 @@ dependencies = [
 
 [[package]]
 name = "candid_parser"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "candid 0.10.29",
+ "candid 0.10.30",
  "codespan-reporting",
  "console",
  "convert_case",
@@ -482,7 +482,7 @@ name = "didc"
 version = "0.6.1"
 dependencies = [
  "anyhow",
- "candid_parser 0.3.2",
+ "candid_parser 0.4.0",
  "clap",
  "console",
  "hex",

--- a/rust/bench/Cargo.lock
+++ b/rust/bench/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.29"
+version = "0.10.30"
 dependencies = [
  "anyhow",
  "binread",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.29"
+version = "0.10.30"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "candid_parser"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "candid",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "candid"
 # sync with the version in `candid_derive/Cargo.toml`
-version = "0.10.29"
+version = "0.10.30"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]
@@ -16,7 +16,7 @@ keywords = ["internet-computer", "idl", "candid", "dfinity"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-candid_derive = { path = "../candid_derive", version = "=0.10.29" }
+candid_derive = { path = "../candid_derive", version = "=0.10.30" }
 ic_principal = { path = "../ic_principal", version = "0.1.0" }
 binread = { version = "2.2", features = ["debug_template"] }
 byteorder = "1.5.0"

--- a/rust/candid/src/pretty/utils.rs
+++ b/rust/candid/src/pretty/utils.rs
@@ -1,4 +1,4 @@
-use pretty::RcDoc;
+use pretty::{RcAllocator, RcDoc};
 
 pub const INDENT_SPACE: isize = 2;
 pub const LINE_WIDTH: usize = 80;
@@ -88,6 +88,48 @@ pub fn quote_ident(id: &str) -> RcDoc<'_> {
         .append(format!("{}", id.escape_debug()))
         .append("'")
         .append(RcDoc::space())
+}
+
+/// Separate each item in `docs` with the separator `sep`, and enclose the result in `open` and `close`.
+/// When placed on multiple lines, the last element gets a trailing separator.
+pub fn sep_enclose<'a, D, S, O, C>(docs: D, sep: S, open: O, close: C) -> RcDoc<'a>
+where
+    D: IntoIterator<Item = RcDoc<'a>>,
+    S: pretty::Pretty<'a, RcAllocator>,
+    O: pretty::Pretty<'a, RcAllocator>,
+    C: pretty::Pretty<'a, RcAllocator>,
+{
+    let sep = sep.pretty(&RcAllocator);
+    let elems = RcDoc::intersperse(docs, sep.clone().append(RcDoc::line()));
+    open.pretty(&RcAllocator)
+        .into_doc()
+        .append(RcDoc::line_())
+        .append(elems)
+        .append(sep.flat_alt(RcDoc::nil()))
+        .nest(INDENT_SPACE)
+        .append(RcDoc::line_())
+        .append(close.pretty(&RcAllocator))
+        .group()
+}
+
+/// Like `sep_enclose`, but inserts a space between the opening delimiter and the first element,
+/// and between the last element and the closing delimiter when placed on a single line.
+pub fn sep_enclose_space<'a, D, S, O, C>(docs: D, sep: S, open: O, close: C) -> RcDoc<'a>
+where
+    D: IntoIterator<Item = RcDoc<'a>>,
+    S: pretty::Pretty<'a, RcAllocator>,
+    O: pretty::Pretty<'a, RcAllocator>,
+    C: pretty::Pretty<'a, RcAllocator>,
+{
+    let mut docs = docs.into_iter().peekable();
+    if docs.peek().is_none() {
+        return open.pretty(&RcAllocator).append(close).into_doc();
+    }
+    let open = open
+        .pretty(&RcAllocator)
+        .append(RcDoc::nil().flat_alt(RcDoc::space()));
+    let close = RcDoc::nil().flat_alt(RcDoc::space()).append(close);
+    sep_enclose(docs, sep, open, close)
 }
 
 #[cfg(test)]

--- a/rust/candid/src/types/type_env.rs
+++ b/rust/candid/src/types/type_env.rs
@@ -42,6 +42,11 @@ impl TypeEnv {
             Some(t) => Ok(t),
         }
     }
+    /// Iterate over the bindings in a deterministic, key-sorted order.
+    /// The backing map is already ordered by key, so this is a plain iteration.
+    pub fn to_sorted_iter(&self) -> impl Iterator<Item = (&String, &Type)> {
+        self.0.iter()
+    }
     pub fn rec_find_type(&self, name: &str) -> Result<&Type> {
         self.rec_find_type_with_depth(name, &RecursionDepth::new())
     }

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "candid_derive"
 # sync with the version in `candid/Cargo.toml`
-version = "0.10.29"
+version = "0.10.30"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]

--- a/rust/candid_parser/Cargo.toml
+++ b/rust/candid_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candid_parser"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]

--- a/rust/candid_parser/src/grammar.lalrpop
+++ b/rust/candid_parser/src/grammar.lalrpop
@@ -1,7 +1,7 @@
 use super::test::{Assert, Input, Test};
-use super::token::{Token, error2, LexicalError, Span, TriviaMap};
+use super::token::{Token, error, error2, LexicalError, Span, TriviaMap};
 use candid::{Principal, types::Label};
-use crate::syntax::{IDLType, PrimType, TypeField, FuncType, Binding, Dec, IDLProg, IDLTypes, IDLInitArgs, IDLActorType};
+use crate::syntax::{IDLType, PrimType, TypeField, FuncType, Binding, Dec, IDLProg, IDLTypes, IDLInitArgs, IDLArgType, IDLActorType};
 use candid::types::value::{IDLField, IDLValue, IDLArgs, VariantValue};
 use candid::types::{TypeEnv, FuncMode};
 use candid::utils::check_unique;
@@ -217,16 +217,22 @@ VariantFieldTyp: TypeField = {
     <doc_comment:DocComment> <id:FieldId> =>? Ok(TypeField { label: Label::Id(id), typ: IDLType::PrimT(PrimType::Null), docs: doc_comment.unwrap_or_default() }),
 }
 
-TupTyp: Vec<IDLType> = "(" <SepBy<ArgTyp, ",">> ")" => <>;
+TupTyp: Vec<IDLArgType> = "(" <SepBy<ArgTyp, ",">> ")" =>? {
+    let args = <>;
+    let mut named_args: Vec<String> = args.iter().filter_map(|a| a.name.clone()).collect();
+    named_args.sort();
+    check_unique(named_args.iter()).map_err(|e| error(e))?;
+    Ok(args)
+};
 
 FuncTyp: FuncType = {
     <args:TupTyp> "->" <rets:TupTyp> <modes:FuncMode*> =>
         FuncType { modes, args, rets },
 }
 
-ArgTyp: IDLType = {
-    Typ => <>,
-    Name ":" <Typ> => <>,
+ArgTyp: IDLArgType = {
+    <t:Typ> => IDLArgType::new(t),
+    <n:Name> ":" <t:Typ> => IDLArgType::new_with_name(t, n),
 }
 
 FuncMode: FuncMode = {

--- a/rust/candid_parser/src/grammar.lalrpop
+++ b/rust/candid_parser/src/grammar.lalrpop
@@ -1,5 +1,5 @@
 use super::test::{Assert, Input, Test};
-use super::token::{Token, error, error2, LexicalError, Span, TriviaMap};
+use super::token::{Token, error2, LexicalError, Span, TriviaMap};
 use candid::{Principal, types::Label};
 use crate::syntax::{IDLType, PrimType, TypeField, FuncType, Binding, Dec, IDLProg, IDLTypes, IDLInitArgs, IDLArgType, IDLActorType};
 use candid::types::value::{IDLField, IDLValue, IDLArgs, VariantValue};
@@ -217,12 +217,12 @@ VariantFieldTyp: TypeField = {
     <doc_comment:DocComment> <id:FieldId> =>? Ok(TypeField { label: Label::Id(id), typ: IDLType::PrimT(PrimType::Null), docs: doc_comment.unwrap_or_default() }),
 }
 
-TupTyp: Vec<IDLArgType> = "(" <SepBy<ArgTyp, ",">> ")" =>? {
-    let args = <>;
-    let mut named_args: Vec<String> = args.iter().filter_map(|a| a.name.clone()).collect();
+TupTyp: Vec<IDLArgType> = "(" <args:Sp<SepBy<ArgTyp, ",">>> ")" =>? {
+    let span = args.1.clone();
+    let mut named_args: Vec<String> = args.0.iter().filter_map(|a| a.name.clone()).collect();
     named_args.sort();
-    check_unique(named_args.iter()).map_err(|e| error(e))?;
-    Ok(args)
+    check_unique(named_args.iter()).map_err(|e| error2(e, span))?;
+    Ok(args.0)
 };
 
 FuncTyp: FuncType = {

--- a/rust/candid_parser/src/syntax/mod.rs
+++ b/rust/candid_parser/src/syntax/mod.rs
@@ -123,7 +123,7 @@ impl IDLArgType {
 
     /// Create a new IDLArgType with a name.
     /// If the name is an `u32` number, we set it to None
-    /// as we don't want to use it as a arg name.
+    /// as we don't want to use it as an arg name.
     pub fn new_with_name(typ: IDLType, name: String) -> Self {
         let name = if name.parse::<u32>().is_ok() {
             None

--- a/rust/candid_parser/src/syntax/mod.rs
+++ b/rust/candid_parser/src/syntax/mod.rs
@@ -20,7 +20,7 @@ pub enum IDLType {
     RecordT(Vec<TypeField>),
     VariantT(Vec<TypeField>),
     ServT(Vec<Binding>),
-    ClassT(Vec<IDLType>, Box<IDLType>),
+    ClassT(Vec<IDLArgType>, Box<IDLType>),
     PrincipalT,
 }
 
@@ -51,7 +51,7 @@ impl std::str::FromStr for IDLType {
 
 #[derive(Debug, Clone)]
 pub struct IDLTypes {
-    pub args: Vec<IDLType>,
+    pub args: Vec<IDLArgType>,
 }
 
 impl std::str::FromStr for IDLTypes {
@@ -106,8 +106,32 @@ pub enum PrimType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FuncType {
     pub modes: Vec<FuncMode>,
-    pub args: Vec<IDLType>,
-    pub rets: Vec<IDLType>,
+    pub args: Vec<IDLArgType>,
+    pub rets: Vec<IDLArgType>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IDLArgType {
+    pub typ: IDLType,
+    pub name: Option<String>,
+}
+
+impl IDLArgType {
+    pub fn new(typ: IDLType) -> Self {
+        Self { typ, name: None }
+    }
+
+    /// Create a new IDLArgType with a name.
+    /// If the name is an `u32` number, we set it to None
+    /// as we don't want to use it as a arg name.
+    pub fn new_with_name(typ: IDLType, name: String) -> Self {
+        let name = if name.parse::<u32>().is_ok() {
+            None
+        } else {
+            Some(name)
+        };
+        Self { typ, name }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -167,7 +191,7 @@ impl std::str::FromStr for IDLProg {
 #[derive(Debug)]
 pub struct IDLInitArgs {
     pub decs: Vec<Dec>,
-    pub args: Vec<IDLType>,
+    pub args: Vec<IDLArgType>,
 }
 
 impl std::str::FromStr for IDLInitArgs {

--- a/rust/candid_parser/src/syntax/pretty.rs
+++ b/rust/candid_parser/src/syntax/pretty.rs
@@ -5,7 +5,9 @@ use crate::{
         candid::{pp_docs, pp_label_raw, pp_modes, pp_text},
         utils::{concat, enclose, enclose_space, ident, kwd, lines, str, INDENT_SPACE, LINE_WIDTH},
     },
-    syntax::{Binding, FuncType, IDLActorType, IDLMergedProg, IDLType, PrimType, TypeField},
+    syntax::{
+        Binding, FuncType, IDLActorType, IDLArgType, IDLMergedProg, IDLType, PrimType, TypeField,
+    },
 };
 
 fn pp_ty(ty: &IDLType) -> RcDoc<'_> {
@@ -94,12 +96,19 @@ fn pp_method(func: &FuncType) -> RcDoc<'_> {
         .nest(INDENT_SPACE)
 }
 
-fn pp_args(args: &[IDLType]) -> RcDoc<'_> {
-    let doc = concat(args.iter().map(pp_ty), ",");
+fn pp_arg(arg: &IDLArgType) -> RcDoc<'_> {
+    match &arg.name {
+        Some(name) => pp_text(name).append(kwd(" :")).append(pp_ty(&arg.typ)),
+        None => pp_ty(&arg.typ),
+    }
+}
+
+fn pp_args(args: &[IDLArgType]) -> RcDoc<'_> {
+    let doc = concat(args.iter().map(pp_arg), ",");
     enclose("(", doc, ")")
 }
 
-fn pp_rets(rets: &[IDLType]) -> RcDoc<'_> {
+fn pp_rets(rets: &[IDLArgType]) -> RcDoc<'_> {
     pp_args(rets)
 }
 
@@ -123,7 +132,7 @@ fn pp_service_methods(methods: &[Binding]) -> RcDoc<'_> {
     enclose_space("{", doc, "}")
 }
 
-fn pp_class<'a>(args: &'a [IDLType], t: &'a IDLType) -> RcDoc<'a> {
+fn pp_class<'a>(args: &'a [IDLArgType], t: &'a IDLType) -> RcDoc<'a> {
     let doc = pp_args(args).append(" ->").append(RcDoc::space());
     match t {
         IDLType::ServT(ref serv) => doc.append(pp_service_methods(serv)),

--- a/rust/candid_parser/src/test.rs
+++ b/rust/candid_parser/src/test.rs
@@ -1,5 +1,5 @@
 use super::typing::check_prog;
-use crate::syntax::{Dec, IDLProg, IDLType};
+use crate::syntax::{Dec, IDLArgType, IDLProg};
 use crate::{Error, Result};
 use candid::types::value::IDLArgs;
 use candid::types::{Type, TypeEnv};
@@ -7,7 +7,7 @@ use candid::DecoderConfig;
 
 const DECODING_COST: usize = 20_000_000;
 
-type TupType = Vec<IDLType>;
+type TupType = Vec<IDLArgType>;
 
 pub struct Test {
     pub defs: Vec<Dec>,
@@ -158,7 +158,7 @@ pub fn check(test: Test) -> Result<()> {
         print!("Checking {} {}...", i + 1, assert.desc());
         let mut types = Vec::new();
         for ty in assert.typ.iter() {
-            types.push(super::typing::ast_to_type(&env, ty)?);
+            types.push(super::typing::ast_to_type(&env, &ty.typ)?);
         }
         let input = assert.left.parse(&env, &types);
         let pass = if let Some(assert_right) = &assert.right {

--- a/rust/candid_parser/src/typing.rs
+++ b/rust/candid_parser/src/typing.rs
@@ -74,11 +74,11 @@ pub fn check_type(env: &Env, t: &IDLType) -> Result<Type> {
         IDLType::FuncT(func) => {
             let mut t1 = Vec::new();
             for arg in func.args.iter() {
-                t1.push(check_type(env, arg)?);
+                t1.push(check_type(env, &arg.typ)?);
             }
             let mut t2 = Vec::new();
             for t in func.rets.iter() {
-                t2.push(check_type(env, t)?);
+                t2.push(check_type(env, &t.typ)?);
             }
             if func.modes.len() > 1 {
                 return Err(Error::msg("cannot have more than one mode"));
@@ -267,7 +267,7 @@ fn check_actor(env: &Env, actor: &Option<IDLActorType>) -> Result<Option<Type>> 
         Some(IDLType::ClassT(ts, t)) => {
             let mut args = Vec::new();
             for arg in ts.iter() {
-                args.push(check_type(env, arg)?);
+                args.push(check_type(env, &arg.typ)?);
             }
             let serv = check_type(env, t)?;
             env.te.as_service(&serv)?;
@@ -342,7 +342,7 @@ pub fn check_init_args(
     env.te.merge(main_env)?;
     let mut args = Vec::new();
     for arg in prog.args.iter() {
-        args.push(check_type(&env, arg)?);
+        args.push(check_type(&env, &arg.typ)?);
     }
     Ok(args)
 }

--- a/rust/candid_parser/tests/assets/ok/class.did
+++ b/rust/candid_parser/tests/assets/ok/class.did
@@ -1,7 +1,7 @@
 type Profile = record { age : nat8; name : text };
 type List = opt record { int; List };
 // Doc comment for class service
-service : (int, List, Profile) -> {
+service : (int, l : List, Profile) -> {
   // Doc comment for get method in class service
   get : () -> (List);
   set : (List) -> (List);

--- a/rust/candid_parser/tests/assets/ok/example.did
+++ b/rust/candid_parser/tests/assets/ok/example.did
@@ -10,7 +10,7 @@ type List = opt record {
 type f = func (List, func (int32) -> (int64)) -> (opt List, res);
 // Doc comment for broker service
 type broker = service {
-  find : (text) -> (service { current : () -> (nat32); up : () -> () });
+  find : (name : text) -> (service { current : () -> (nat32); up : () -> () });
 };
 // Doc comment for nested type
 type nested = record {
@@ -77,14 +77,14 @@ type tree = variant {
 };
 // Doc comment for service id
 type s = service { f : t; g : (list) -> (B, tree, stream) };
-type t = func (s) -> ();
+type t = func (server : s) -> ();
 type stream = opt record { head : nat; next : func () -> (stream) query };
 type b = record { int; nat };
 type a = variant { a; b : b };
 // Doc comment for service
 service : {
   // Doc comment for f1 method of service
-  f1 : (list, blob, opt bool) -> () oneway;
+  f1 : (list, test : blob, opt bool) -> () oneway;
   g1 : (my_type, List, opt List, nested) -> (int, broker, nested_res) query;
   h : (vec opt text, variant { A : nat; B : opt text }, opt List) -> (
       record {

--- a/rust/candid_parser/tests/assets/ok/fieldnat.did
+++ b/rust/candid_parser/tests/assets/ok/fieldnat.did
@@ -1,7 +1,7 @@
 type tuple = record { text; text };
 type non_tuple = record { 1 : text; 2 : text };
 service : {
-  bab : (int, nat) -> ();
+  bab : (two : int, nat) -> ();
   bar : (record { "2" : int }) -> (variant { e20; e30 });
   bas : (record { int; int }) -> (record { text; nat });
   baz : (record { 2 : int; "2" : nat }) -> (record {});

--- a/rust/candid_parser/tests/assets/ok/keyword.did
+++ b/rust/candid_parser/tests/assets/ok/keyword.did
@@ -6,7 +6,7 @@ type if = variant {
   leaf : int;
 };
 type return = service { f : t; g : (list) -> (if, stream) };
-type t = func (return) -> ();
+type t = func (server : return) -> ();
 type stream = opt record { head : nat; next : func () -> (stream) query };
 service : {
   Oneway : () -> () oneway;

--- a/rust/candid_parser/tests/assets/ok/recursion.did
+++ b/rust/candid_parser/tests/assets/ok/recursion.did
@@ -8,6 +8,6 @@ type tree = variant {
 };
 // Doc comment for service id
 type s = service { f : t; g : (list) -> (B, tree, stream) };
-type t = func (s) -> ();
+type t = func (server : s) -> ();
 type stream = opt record { head : nat; next : func () -> (stream) query };
 service : s

--- a/tools/didc/src/main.rs
+++ b/tools/didc/src/main.rs
@@ -131,7 +131,7 @@ impl TypeAnnotation {
             (Some(tys), None) => {
                 let mut types = Vec::new();
                 for ty in tys.args.iter() {
-                    types.push(ast_to_type(&env, ty)?);
+                    types.push(ast_to_type(&env, &ty.typ)?);
                 }
                 Ok((env, types))
             }


### PR DESCRIPTION
## Summary

Lets binding generators emit meaningful parameter names (`transfer(to, amount)` instead of `transfer(arg0, arg1)`) by capturing argument/result names in the `candid_parser` AST — **without changing the `candid` type model** (`candid` stays 0.10).

This is the subset of the `next` branch's named-args feature that the [icp-js-bindgen](https://github.com/dfinity/icp-js-bindgen) project needs, ported to `master` so it can depend on published releases instead of the floating `next` branch.

## Changes

### `candid_parser` — breaking (0.3.2 → 0.4.0)
- New `syntax::IDLArgType { typ: IDLType, name: Option<String> }` with `IDLArgType::new` / `new_with_name` (purely numeric names normalize to `None`).
- `FuncType::{args, rets}`, `IDLType::ClassT`, `IDLTypes::args`, and `IDLInitArgs::args` now hold `Vec<IDLArgType>` instead of `Vec<IDLType>`.
- Grammar captures named args (with a uniqueness check); the pretty-printer round-trips them (e.g. `(from : principal)`).
- **Type checking is unchanged** — names are dropped when lowering to `candid::types::Function`, so the `candid` crate's type model is unaffected.

### `candid` — non-breaking (0.10.29 → 0.10.30)
- Add `pretty::utils::sep_enclose` / `sep_enclose_space` (list/tuple combinators).
- Add `TypeEnv::to_sorted_iter()` for deterministic, key-sorted iteration.

## Test plan
- [x] `cargo test --workspace --all-features` (golden `.did` files updated to reflect preserved arg names)
- [x] `cargo clippy -p candid_parser --all-features`
- [x] Verified the consuming icp-js-bindgen crate builds against these changes (host + `wasm32-unknown-unknown`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)