### PR TITLE
ci: fix didc-release on musl with precise-builds

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -9,6 +9,10 @@ cargo-dist-version = "0.31.0"
 ci = "github"
 # The installers to generate for each app
 installers = ["shell"]
+# Build each app individually with `-p`, not the whole workspace with `--workspace`.
+# The workspace includes `didc-js` (a `cdylib` wasm crate) which can't be built for
+# musl, so a `--workspace` build aborts before producing the `didc` binary.
+precise-builds = true
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 # Path that installers should place binaries in


### PR DESCRIPTION
Fix https://github.com/dfinity/candid/actions/runs/28178275960/job/83460624957