### PR TITLE
feat: `const` getters for `Principal` (release `ic_principal` v0.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-07-03
+
+### ic_principal 0.1.5
+
+* Non-breaking changes:
+  + Make `Principal::as_slice()`, `Principal::len()` and `Principal::as_fixed_bytes()` const functions.
+
 ## 2026-07-02
 
 ### ic_principal 0.1.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
  "candid_derive 0.10.31",
  "candid_parser 0.4.0",
  "hex",
- "ic_principal 0.1.4",
+ "ic_principal 0.1.5",
  "leb128",
  "num-bigint",
  "num-traits",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "ic_principal"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/rust/bench/Cargo.lock
+++ b/rust/bench/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
 
 [[package]]
 name = "ic_principal"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/rust/candid/fuzz/Cargo.lock
+++ b/rust/candid/fuzz/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ic_principal"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/rust/ic_principal/Cargo.toml
+++ b/rust/ic_principal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic_principal"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 rust-version.workspace = true

--- a/rust/ic_principal/src/lib.rs
+++ b/rust/ic_principal/src/lib.rs
@@ -240,7 +240,7 @@ impl Principal {
     /// fixed-size backing array instead.
     #[inline]
     pub const fn as_slice(&self) -> &[u8] {
-        &self.bytes.split_at(self.len as usize).0
+        self.bytes.split_at(self.len as usize).0
     }
 
     /// Returns the number of significant bytes in the [`Principal`], between

--- a/rust/ic_principal/src/lib.rs
+++ b/rust/ic_principal/src/lib.rs
@@ -239,8 +239,8 @@ impl Principal {
     /// Use [`as_fixed_bytes`](Self::as_fixed_bytes) to get the full,
     /// fixed-size backing array instead.
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
-        &self.bytes[..self.len as usize]
+    pub const fn as_slice(&self) -> &[u8] {
+        &self.bytes.split_at(self.len as usize).0
     }
 
     /// Returns the number of significant bytes in the [`Principal`], between
@@ -250,7 +250,7 @@ impl Principal {
     /// [`as_slice`](Self::as_slice).
     #[inline]
     #[allow(clippy::len_without_is_empty)]
-    pub fn len(&self) -> u8 {
+    pub const fn len(&self) -> u8 {
         self.len
     }
 
@@ -261,7 +261,7 @@ impl Principal {
     /// Prefer [`as_slice`](Self::as_slice) for the significant bytes without
     /// padding.
     #[inline]
-    pub fn as_fixed_bytes(&self) -> &[u8; Self::MAX_LENGTH_IN_BYTES] {
+    pub const fn as_fixed_bytes(&self) -> &[u8; Self::MAX_LENGTH_IN_BYTES] {
         &self.bytes
     }
 }

--- a/tools/ui/Cargo.lock
+++ b/tools/ui/Cargo.lock
@@ -523,7 +523,7 @@ checksum = "c77c8932bff1f09502d0d8c079d5a206a06afe523e35e816162cf4d30b5bf80d"
 
 [[package]]
 name = "ic_principal"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arbitrary",
  "crc32fast",


### PR DESCRIPTION
Make the `Principal` getters `const`. This allows for further downstream optimizations.

## Release

This is a release PR for `ic_principal` **v0.1.5**:
- Bumps the version `0.1.4` → `0.1.5` in `rust/ic_principal/Cargo.toml` and all four `Cargo.lock` files.
- Adds the `ic_principal 0.1.5` entry to `CHANGELOG.md`.

## What's new

- `Principal::as_slice()`, `Principal::len()` and `Principal::as_fixed_bytes()` are now `const fn`. This allows for further downstream optimizations.