### PR TITLE
feat: Add arm64 releases and update release format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,12 +94,16 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ matrix.asset_name }}
+      - name: Create tarball
+        run: |
+          chmod +x didc
+          tar czf ${{ matrix.asset_name }}.tar.gz didc
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: didc
-          asset_name: ${{ matrix.asset_name }}
+          file: ${{ matrix.asset_name }}.tar.gz
+          asset_name: ${{ matrix.asset_name }}.tar.gz
           tag: ${{ github.ref }}
 
   candid-ui:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.target
         run: rustup target add ${{ matrix.target}}
       - name: Set up musl
-        if: ${{ contains(matrix.os, 'ubuntu') && contains(matrix.target, 'musl') }}
+        if: ${{ contains(matrix.os, 'ubuntu') && contains(matrix.target, 'musl') && !matrix.cross }}
         run: sudo apt-get update -yy && sudo apt-get install -yy musl musl-dev musl-tools
       - name: Build
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,48 +12,47 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
-            name: linux64
-            artifact_name: target/x86_64-unknown-linux-musl/release/didc
-            asset_name: didc-linux64
-          - os: macos-15-intel
-            name: macos
-            artifact_name: target/release/didc
-            asset_name: didc-macos
-          - os: ubuntu-22.04
-            name: arm
-            artifact_name: target/arm-unknown-linux-gnueabihf/release/didc
-            asset_name: didc-arm32
+          - name: linux-x86_64
+            os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+            asset_name: didc-linux-x86_64
+          - name: macos-x86_64
+            os: macos-15-intel
+            asset_name: didc-macos-x86_64
+          - name: linux-arm32
+            os: ubuntu-22.04
+            cross: true
+            target: arm-unknown-linux-musleabihf
+            asset_name: didc-linux-arm32
+          - name: linux-arm64
+            os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-musl
+            asset_name: didc-linux-arm64
+          - name: macos-arm64
+            os: macos-15
+            asset_name: didc-macos-arm64
+
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install Rust toolchain
         run: rustup show active-toolchain || rustup toolchain install
-      - name: Add arm target
-        if: matrix.name == 'arm'
-        run: rustup target add arm-unknown-linux-gnueabihf
+      - name: Add target
+        if: matrix.target
+        run: rustup target add ${{ matrix.target}}
+      - name: Set up musl
+        if: ${{ contains(matrix.os, 'ubuntu') && contains(matrix.target, 'musl') }}
+        run: sudo apt-get update -yy && sudo apt-get install -yy musl musl-dev musl-tools
       - name: Build
-        if: matrix.name == 'linux64'
-        run: |
-          set -x
-          sudo apt-get update -yy
-          sudo apt-get install -yy musl musl-dev musl-tools
-          rustup target add x86_64-unknown-linux-musl
-          cargo build --package didc --release --locked --target x86_64-unknown-linux-musl
-      - name: Build
-        if: matrix.name == 'macos'
-        run: cargo build --package didc --release --locked
-      - name: Cross build
-        if: matrix.name == 'arm'
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
-          use-cross: true
+          use-cross: ${{ matrix.cross || 'false' }}
           command: build
-          args: --package didc --target arm-unknown-linux-gnueabihf --release --locked
+          args: --package didc ${{ matrix.target && format('--target {0}', matrix.target) || '' }} --release --locked
       - name: "Upload assets"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.asset_name }}
-          path: ${{ matrix.artifact_name }}
+          path: ${{ matrix.target && format('target/{0}/release/didc', matrix.target) || 'target/release/didc' }}
           retention-days: 3
   test:
     needs: build
@@ -64,9 +63,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            asset_name: didc-linux64
+            asset_name: didc-linux-x86_64
           - os: ubuntu-22.04
-            asset_name: didc-linux64
+            asset_name: didc-linux-x86_64
     steps:
       - name: Get executable
         id: download
@@ -83,10 +82,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - asset_name: didc-linux64
-          - asset_name: didc-arm32
-          - asset_name: didc-macos
+        asset_name:
+          - didc-linux-x86_64
+          - didc-linux-arm32
+          - didc-linux-arm64
+          - didc-macos-x86_64
+          - didc-macos-arm64
     runs-on: ubuntu-latest
     steps:
       - name: Get executable


### PR DESCRIPTION
This PR:
* adds aarch64-apple-darwin and aarch64-unknown-linux-musl targets, for M1 workflows
* changes the release artifact names to be more regular
* changes the release artifact format to be a tgz containing a bin, so you don't have to rename the bin on downloading it