### PR TITLE
feat(ui): support `icp.net` domain for Internet Identity login

### DIFF
--- a/tools/ui/src/auth/auth.ts
+++ b/tools/ui/src/auth/auth.ts
@@ -41,7 +41,9 @@ async function insertLoginForm() {
 
   try {
     const params = new URLSearchParams(window.location.search);
-    const is_mainnet = window.location.hostname.endsWith("icp0.io") || window.location.hostname.endsWith("ic0.app");
+    const mainnet_domains = ["icp0.io", "ic0.app", "icp.net"];
+    const mainnet_domain = mainnet_domains.find((domain) => window.location.hostname.endsWith(domain));
+    const is_mainnet = mainnet_domain !== undefined;
     let provider = params.get("ii");
     if (is_mainnet && !provider) {
       provider = "https://identity.internetcomputer.org";
@@ -56,7 +58,7 @@ async function insertLoginForm() {
     const cid = Principal.fromText(params.get("id")!);
     let origin = params.get("origin");
     if (!origin && is_mainnet && await check_alternative_origin()) {
-      origin = `https://${cid.toText()}.icp0.io`;
+      origin = `https://${cid.toText()}.${mainnet_domain}`;
     }
     if (origin) {
       if (!is_valid_url(origin)) {


### PR DESCRIPTION
## Problem

The Candid UI did not support the new `icp.net` domain for Internet Identity (II) login. The mainnet-detection logic in the login form only recognized `icp0.io` and `ic0.app` as mainnet hostnames. As a result, when the Candid UI is served from `<canisterId>.icp.net`:

- II login was **not** offered (no default identity provider was selected), and
- `derivationOrigin` was not derived, breaking alternative-origins-based login.

## Change

In [`tools/ui/src/auth/auth.ts`](tools/ui/src/auth/auth.ts):

- Replace the two hard-coded `icp0.io` / `ic0.app` suffix checks with a `mainnet_domains` list that now also includes `icp.net`.
- Derive the `derivationOrigin` from whichever mainnet domain the UI is actually served on (`https://<canisterId>.<matched-domain>`) instead of hard-coding `icp0.io`. This keeps the derivation origin consistent with the domain the user is on for all supported domains.

## Testing

- `npx tsc --noEmit` — passes.
- `npm run build` (vite) — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)