### PR TITLE
feat: Add `Principal::as_fixed_bytes()` and `len()` (release ic_principal v0.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-07-02
+
+### ic_principal 0.1.4
+
+* Non-breaking changes:
+  + Add `Principal::as_fixed_bytes()`, returning a reference to the underlying fixed-size `[u8; MAX_LENGTH_IN_BYTES]` backing array. Bytes at index `len()` and beyond are always zero.
+  + Add `Principal::len()`, returning the number of significant bytes in the `Principal` (equivalent to `as_slice().len()`).
+
 ## 2026-06-25
 
 ### Candid 0.10.31

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
  "candid_derive 0.10.31",
  "candid_parser 0.4.0",
  "hex",
- "ic_principal 0.1.3",
+ "ic_principal 0.1.4",
  "leb128",
  "num-bigint",
  "num-traits",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "ic_principal"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/rust/bench/Cargo.lock
+++ b/rust/bench/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
 
 [[package]]
 name = "ic_principal"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/rust/candid/fuzz/Cargo.lock
+++ b/rust/candid/fuzz/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ic_principal"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/rust/ic_principal/Cargo.toml
+++ b/rust/ic_principal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic_principal"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 rust-version.workspace = true

--- a/rust/ic_principal/src/lib.rs
+++ b/rust/ic_principal/src/lib.rs
@@ -232,22 +232,36 @@ impl Principal {
         format!("{self}")
     }
 
-    /// Returns the [`Principal`]'s underlying slice of bytes.
+    /// Returns the [`Principal`]'s significant bytes as a slice: the first
+    /// [`len`](Self::len) bytes of the backing array, without the trailing
+    /// zero padding.
+    ///
+    /// Use [`as_fixed_bytes`](Self::as_fixed_bytes) to get the full,
+    /// fixed-size backing array instead.
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
         &self.bytes[..self.len as usize]
     }
 
-    /// Returns the [`Principal`]'s length.
+    /// Returns the number of significant bytes in the [`Principal`], between
+    /// `0` and [`MAX_LENGTH_IN_BYTES`](Self::MAX_LENGTH_IN_BYTES) inclusive.
+    ///
+    /// This equals the length of the slice returned by
+    /// [`as_slice`](Self::as_slice).
     #[inline]
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> u8 {
         self.len
     }
 
-    /// Returns the [`Principal`]'s underlying byte array.
+    /// Returns a reference to the [`Principal`]'s fixed-size backing array.
+    ///
+    /// The array is always [`MAX_LENGTH_IN_BYTES`](Self::MAX_LENGTH_IN_BYTES)
+    /// long; bytes from index [`len`](Self::len) onwards are always zero.
+    /// Prefer [`as_slice`](Self::as_slice) for the significant bytes without
+    /// padding.
     #[inline]
-    pub fn as_bytes(&self) -> &[u8; Self::MAX_LENGTH_IN_BYTES] {
+    pub fn as_fixed_bytes(&self) -> &[u8; Self::MAX_LENGTH_IN_BYTES] {
         &self.bytes
     }
 }

--- a/rust/ic_principal/src/lib.rs
+++ b/rust/ic_principal/src/lib.rs
@@ -232,10 +232,23 @@ impl Principal {
         format!("{self}")
     }
 
-    /// Return the [`Principal`]'s underlying slice of bytes.
+    /// Returns the [`Principal`]'s underlying slice of bytes.
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
         &self.bytes[..self.len as usize]
+    }
+
+    /// Returns the [`Principal`]'s length.
+    #[inline]
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> u8 {
+        self.len
+    }
+
+    /// Returns the [`Principal`]'s underlying byte array.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8; Self::MAX_LENGTH_IN_BYTES] {
+        &self.bytes
     }
 }
 

--- a/rust/ic_principal/tests/principal.rs
+++ b/rust/ic_principal/tests/principal.rs
@@ -333,3 +333,42 @@ fn as_slice_len_principal() {
     let from_text = Principal::from_text(TEST_CASE_TEXT).unwrap();
     assert_eq!(from_text.as_slice().len(), 9);
 }
+
+#[test]
+fn as_bytes() {
+    fn principal_bytes(slice: &[u8]) -> [u8; Principal::MAX_LENGTH_IN_BYTES] {
+        let mut bytes = [0; Principal::MAX_LENGTH_IN_BYTES];
+        bytes[..slice.len()].copy_from_slice(slice);
+        bytes
+    }
+
+    let anonymous_principal = Principal::anonymous();
+    assert_eq!(anonymous_principal.len(), 1);
+    assert_eq!(
+        anonymous_principal.as_bytes(),
+        &principal_bytes(&ANONYMOUS_CANISTER_BYTES[..])
+    );
+
+    let management_canister = Principal::management_canister();
+    assert_eq!(management_canister.len(), 0);
+    assert_eq!(
+        management_canister.as_bytes(),
+        &[0; Principal::MAX_LENGTH_IN_BYTES]
+    );
+
+    let key = b"42";
+    let self_authenticating = Principal::self_authenticating(key);
+    assert_eq!(self_authenticating.len(), 29);
+    assert_eq!(
+        self_authenticating.as_bytes(),
+        &principal_bytes(self_authenticating.as_slice())
+    );
+
+    let from_slice = Principal::from_slice(&TEST_CASE_BYTES);
+    assert_eq!(from_slice.len(), 9);
+    assert_eq!(from_slice.as_bytes(), &principal_bytes(&TEST_CASE_BYTES));
+
+    let from_text = Principal::from_text(TEST_CASE_TEXT).unwrap();
+    assert_eq!(from_text.len(), 9);
+    assert_eq!(from_text.as_bytes(), &principal_bytes(&TEST_CASE_BYTES));
+}

--- a/rust/ic_principal/tests/principal.rs
+++ b/rust/ic_principal/tests/principal.rs
@@ -335,7 +335,7 @@ fn as_slice_len_principal() {
 }
 
 #[test]
-fn as_bytes() {
+fn as_fixed_bytes() {
     fn principal_bytes(slice: &[u8]) -> [u8; Principal::MAX_LENGTH_IN_BYTES] {
         let mut bytes = [0; Principal::MAX_LENGTH_IN_BYTES];
         bytes[..slice.len()].copy_from_slice(slice);
@@ -345,14 +345,14 @@ fn as_bytes() {
     let anonymous_principal = Principal::anonymous();
     assert_eq!(anonymous_principal.len(), 1);
     assert_eq!(
-        anonymous_principal.as_bytes(),
+        anonymous_principal.as_fixed_bytes(),
         &principal_bytes(&ANONYMOUS_CANISTER_BYTES[..])
     );
 
     let management_canister = Principal::management_canister();
     assert_eq!(management_canister.len(), 0);
     assert_eq!(
-        management_canister.as_bytes(),
+        management_canister.as_fixed_bytes(),
         &[0; Principal::MAX_LENGTH_IN_BYTES]
     );
 
@@ -360,15 +360,21 @@ fn as_bytes() {
     let self_authenticating = Principal::self_authenticating(key);
     assert_eq!(self_authenticating.len(), 29);
     assert_eq!(
-        self_authenticating.as_bytes(),
+        self_authenticating.as_fixed_bytes(),
         &principal_bytes(self_authenticating.as_slice())
     );
 
     let from_slice = Principal::from_slice(&TEST_CASE_BYTES);
     assert_eq!(from_slice.len(), 9);
-    assert_eq!(from_slice.as_bytes(), &principal_bytes(&TEST_CASE_BYTES));
+    assert_eq!(
+        from_slice.as_fixed_bytes(),
+        &principal_bytes(&TEST_CASE_BYTES)
+    );
 
     let from_text = Principal::from_text(TEST_CASE_TEXT).unwrap();
     assert_eq!(from_text.len(), 9);
-    assert_eq!(from_text.as_bytes(), &principal_bytes(&TEST_CASE_BYTES));
+    assert_eq!(
+        from_text.as_fixed_bytes(),
+        &principal_bytes(&TEST_CASE_BYTES)
+    );
 }

--- a/tools/ui/Cargo.lock
+++ b/tools/ui/Cargo.lock
@@ -523,7 +523,7 @@ checksum = "c77c8932bff1f09502d0d8c079d5a206a06afe523e35e816162cf4d30b5bf80d"
 
 [[package]]
 name = "ic_principal"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arbitrary",
  "crc32fast",


### PR DESCRIPTION
Adds two public getters to `Principal` and releases them as **ic_principal v0.1.4**.

## Release

This is a release PR for `ic_principal` **v0.1.4**:
- Bumps the version `0.1.3` → `0.1.4` in `rust/ic_principal/Cargo.toml` and all four `Cargo.lock` files.
- Adds the `ic_principal 0.1.4` entry to `CHANGELOG.md`.

## What's new

- **`Principal::as_fixed_bytes() -> &[u8; MAX_LENGTH_IN_BYTES]`** — a reference to the fixed-size backing array. Because the length is known at compile time, this enables more efficient (`u64`-based) `CanisterId` equality checks. `CanisterId` is internally, for now, a `Principal` representation of a `u64`, so this makes a measurable difference when looking up e.g. `CanisterState`s on large subnets.
- **`Principal::len() -> u8`** — the number of significant bytes (equivalent to `as_slice().len()`).

Bytes at index `len()` and beyond are always zero; this is now documented as part of the API contract, since the derived `Eq`/`Hash` and the `u64`-based comparisons rely on it.

## Naming

Originally proposed as `as_bytes()`, renamed to **`as_fixed_bytes()`**. Ecosystem-wide, `as_bytes()` returns the *significant* bytes (`str::as_bytes`, `fixed-hash`), whereas this returns the full zero-padded `&[u8; N]` array — so `as_bytes()` would collide with that expectation and sit misleadingly next to `as_slice()`. `as_fixed_bytes()` matches the `fixed-hash` / `primitive-types` convention for a `&[u8; N]` accessor. (`as_ref()` was not viable — `Principal` already implements `AsRef<[u8]>` returning the slice.)

## Considered alternatives

`as_slice()` would also work for the comparison use case, but is marginally less efficient (runtime length rather than a compile-time-known array).
