### PR TITLE
fix(ui): serve `ic_env` with `SameSite=None; Secure; Partitioned` for cross-site iframe embedding

### DIFF
--- a/tools/ui/src/didjs/lib.rs
+++ b/tools/ui/src/didjs/lib.rs
@@ -161,6 +161,15 @@ thread_local! {
 
 // The `ic_env` cookie carries environment data compatible with the canister environment
 // variables cookie. It is only attached to `text/html` responses.
+//
+// `Secure; SameSite=None; Partitioned` (CHIPS) so page scripts can still read it when the
+// UI is shown inside a **cross-site iframe** (e.g. the icp.ninja backend preview): a
+// `SameSite=Lax` cookie is never stored in a third-party context, so `getCanisterEnv()`
+// would throw before the app boots. `Partitioned` scopes the cookie to the embedding
+// top-level site, so it does not become a blanket cross-site cookie. (`ic_env` is
+// read-only client state, never sent back, so `None` only affects whether the browser
+// stores it, not any request.) Kept byte-compatible with the asset canister's
+// `render_env_cookie`.
 const SET_COOKIE_HEADER_NAME: &str = "Set-Cookie";
 const IC_ENV_COOKIE_NAME: &str = "ic_env";
 
@@ -206,7 +215,9 @@ fn build_response(
     if content_type == "text/html" {
         headers.push((
             SET_COOKIE_HEADER_NAME.to_string(),
-            format!("{IC_ENV_COOKIE_NAME}={encoded_canister_env}; SameSite=Lax"),
+            format!(
+                "{IC_ENV_COOKIE_NAME}={encoded_canister_env}; Secure; SameSite=None; Partitioned"
+            ),
         ));
     }
 


### PR DESCRIPTION
## What

Set the `ic_env` cookie with `Secure; SameSite=None; Partitioned` (CHIPS) instead of `SameSite=Lax`, so Candid UI works when it is embedded in a **cross-site iframe**.

```diff
-format!("{IC_ENV_COOKIE_NAME}={encoded_canister_env}; SameSite=Lax"),
+format!(
+    "{IC_ENV_COOKIE_NAME}={encoded_canister_env}; Secure; SameSite=None; Partitioned"
+),
```

## Why

This is a live production break. icp.ninja's backend preview embeds `https://a4gq6-oaaaa-aaaab-qaa4q-cai.icp0.io/?id=<canister>` in a cross-site iframe. A `SameSite=Lax` cookie is never stored when written in a third-party context, so:

1. The browser drops `ic_env`.
2. `getCanisterEnv()` — called at **module top level** in `tools/ui/src/candid.ts` — throws `Uncaught InputError: Cookie 'ic_env' not found`.
3. Because the throw happens during module evaluation, it precedes `main()`, so the `main().catch()` handler in `tools/ui/src/index.ts` never runs and nothing is rendered. The preview sits on the loading spinner forever, with the only signal in the browser console.

Without the cookie the frontend has neither `IC_ROOT_KEY` nor `CANISTER_ID` (needed for the `did_to_js` self-call), so there is nothing to fall back to.

This mirrors dfinity/certified-assets#107, which fixed the identical break for the asset canister's `render_env_cookie`. Keeping the attributes identical means both canisters emit a byte-compatible `ic_env`.

`Partitioned` scopes the cookie to the embedding top-level site, so it does not become a blanket cross-site cookie sent to arbitrary embedders. Plain `SameSite=None` would be restricted by Chrome/Firefox. `ic_env` is read-only client state that is never sent back to the canister, so `SameSite=None` only affects whether the browser *stores* it, not any request.

## Notes

- **First-party use is unaffected.** In a top-level context the partition key is the site itself, so `document.cookie` still sees it.
- **No certification bookkeeping.** The header is inside the certified response (`response_header_exclusions(vec![])` certifies all headers), but `build_response()` is the single code path used for both certifying and serving, and `certify_all_assets()` re-runs from `post_upgrade` — so the new header is re-certified on upgrade with no certify/serve mismatch hazard.
- **`Secure` over local http.** Local dev serves the canister at `*.localhost`, which Chrome and Firefox treat as a potentially-trustworthy origin, so `Secure` cookies are accepted there.
- **Deliberately not included:** an `agent.fetchRootKey()` fallback. That would trade the certified root key for an uncertified trust-on-first-use fetch — exactly what #738 removed — to hedge a case this fix already covers.

## Testing

- `cargo check --target wasm32-unknown-unknown -p didjs` passes; `cargo fmt -p didjs -- --check` reports no diff for the changed lines (the one remaining diff is a pre-existing `use ic_cdk::api::{…}` wrap, untouched here — the root `cargo fmt` CI gate runs on a different workspace than `tools/ui`).
- No PR-time CI builds `tools/ui` (`candid-ui.yml` only runs on date tags), so this was verified locally.
- Needs a mainnet upgrade of `a4gq6-oaaaa-aaaab-qaa4q-cai` (`icp deploy -e ic` from `tools/ui/`) to take effect — merging alone does not fix the icp.ninja preview.
- Not yet verified end-to-end in a real cross-site iframe against a deployed canister; worth an eyeball in Chrome and Safari after the upgrade.

## Follow-up (not blocking)

`getCanisterEnv()` at module scope is why this presented as a silent hang rather than an error on the page. A small follow-up will switch to `safeGetCanisterEnv()` and guard inside `main()` so any future cookie failure surfaces through the existing error handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
