### PR TITLE
chore: migrate from binread to binrw + release candid 0.10.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Candid 0.10.33
 
 * Breaking changes:
-  + Migrated from the deprecated [`binread`](https://github.com/jam1garner/binread) crate to its successor `binrw`. The types in the public `candid::binary_parser` module (`Header`, `PrincipalBytes`, `Len`, `BoolValue`) now implement `binrw::BinRead` instead of `binread::BinRead`, and `From<binread::Error> for candid::Error` is replaced by `From<binrw::Error>`. Decoder error messages and byte offsets are unchanged. Only code that names those trait impls directly is affected; ordinary encoding and decoding is not.
+  + Migrated from the deprecated [`binread`](https://github.com/jam1garner/binread) crate to its successor `binrw`. The types in the `candid::binary_parser` module (`Header`, `PrincipalBytes`, `Len`, `BoolValue`) now implement `binrw::BinRead` instead of `binread::BinRead`, and `From<binread::Error> for candid::Error` is replaced by `From<binrw::Error>`.
+
+    Released as a patch rather than a minor bump because the affected surface is limited to those trait impls. `binary_parser` is an internal wire-format parsing module that is `pub` only incidentally — it is used nowhere outside candid's own deserializer, and it is now `#[doc(hidden)]` to say so. Code is affected only if it depends on `binread` directly *and* names these impls; the wire format, decoder error messages, byte offsets, type layouts, and all function signatures are unchanged, so the worst case is a compile error rather than a behaviour change.
 
 * Non-breaking changes:
   + Decoding is faster as a side effect of the `binrw` migration, which drops `binread`'s `debug_template` codegen: up to 37% fewer instructions on variant-heavy payloads (`multi_arg` −36.6%, `result_variant` −10.3%, `large_variant` −9.5%, `subtype_decode` −8.0%, `double_option` −7.0%), with no regressions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-07-27
+
+### Candid 0.10.33
+
+* Breaking changes:
+  + Migrated from the deprecated [`binread`](https://github.com/jam1garner/binread) crate to its successor `binrw`. The types in the public `candid::binary_parser` module (`Header`, `PrincipalBytes`, `Len`, `BoolValue`) now implement `binrw::BinRead` instead of `binread::BinRead`, and `From<binread::Error> for candid::Error` is replaced by `From<binrw::Error>`. Decoder error messages and byte offsets are unchanged. Only code that names those trait impls directly is affected; ordinary encoding and decoding is not.
+
+* Non-breaking changes:
+  + Decoding is faster as a side effect of the `binrw` migration, which drops `binread`'s `debug_template` codegen: up to 37% fewer instructions on variant-heavy payloads (`multi_arg` −36.6%, `result_variant` −10.3%, `large_variant` −9.5%, `subtype_decode` −8.0%, `double_option` −7.0%), with no regressions.
+  + Dropped the duplicate `syn 1.x` dependency tree that `binread_derive` pinned (along with `rustversion`).
+  + A future unrecognized `binrw::Error` variant now degrades to a label-less error instead of panicking, since `binrw::Error` is `#[non_exhaustive]` and decoding runs on untrusted input.
+
 ## 2026-07-06
 
 ### Candid 0.10.32

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +138,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "binrw"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad120d555272286c1017d25165ab8bd74806f13fc85b258484ec7e4ce75458f"
+dependencies = [
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
+]
+
+[[package]]
+name = "binrw_derive"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df92e0e9baae4dc82c7bad7715ca40c0a5c71539057bf2ea04a5c29c980410b"
+dependencies = [
+ "either",
+ "owo-colors",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,7 +249,7 @@ version = "0.10.32"
 dependencies = [
  "anyhow",
  "bincode",
- "binread",
+ "binrw",
  "byteorder",
  "candid_derive 0.10.32",
  "candid_parser 0.4.0",
@@ -974,6 +1010,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6df92e0e9baae4dc82c7bad7715ca40c0a5c71539057bf2ea04a5c29c980410b"
 dependencies = [
  "either",
- "owo-colors",
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 2.0.87",
@@ -245,13 +244,13 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.32"
+version = "0.10.33"
 dependencies = [
  "anyhow",
  "bincode",
  "binrw",
  "byteorder",
- "candid_derive 0.10.32",
+ "candid_derive 0.10.33",
  "candid_parser 0.4.0",
  "hex",
  "ic_principal 0.1.5",
@@ -283,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.32"
+version = "0.10.33"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.86",
@@ -316,7 +315,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "candid 0.10.32",
+ "candid 0.10.33",
  "codespan-reporting",
  "console",
  "convert_case",
@@ -1010,12 +1009,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"

--- a/rust/bench/Cargo.lock
+++ b/rust/bench/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,26 +79,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "binread"
-version = "2.2.0"
+name = "binrw"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16598dfc8e6578e9b597d9910ba2e73618385dc9f4b1d43dd92c349d6be6418f"
+checksum = "6ad120d555272286c1017d25165ab8bd74806f13fc85b258484ec7e4ce75458f"
 dependencies = [
- "binread_derive",
- "lazy_static",
- "rustversion",
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
 ]
 
 [[package]]
-name = "binread_derive"
-version = "2.1.0"
+name = "binrw_derive"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9672209df1714ee804b1f4d4f68c8eb2a90b1f7a07acf472f88ce198ef1fed"
+checksum = "6df92e0e9baae4dc82c7bad7715ca40c0a5c71539057bf2ea04a5c29c980410b"
 dependencies = [
  "either",
+ "owo-colors",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -124,6 +131,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -159,7 +172,7 @@ name = "candid"
 version = "0.10.32"
 dependencies = [
  "anyhow",
- "binread",
+ "binrw",
  "byteorder",
  "candid_derive",
  "hex",
@@ -719,6 +732,12 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"

--- a/rust/bench/Cargo.lock
+++ b/rust/bench/Cargo.lock
@@ -96,7 +96,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6df92e0e9baae4dc82c7bad7715ca40c0a5c71539057bf2ea04a5c29c980410b"
 dependencies = [
  "either",
- "owo-colors",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -169,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.32"
+version = "0.10.33"
 dependencies = [
  "anyhow",
  "binrw",
@@ -190,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.32"
+version = "0.10.33"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -732,12 +731,6 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -18,7 +18,7 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 [dependencies]
 candid_derive = { path = "../candid_derive", version = "=0.10.32" }
 ic_principal = { path = "../ic_principal", version = "0.1.0" }
-binread = { version = "2.2", features = ["debug_template"] }
+binrw = "0.15"
 byteorder = "1.5.0"
 leb128 = "0.2.5"
 paste = "1.0"

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "candid"
 # sync with the version in `candid_derive/Cargo.toml`
-version = "0.10.32"
+version = "0.10.33"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]
@@ -16,9 +16,11 @@ keywords = ["internet-computer", "idl", "candid", "dfinity"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-candid_derive = { path = "../candid_derive", version = "=0.10.32" }
+candid_derive = { path = "../candid_derive", version = "=0.10.33" }
 ic_principal = { path = "../ic_principal", version = "0.1.0" }
-binrw = "0.15"
+# `verbose-backtrace` (a default feature) pulls in `owo-colors` and generates
+# backtrace frames that `get_binread_labels` discards, so keep it off.
+binrw = { version = "0.15", default-features = false, features = ["std"] }
 byteorder = "1.5.0"
 leb128 = "0.2.5"
 paste = "1.0"

--- a/rust/candid/fuzz/Cargo.lock
+++ b/rust/candid/fuzz/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,26 +33,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "binread"
-version = "2.2.0"
+name = "binrw"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16598dfc8e6578e9b597d9910ba2e73618385dc9f4b1d43dd92c349d6be6418f"
+checksum = "6ad120d555272286c1017d25165ab8bd74806f13fc85b258484ec7e4ce75458f"
 dependencies = [
- "binread_derive",
- "lazy_static",
- "rustversion",
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
 ]
 
 [[package]]
-name = "binread_derive"
-version = "2.1.0"
+name = "binrw_derive"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9672209df1714ee804b1f4d4f68c8eb2a90b1f7a07acf472f88ce198ef1fed"
+checksum = "6df92e0e9baae4dc82c7bad7715ca40c0a5c71539057bf2ea04a5c29c980410b"
 dependencies = [
  "either",
+ "owo-colors",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -59,6 +66,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,10 +79,10 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "candid"
-version = "0.10.27"
+version = "0.10.32"
 dependencies = [
  "anyhow",
- "binread",
+ "binrw",
  "byteorder",
  "candid_derive",
  "hex",
@@ -97,12 +110,12 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.27"
+version = "0.10.32"
 dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -274,6 +287,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,12 +337,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
-
-[[package]]
 name = "serde"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,7 +362,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -374,17 +387,6 @@ dependencies = [
  "libc",
  "psm",
  "winapi",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -415,7 +417,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]

--- a/rust/candid/fuzz/Cargo.lock
+++ b/rust/candid/fuzz/Cargo.lock
@@ -50,7 +50,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6df92e0e9baae4dc82c7bad7715ca40c0a5c71539057bf2ea04a5c29c980410b"
 dependencies = [
  "either",
- "owo-colors",
  "proc-macro2",
  "quote",
  "syn",
@@ -79,7 +78,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "candid"
-version = "0.10.32"
+version = "0.10.33"
 dependencies = [
  "anyhow",
  "binrw",
@@ -110,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.32"
+version = "0.10.33"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -285,12 +284,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "paste"

--- a/rust/candid/src/binary_parser.rs
+++ b/rust/candid/src/binary_parser.rs
@@ -154,8 +154,7 @@ pub struct BoolValue(
 );
 #[derive(BinRead)]
 pub struct Len(
-    #[br(parse_with = read_leb_usize, args("len", "length out of usize range"))]
-    pub usize,
+    #[br(parse_with = read_leb_usize, args("len", "length out of usize range"))] pub usize,
 );
 #[derive(BinRead)]
 pub struct PrincipalBytes {

--- a/rust/candid/src/binary_parser.rs
+++ b/rust/candid/src/binary_parser.rs
@@ -1,24 +1,49 @@
 use crate::types::internal::{Field, Function, Label, Type, TypeInner};
 use crate::types::{FuncMode, TypeEnv};
 use anyhow::{anyhow, Context, Result};
-use binread::io::{Read, Seek};
-use binread::{BinRead, BinResult, Error as BError, ReadOptions};
+use binrw::{BinRead, BinResult, Error as BError};
 use std::convert::TryInto;
 
 const MAX_TYPE_TABLE_LEN: u64 = 10_000; // Max type entries
 
-fn read_leb<R: Read + Seek>(reader: &mut R, ro: &ReadOptions, (): ()) -> BinResult<u64> {
+#[binrw::parser(reader)]
+fn read_leb(name: &'static str) -> BinResult<u64> {
     let pos = reader.stream_position()?;
     leb128::read::unsigned(reader).map_err(|_| BError::Custom {
         pos,
-        err: Box::new(ro.variable_name.unwrap_or("Invalid leb128")),
+        err: Box::new(name),
     })
 }
-fn read_sleb<R: Read + Seek>(reader: &mut R, ro: &ReadOptions, (): ()) -> BinResult<i64> {
+#[binrw::parser(reader)]
+fn read_sleb(name: &'static str) -> BinResult<i64> {
     let pos = reader.stream_position()?;
     leb128::read::signed(reader).map_err(|_| BError::Custom {
         pos,
-        err: Box::new(ro.variable_name.unwrap_or("Invalid sleb128")),
+        err: Box::new(name),
+    })
+}
+#[binrw::parser(reader)]
+fn read_leb_u32(name: &'static str, range_msg: &'static str) -> BinResult<u32> {
+    let pos = reader.stream_position()?;
+    let v = leb128::read::unsigned(reader).map_err(|_| BError::Custom {
+        pos,
+        err: Box::new(name),
+    })?;
+    v.try_into().map_err(|_| BError::Custom {
+        pos,
+        err: Box::new(range_msg),
+    })
+}
+#[binrw::parser(reader)]
+fn read_leb_usize(name: &'static str, range_msg: &'static str) -> BinResult<usize> {
+    let pos = reader.stream_position()?;
+    let v = leb128::read::unsigned(reader).map_err(|_| BError::Custom {
+        pos,
+        err: Box::new(name),
+    })?;
+    v.try_into().map_err(|_| BError::Custom {
+        pos,
+        err: Box::new(range_msg),
     })
 }
 
@@ -28,7 +53,7 @@ fn read_sleb<R: Read + Seek>(reader: &mut R, ro: &ReadOptions, (): ()) -> BinRes
 pub struct Header {
     #[br(args(max_type_len))]
     table: Table,
-    #[br(parse_with = read_leb)]
+    #[br(parse_with = read_leb, args("len"))]
     len: u64,
     #[br(count = len)]
     args: Vec<IndexType>,
@@ -37,7 +62,7 @@ pub struct Header {
 #[derive(BinRead, Debug)]
 #[br(import(max_type_len: Option<usize>))]
 struct Table {
-    #[br(parse_with = read_leb)]
+    #[br(parse_with = read_leb, args("len"))]
     #[br(assert(len <= max_type_len.unwrap_or(MAX_TYPE_TABLE_LEN as usize) as u64, "type table size exceeded"))]
     len: u64,
     #[br(count = len)]
@@ -61,29 +86,29 @@ enum ConsType {
 }
 #[derive(BinRead, Debug)]
 struct IndexType {
-    #[br(parse_with = read_sleb, assert(index >= -17 || index == -24, "unknown opcode {}", index))]
+    #[br(parse_with = read_sleb, args("index"), assert(index >= -17 || index == -24, "unknown opcode {}", index))]
     index: i64,
 }
 #[derive(BinRead, Debug)]
 struct Fields {
-    #[br(parse_with = read_leb, try_map = |x:u64| x.try_into().map_err(|_| "field length out of 32-bit range"))]
+    #[br(parse_with = read_leb_u32, args("len", "field length out of 32-bit range"))]
     len: u32,
     #[br(count = len)]
     inner: Vec<FieldType>,
 }
 #[derive(BinRead, Debug)]
 struct FieldType {
-    #[br(parse_with = read_leb, try_map = |x:u64| x.try_into().map_err(|_| "field id out of 32-bit range"))]
+    #[br(parse_with = read_leb_u32, args("id", "field id out of 32-bit range"))]
     id: u32,
     index: IndexType,
 }
 #[derive(BinRead, Debug)]
 struct FuncType {
-    #[br(parse_with = read_leb)]
+    #[br(parse_with = read_leb, args("arg_len"))]
     arg_len: u64,
     #[br(count = arg_len)]
     args: Vec<IndexType>,
-    #[br(parse_with = read_leb)]
+    #[br(parse_with = read_leb, args("ret_len"))]
     ret_len: u64,
     #[br(count = ret_len)]
     rets: Vec<IndexType>,
@@ -94,23 +119,23 @@ struct FuncType {
 }
 #[derive(BinRead, Debug)]
 struct ServType {
-    #[br(parse_with = read_leb)]
+    #[br(parse_with = read_leb, args("len"))]
     len: u64,
     #[br(count = len)]
     meths: Vec<Meths>,
 }
 #[derive(BinRead, Debug)]
 struct FutureType {
-    #[br(parse_with = read_sleb, assert(opcode < -24, "{} is not a valid future type", opcode))]
+    #[br(parse_with = read_sleb, args("opcode"), assert(opcode < -24, "{} is not a valid future type", opcode))]
     opcode: i64,
-    #[br(parse_with = read_leb)]
+    #[br(parse_with = read_leb, args("len"))]
     len: u64,
     #[br(count = len)]
     blob: Vec<u8>,
 }
 #[derive(BinRead, Debug)]
 struct Meths {
-    #[br(parse_with = read_leb)]
+    #[br(parse_with = read_leb, args("len"))]
     len: u64,
     #[br(count = len, try_map = |x:Vec<u8>| String::from_utf8(x).map_err(|_| "invalid utf8"))]
     name: String,
@@ -129,14 +154,14 @@ pub struct BoolValue(
 );
 #[derive(BinRead)]
 pub struct Len(
-    #[br(parse_with = read_leb, try_map = |x:u64| x.try_into().map_err(|_| "length out of usize range"))]
+    #[br(parse_with = read_leb_usize, args("len", "length out of usize range"))]
     pub usize,
 );
 #[derive(BinRead)]
 pub struct PrincipalBytes {
     #[br(assert(flag == 1u8, "Opaque reference not supported"))]
     pub flag: u8,
-    #[br(parse_with = read_leb, assert(len <= 29, "Principal is longer than 29 bytes"))]
+    #[br(parse_with = read_leb, args("len"), assert(len <= 29, "Principal is longer than 29 bytes"))]
     pub len: u64,
     #[br(count = len)]
     pub inner: Vec<u8>,

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -13,7 +13,7 @@ use crate::{
     types::subtype::{subtype_with_config, Gamma, OptReport},
 };
 use anyhow::{anyhow, Context};
-use binread::BinRead;
+use binrw::BinRead;
 use byteorder::{LittleEndian, ReadBytesExt};
 use serde::de::{self, Visitor};
 use std::fmt::Write;
@@ -311,7 +311,7 @@ struct Deserializer<'de> {
 impl<'de> Deserializer<'de> {
     fn from_bytes(bytes: &'de [u8], config: &DecoderConfig) -> Result<Self> {
         let mut reader = Cursor::new(bytes);
-        let header = Header::read_args(&mut reader, (config.max_type_len,))?;
+        let header = Header::read_le_args(&mut reader, (config.max_type_len,))?;
         let (env, types) = header.to_types()?;
         Ok(Deserializer {
             input: reader,
@@ -635,7 +635,7 @@ impl<'de> Deserializer<'de> {
             "principal"
         );
         let mut bytes = vec![2u8];
-        let id = PrincipalBytes::read(&mut self.input)?;
+        let id = PrincipalBytes::read_le(&mut self.input)?;
         self.add_cost(std::cmp::max(30, id.len as usize))?;
         bytes.extend_from_slice(&id.inner);
         visitor.visit_byte_buf(bytes)
@@ -655,7 +655,7 @@ impl<'de> Deserializer<'de> {
         self.unroll_type()?;
         self.check_subtype()?;
         let mut bytes = vec![4u8];
-        let id = PrincipalBytes::read(&mut self.input)?;
+        let id = PrincipalBytes::read_le(&mut self.input)?;
         self.add_cost(std::cmp::max(30, id.len as usize))?;
         bytes.extend_from_slice(&id.inner);
         visitor.visit_byte_buf(bytes)
@@ -670,7 +670,7 @@ impl<'de> Deserializer<'de> {
             return Err(Error::msg("Opaque reference not supported"));
         }
         let mut bytes = vec![5u8];
-        let id = PrincipalBytes::read(&mut self.input)?;
+        let id = PrincipalBytes::read_le(&mut self.input)?;
         let len = self.read_len()?;
         let meth = self.borrow_bytes(len)?;
         self.add_cost(
@@ -1378,7 +1378,7 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
         self.add_cost(1)?;
         match (self.expect_type.as_ref(), self.wire_type.as_ref()) {
             (TypeInner::Variant(e), TypeInner::Variant(w)) => {
-                let index = Len::read(&mut self.input)?.0;
+                let index = Len::read_le(&mut self.input)?.0;
                 let len = w.len();
                 if index >= len {
                     return Err(Error::msg(format!(

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -35,7 +35,7 @@ impl<'de> IDLDeserialize<'de> {
     pub fn new_with_config(bytes: &'de [u8], config: &DecoderConfig) -> Result<Self> {
         let mut de = Deserializer::from_bytes(bytes, config).with_context(|| {
             if config.full_error_message || bytes.len() <= 500 {
-                format!("Cannot parse header {}", &hex::encode(bytes))
+                format!("Cannot parse header {}", hex::encode(bytes))
             } else {
                 "Cannot parse header".to_string()
             }

--- a/rust/candid/src/error.rs
+++ b/rust/candid/src/error.rs
@@ -37,18 +37,18 @@ impl Error {
     }
 }
 
-fn get_binread_labels(e: &binread::Error) -> Vec<Label> {
-    use binread::Error::*;
+fn get_binread_labels(e: &binrw::Error) -> Vec<Label> {
+    use binrw::Error::*;
     match e {
         BadMagic { pos, .. } => {
-            let pos = (pos * 2) as usize;
+            let pos = (*pos * 2) as usize;
             vec![Label {
                 pos,
                 message: "Unexpected bytes".to_string(),
             }]
         }
         Custom { pos, err } => {
-            let pos = (pos * 2) as usize;
+            let pos = (*pos * 2) as usize;
             let err = err
                 .downcast_ref::<&str>()
                 .unwrap_or(&"unknown error (there's a bug in error reporting)");
@@ -61,7 +61,7 @@ fn get_binread_labels(e: &binread::Error) -> Vec<Label> {
             pos,
             variant_errors,
         } => {
-            let pos = (pos * 2) as usize;
+            let pos = (*pos * 2) as usize;
             let variant = variant_errors
                 .iter()
                 .find(|(_, e)| !matches!(e, BadMagic { .. }));
@@ -82,20 +82,21 @@ fn get_binread_labels(e: &binread::Error) -> Vec<Label> {
             }
         }
         NoVariantMatch { pos } => {
-            let pos = (pos * 2) as usize;
+            let pos = (*pos * 2) as usize;
             vec![Label {
                 pos,
                 message: "No variant match".to_string(),
             }]
         }
         AssertFail { pos, message } => {
-            let pos = (pos * 2) as usize;
+            let pos = (*pos * 2) as usize;
             vec![Label {
                 pos,
                 message: message.to_string(),
             }]
         }
         Io(_) => vec![],
+        Backtrace(backtrace) => get_binread_labels(&backtrace.error),
         _ => unreachable!(),
     }
 }
@@ -126,8 +127,8 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<binread::Error> for Error {
-    fn from(e: binread::Error) -> Error {
+impl From<binrw::Error> for Error {
+    fn from(e: binrw::Error) -> Error {
         Error::Binread(get_binread_labels(&e))
     }
 }

--- a/rust/candid/src/error.rs
+++ b/rust/candid/src/error.rs
@@ -97,7 +97,10 @@ fn get_binread_labels(e: &binrw::Error) -> Vec<Label> {
         }
         Io(_) => vec![],
         Backtrace(backtrace) => get_binread_labels(&backtrace.error),
-        _ => unreachable!(),
+        // `binrw::Error` is `#[non_exhaustive]`. Decoding runs on untrusted
+        // input, so degrade to a label-less error instead of panicking if a
+        // future version of binrw adds a variant.
+        _ => vec![],
     }
 }
 

--- a/rust/candid/src/lib.rs
+++ b/rust/candid/src/lib.rs
@@ -279,6 +279,13 @@ pub use types::{
     TypeEnv,
 };
 
+/// Internal wire-format parsing types, used only by candid's own deserializer.
+///
+/// Not part of the public API: the traits these types implement track whichever
+/// binary-parsing crate the deserializer happens to use, so they may change in
+/// any release. Hidden from the docs rather than made `pub(crate)` only to
+/// avoid breaking anything that already names them.
+#[doc(hidden)]
 #[allow(dead_code)]
 pub mod binary_parser;
 pub mod de;

--- a/rust/candid/src/pretty/candid.rs
+++ b/rust/candid/src/pretty/candid.rs
@@ -523,7 +523,7 @@ pub mod value {
                         for v in vs.iter() {
                             match v {
                                 // only here for completeness. The deserializer should generate IDLValue::Blob instead.
-                                Nat8(v) => write!(f, "{}", &pp_char(*v))?,
+                                Nat8(v) => write!(f, "{}", pp_char(*v))?,
                                 _ => unreachable!(),
                             }
                         }

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "candid_derive"
 # sync with the version in `candid/Cargo.toml`
-version = "0.10.32"
+version = "0.10.33"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]

--- a/rust/candid_parser/src/assist.rs
+++ b/rust/candid_parser/src/assist.rs
@@ -404,17 +404,17 @@ impl Theme for IndentTheme {
         write!(
             f,
             "{} {} ",
-            &self.prompt_prefix,
+            self.prompt_prefix,
             self.prompt_style.apply_to(prompt)
         )?;
-        write!(f, "{}", &self.prompt_suffix)
+        write!(f, "{}", self.prompt_suffix)
     }
     fn format_error(&self, f: &mut dyn fmt::Write, err: &str) -> fmt::Result {
         self.indent(f)?;
         write!(
             f,
             "{} {}",
-            &self.error_prefix,
+            self.error_prefix,
             self.error_style.apply_to(err)
         )
     }
@@ -429,7 +429,7 @@ impl Theme for IndentTheme {
             write!(
                 f,
                 "{} {} ",
-                &self.prompt_prefix,
+                self.prompt_prefix,
                 self.prompt_style.apply_to(prompt)
             )?;
         }
@@ -439,9 +439,9 @@ impl Theme for IndentTheme {
                 f,
                 "{} {} ",
                 self.hint_style.apply_to(&format!("({})", default)),
-                &self.prompt_suffix
+                self.prompt_suffix
             ),
-            None => write!(f, "{} ", &self.prompt_suffix),
+            None => write!(f, "{} ", self.prompt_suffix),
         }
     }
     fn format_confirm_prompt(
@@ -455,7 +455,7 @@ impl Theme for IndentTheme {
             write!(
                 f,
                 "{} {} ",
-                &self.prompt_prefix,
+                self.prompt_prefix,
                 self.prompt_style.apply_to(prompt)
             )?;
         }
@@ -465,20 +465,20 @@ impl Theme for IndentTheme {
                 f,
                 "{} {}",
                 self.hint_style.apply_to("(y/n)"),
-                &self.prompt_suffix
+                self.prompt_suffix
             ),
             Some(true) => write!(
                 f,
                 "{} {} {}",
                 self.hint_style.apply_to("(y/n)"),
-                &self.prompt_suffix,
+                self.prompt_suffix,
                 self.defaults_style.apply_to("yes")
             ),
             Some(false) => write!(
                 f,
                 "{} {} {}",
                 self.hint_style.apply_to("(y/n)"),
-                &self.prompt_suffix,
+                self.prompt_suffix,
                 self.defaults_style.apply_to("no")
             ),
         }
@@ -494,7 +494,7 @@ impl Theme for IndentTheme {
             write!(
                 f,
                 "{} {} ",
-                &self.success_prefix,
+                self.success_prefix,
                 self.prompt_style.apply_to(prompt)
             )?;
         }
@@ -505,12 +505,12 @@ impl Theme for IndentTheme {
                 write!(
                     f,
                     "{} {}",
-                    &self.success_suffix,
+                    self.success_suffix,
                     self.values_style.apply_to(selection)
                 )
             }
             None => {
-                write!(f, "{}", &self.success_suffix)
+                write!(f, "{}", self.success_suffix)
             }
         }
     }
@@ -525,7 +525,7 @@ impl Theme for IndentTheme {
             write!(
                 f,
                 "{} {} ",
-                &self.success_prefix,
+                self.success_prefix,
                 self.prompt_style.apply_to(prompt)
             )?;
         }
@@ -533,7 +533,7 @@ impl Theme for IndentTheme {
         write!(
             f,
             "{} {}",
-            &self.success_suffix,
+            self.success_suffix,
             self.values_style.apply_to(sel)
         )
     }

--- a/tools/ui/Cargo.lock
+++ b/tools/ui/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,26 +72,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
-name = "binread"
-version = "2.2.0"
+name = "binrw"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16598dfc8e6578e9b597d9910ba2e73618385dc9f4b1d43dd92c349d6be6418f"
+checksum = "6ad120d555272286c1017d25165ab8bd74806f13fc85b258484ec7e4ce75458f"
 dependencies = [
- "binread_derive",
- "lazy_static",
- "rustversion",
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
 ]
 
 [[package]]
-name = "binread_derive"
-version = "2.1.0"
+name = "binrw_derive"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9672209df1714ee804b1f4d4f68c8eb2a90b1f7a07acf472f88ce198ef1fed"
+checksum = "6df92e0e9baae4dc82c7bad7715ca40c0a5c71539057bf2ea04a5c29c980410b"
 dependencies = [
  "either",
+ "owo-colors",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -119,6 +126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,7 +148,7 @@ name = "candid"
 version = "0.10.32"
 dependencies = [
  "anyhow",
- "binread",
+ "binrw",
  "byteorder",
  "candid_derive",
  "hex",
@@ -158,7 +171,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -269,7 +282,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -280,7 +293,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -465,7 +478,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -658,7 +671,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -719,6 +732,12 @@ checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -954,7 +973,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -1045,18 +1064,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]
@@ -1116,7 +1124,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -1127,7 +1135,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]

--- a/tools/ui/Cargo.lock
+++ b/tools/ui/Cargo.lock
@@ -89,7 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6df92e0e9baae4dc82c7bad7715ca40c0a5c71539057bf2ea04a5c29c980410b"
 dependencies = [
  "either",
- "owo-colors",
  "proc-macro2",
  "quote",
  "syn",
@@ -145,7 +144,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "candid"
-version = "0.10.32"
+version = "0.10.33"
 dependencies = [
  "anyhow",
  "binrw",
@@ -166,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.32"
+version = "0.10.33"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -732,12 +731,6 @@ checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"


### PR DESCRIPTION
The `binread` crate is deprecated: https://github.com/jam1garner/binread

The `binrw` crate is a replacement from the same author which supports both read and writing. The changes related to reading are mostly mechanical.

This was assisted by Claude Opus 4.8.

---

## Follow-ups (@lwshang)

Picked this up from @nmattia to get it through CI and out to crates.io, since `dfinity/ic` wants the new version. Original migration commits are unchanged; everything below is additive.

### Verification

The repo has no tests covering decoder error messages, and those drive user-facing diagnostics, so they were the main migration risk — `binrw` wraps errors in `Error::Backtrace`, which could have silently defeated the `!matches!(e, BadMagic { .. })` filter in `get_binread_labels`. Checked with a throwaway harness over 20 malformed inputs (bad magic, truncated LEB128, oversized type table, unknown opcodes, bad function annotations, invalid UTF-8 method names, opaque references, over-long principals, huge vec lengths): **error text and byte offsets are byte-identical to `master` in every case**, including the `EnumErrors` path.

Every step of `rust.yml` passes locally: `cargo build`, all three `cargo test` variants (23/23 test binaries), `cargo fmt --check`, `cargo clippy --features all --tests -- -D warnings`, `cargo doc`.

### CI was red for an unrelated reason

`master` itself is failing: 17 pre-existing `clippy::useless_borrows_in_formatting` errors from clippy 1.97 lint drift (1 in `de.rs`, 1 in `pretty/candid.rs`, 15 in `candid_parser`'s `IndentTheme`). Fixed here so this PR can go green; the migration itself was already clippy- and fmt-clean.

Also: the Copilot review comment claiming `reader.stream_position()` needs `Seek` in scope is a false positive — `#[binrw::parser(reader)]` supplies the bound.

### `binrw` without `verbose-backtrace`

`verbose-backtrace` is a default feature that pulls in `owo-colors` and emits backtrace frames which `get_binread_labels` discards. Turned off, which makes the dependency change for the published crate a clean swap:

| | |
|---|---|
| **removed** | `binread`, `binread_derive`, `rustversion`, `syn 1.0.109` |
| **added** | `binrw`, `binrw_derive`, `array-init`, `bytemuck` |

Dropping the duplicate old `syn 1.x` that `binread_derive` pinned is the actual win for `dfinity/ic`.

### Hardening

`binrw::Error` is `#[non_exhaustive]`, so the trailing `_ => unreachable!()` in `get_binread_labels` was a latent panic on untrusted input. Now degrades to a label-less error. Pre-existing (`binread::Error` was also `#[non_exhaustive]`), but worth closing while we're in here.

### Release: candid 0.10.33

Bumps `candid` + `candid_derive`, adds the changelog entry, regenerates the four lockfiles. The lock diffs contain only the version bumps and the `owo-colors` removal — no incidental dependency churn.

**On patch vs. minor** — this is *technically* breaking: the types in `candid::binary_parser` now implement `binrw::BinRead` rather than `binread::BinRead`, and `From<binread::Error> for candid::Error` becomes `From<binrw::Error>`. Shipping it as a patch anyway, because the trade is lopsided:

- `binary_parser` is an internal wire-format module that is `pub` only incidentally. It is imported by nothing outside candid's own `de.rs`; a GitHub-wide search turns up no real dependents. Now marked `#[doc(hidden)]` to say so explicitly (rather than `pub(crate)`, which would be a harder break — that belongs in a future `0.11.0`).
- To be affected you must already depend on `binread` directly *and* name those impls. Wire format, error messages, byte offsets, type layouts and function signatures are all unchanged, so the worst case is a compile error, never a behaviour change.
- A `0.11.0` would strand every downstream pinned `candid = "0.10"` — ic-cdk, agent-rs, sdk, icp-cli and thousands of canister crates stop receiving updates until each bumps its requirement. That certain, broad cost outweighs the near-zero breakage it would signal.

Worth noting this cuts against repo precedent: `candid` has not previously shipped a documented breaking change in a patch release, and `candid_parser` bumped its minor each time it broke API. Happy to move to `0.11.0` if reviewers would rather stay strict.

### Out of scope

`binread` does not disappear from the root `Cargo.lock`: `tools/didc-js/wasm-package` depends on *published* `candid 0.10.10` / `candid_parser 0.1.4` instead of the workspace paths, and that old candid still pulls `binread` → `syn 1.0.109`. Unrelated stale pin, and irrelevant to `dfinity/ic`, which consumes the published crate — that tree is now `binread`-free. Left for a separate cleanup.

🤖 Follow-up commits generated with [Claude Code](https://claude.com/claude-code)
