### PR TITLE
fix(candid): newtype elements and binary format in the primitive-vec fast path + release candid 0.10.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Bug fixes:
   + Fix decoding a `vec` of fixed-width primitives into newtype elements (e.g. `struct EventIndex(u32)`), which failed with a spurious subtyping error since 0.10.27. The bulk decode fast path fed each element through serde's value deserializers, which do not implement `deserialize_newtype_struct`; they now go through a wrapper that forwards it, as the main deserializer does. Nested newtypes are unwrapped recursively.
+  + Fix `is_human_readable()` reporting `true` for elements of a `vec` of fixed-width primitives, also since 0.10.27. The bulk decode fast path inherited serde's default from the same value deserializers, so a `Deserialize` impl that branches on it took its human-readable path inside a `vec` while taking the binary path everywhere else, silently decoding to a different value with no error. It now reports `false` for the whole decoder, as candid is a binary format.
 
 ### Candid 0.10.33
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-07-27
+
+### Candid 0.10.33
+
+* Bug fixes:
+  + Fix decoding a `vec` of fixed-width primitives into newtype elements (e.g. `struct EventIndex(u32)`), which failed with a spurious subtyping error since 0.10.27. The bulk decode fast path fed each element through serde's value deserializers, which do not implement `deserialize_newtype_struct`; they now go through a wrapper that forwards it, as the main deserializer does. Nested newtypes are unwrapped recursively.
+
 ## 2026-07-06
 
 ### Candid 0.10.32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## 2026-07-27
 
-### Candid 0.10.33
+### Candid 0.10.34
 
 * Bug fixes:
   + Fix decoding a `vec` of fixed-width primitives into newtype elements (e.g. `struct EventIndex(u32)`), which failed with a spurious subtyping error since 0.10.27. The bulk decode fast path fed each element through serde's value deserializers, which do not implement `deserialize_newtype_struct`; they now go through a wrapper that forwards it, as the main deserializer does. Nested newtypes are unwrapped recursively.
+
+### Candid 0.10.33
 
 * Breaking changes:
   + Migrated from the deprecated [`binread`](https://github.com/jam1garner/binread) crate to its successor `binrw`. The types in the `candid::binary_parser` module (`Header`, `PrincipalBytes`, `Len`, `BoolValue`) now implement `binrw::BinRead` instead of `binread::BinRead`, and `From<binread::Error> for candid::Error` is replaced by `From<binrw::Error>`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,13 +244,13 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.33"
+version = "0.10.34"
 dependencies = [
  "anyhow",
  "bincode",
  "binrw",
  "byteorder",
- "candid_derive 0.10.33",
+ "candid_derive 0.10.34",
  "candid_parser 0.4.0",
  "hex",
  "ic_principal 0.1.5",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.33"
+version = "0.10.34"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.86",
@@ -315,7 +315,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "candid 0.10.33",
+ "candid 0.10.34",
  "codespan-reporting",
  "console",
  "convert_case",

--- a/rust/bench/Cargo.lock
+++ b/rust/bench/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.33"
+version = "0.10.34"
 dependencies = [
  "anyhow",
  "binrw",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.33"
+version = "0.10.34"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "candid"
 # sync with the version in `candid_derive/Cargo.toml`
-version = "0.10.33"
+version = "0.10.34"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]
@@ -16,7 +16,7 @@ keywords = ["internet-computer", "idl", "candid", "dfinity"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-candid_derive = { path = "../candid_derive", version = "=0.10.33" }
+candid_derive = { path = "../candid_derive", version = "=0.10.34" }
 ic_principal = { path = "../ic_principal", version = "0.1.0" }
 # `verbose-backtrace` (a default feature) pulls in `owo-colors` and generates
 # backtrace frames that `get_binread_labels` discards, so keep it off.

--- a/rust/candid/fuzz/Cargo.lock
+++ b/rust/candid/fuzz/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "candid"
-version = "0.10.33"
+version = "0.10.34"
 dependencies = [
  "anyhow",
  "binrw",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.33"
+version = "0.10.34"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -35,7 +35,7 @@ impl<'de> IDLDeserialize<'de> {
     pub fn new_with_config(bytes: &'de [u8], config: &DecoderConfig) -> Result<Self> {
         let mut de = Deserializer::from_bytes(bytes, config).with_context(|| {
             if config.full_error_message || bytes.len() <= 500 {
-                format!("Cannot parse header {}", &hex::encode(bytes))
+                format!("Cannot parse header {}", hex::encode(bytes))
             } else {
                 "Cannot parse header".to_string()
             }

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -1456,9 +1456,16 @@ struct PrimitiveVecAccess<'de> {
     prim: PrimitiveType,
 }
 
-/// Adds newtype-struct support (e.g. `struct EventIndex(u32)`) to serde's
-/// value deserializers, which lack it, by forwarding through
-/// `visit_newtype_struct` like the main `Deserializer` does.
+/// Adapts serde's value deserializers to candid's contract in the two places they
+/// differ from the main `Deserializer`:
+///
+/// * they have no `deserialize_newtype_struct`, so a newtype element (e.g.
+///   `struct EventIndex(u32)`) failed to decode; it now forwards through
+///   `visit_newtype_struct` as the main `Deserializer` does, which also makes
+///   nested newtypes unwrap recursively;
+/// * they inherit serde's default `is_human_readable() == true`, which would send
+///   an impl that branches on it down its human-readable path even though candid
+///   is a binary format.
 #[cfg(target_endian = "little")]
 struct NewtypeCompat<D>(D);
 
@@ -1474,6 +1481,9 @@ impl<'de, D: de::Deserializer<'de, Error = Error>> de::Deserializer<'de> for New
         visitor: V,
     ) -> Result<V::Value> {
         visitor.visit_newtype_struct(self)
+    }
+    fn is_human_readable(&self) -> bool {
+        false
     }
     serde::forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string

--- a/rust/candid/src/de.rs
+++ b/rust/candid/src/de.rs
@@ -1456,6 +1456,39 @@ struct PrimitiveVecAccess<'de> {
     prim: PrimitiveType,
 }
 
+/// Adds newtype-struct support (e.g. `struct EventIndex(u32)`) to serde's
+/// value deserializers, which lack it, by forwarding through
+/// `visit_newtype_struct` like the main `Deserializer` does.
+#[cfg(target_endian = "little")]
+struct NewtypeCompat<D>(D);
+
+#[cfg(target_endian = "little")]
+impl<'de, D: de::Deserializer<'de, Error = Error>> de::Deserializer<'de> for NewtypeCompat<D> {
+    type Error = Error;
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        self.0.deserialize_any(visitor)
+    }
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value> {
+        visitor.visit_newtype_struct(self)
+    }
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+#[cfg(target_endian = "little")]
+fn newtype_compat<'de, T: de::IntoDeserializer<'de, Error>>(
+    value: T,
+) -> NewtypeCompat<T::Deserializer> {
+    NewtypeCompat(value.into_deserializer())
+}
+
 #[cfg(target_endian = "little")]
 impl<'de> de::SeqAccess<'de> for PrimitiveVecAccess<'de> {
     type Error = Error;
@@ -1464,7 +1497,6 @@ impl<'de> de::SeqAccess<'de> for PrimitiveVecAccess<'de> {
     where
         T: de::DeserializeSeed<'de>,
     {
-        use serde::de::IntoDeserializer;
         if self.remaining == 0 {
             return Ok(None);
         }
@@ -1474,45 +1506,43 @@ impl<'de> de::SeqAccess<'de> for PrimitiveVecAccess<'de> {
 
         match self.prim {
             PrimitiveType::Bool => match bytes[0] {
-                0 => seed.deserialize(false.into_deserializer()).map(Some),
-                1 => seed.deserialize(true.into_deserializer()).map(Some),
+                0 => seed.deserialize(newtype_compat(false)).map(Some),
+                1 => seed.deserialize(newtype_compat(true)).map(Some),
                 _ => Err(Error::msg("Expect 00 or 01")),
             },
-            PrimitiveType::Nat8 => seed.deserialize(bytes[0].into_deserializer()).map(Some),
-            PrimitiveType::Int8 => seed
-                .deserialize((bytes[0] as i8).into_deserializer())
-                .map(Some),
+            PrimitiveType::Nat8 => seed.deserialize(newtype_compat(bytes[0])).map(Some),
+            PrimitiveType::Int8 => seed.deserialize(newtype_compat(bytes[0] as i8)).map(Some),
             PrimitiveType::Nat16 => {
                 let v = u16::from_le_bytes(bytes.try_into().unwrap());
-                seed.deserialize(v.into_deserializer()).map(Some)
+                seed.deserialize(newtype_compat(v)).map(Some)
             }
             PrimitiveType::Int16 => {
                 let v = i16::from_le_bytes(bytes.try_into().unwrap());
-                seed.deserialize(v.into_deserializer()).map(Some)
+                seed.deserialize(newtype_compat(v)).map(Some)
             }
             PrimitiveType::Nat32 => {
                 let v = u32::from_le_bytes(bytes.try_into().unwrap());
-                seed.deserialize(v.into_deserializer()).map(Some)
+                seed.deserialize(newtype_compat(v)).map(Some)
             }
             PrimitiveType::Int32 => {
                 let v = i32::from_le_bytes(bytes.try_into().unwrap());
-                seed.deserialize(v.into_deserializer()).map(Some)
+                seed.deserialize(newtype_compat(v)).map(Some)
             }
             PrimitiveType::Float32 => {
                 let v = f32::from_le_bytes(bytes.try_into().unwrap());
-                seed.deserialize(v.into_deserializer()).map(Some)
+                seed.deserialize(newtype_compat(v)).map(Some)
             }
             PrimitiveType::Nat64 => {
                 let v = u64::from_le_bytes(bytes.try_into().unwrap());
-                seed.deserialize(v.into_deserializer()).map(Some)
+                seed.deserialize(newtype_compat(v)).map(Some)
             }
             PrimitiveType::Int64 => {
                 let v = i64::from_le_bytes(bytes.try_into().unwrap());
-                seed.deserialize(v.into_deserializer()).map(Some)
+                seed.deserialize(newtype_compat(v)).map(Some)
             }
             PrimitiveType::Float64 => {
                 let v = f64::from_le_bytes(bytes.try_into().unwrap());
-                seed.deserialize(v.into_deserializer()).map(Some)
+                seed.deserialize(newtype_compat(v)).map(Some)
             }
         }
     }

--- a/rust/candid/src/pretty/candid.rs
+++ b/rust/candid/src/pretty/candid.rs
@@ -523,7 +523,7 @@ pub mod value {
                         for v in vs.iter() {
                             match v {
                                 // only here for completeness. The deserializer should generate IDLValue::Blob instead.
-                                Nat8(v) => write!(f, "{}", &pp_char(*v))?,
+                                Nat8(v) => write!(f, "{}", pp_char(*v))?,
                                 _ => unreachable!(),
                             }
                         }

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -856,6 +856,47 @@ fn test_nested_map_non_text_key() {
     assert_eq!(outer, decoded);
 }
 
+/// Regression test: elements decoded through the bulk primitive-vec fast path must
+/// report the same `is_human_readable()` answer as the main deserializer, which is
+/// `false` because candid is a binary format.
+///
+/// The fast path hands each element to a serde value deserializer, which inherits
+/// serde's default `is_human_readable() == true`. A `Deserialize` impl that branches
+/// on it — the common "string when human-readable, native when binary" pattern — then
+/// took the wrong branch inside a `vec`, silently decoding to a different value than
+/// the same bytes decoded on their own, with no error raised.
+#[test]
+fn test_primitive_vec_reports_binary_format() {
+    #[derive(CandidType, Debug, PartialEq)]
+    struct Flag(u32);
+
+    impl<'de> Deserialize<'de> for Flag {
+        fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+            // Stand in for the string-parsing branch such impls would take.
+            let human_readable = d.is_human_readable();
+            let v = u32::deserialize(d)?;
+            Ok(Flag(if human_readable { u32::MAX } else { v }))
+        }
+    }
+
+    // Scalar: goes through the main `Deserializer`.
+    let config = get_config();
+    let scalar = decode_one_with_config::<Flag>(&encode(&Flag(7)), &config).unwrap();
+    assert_eq!(
+        scalar,
+        Flag(7),
+        "main deserializer must report a binary format"
+    );
+
+    // Inside a vec: goes through the bulk primitive-vec fast path, which must agree.
+    let v = vec![Flag(7), Flag(8)];
+    let decoded = decode_one_with_config::<Vec<Flag>>(&encode(&v), &config).unwrap();
+    assert_eq!(
+        decoded, v,
+        "bulk primitive-vec fast path must report a binary format like the main deserializer"
+    );
+}
+
 #[test]
 fn test_collection() {
     use std::collections::{BTreeMap, BTreeSet, HashMap};

--- a/rust/candid/tests/serde.rs
+++ b/rust/candid/tests/serde.rs
@@ -665,6 +665,27 @@ fn test_newtype() {
         A(i32),
     }
     all_check(Y::A(42), "4449444c016b0141750100002a000000");
+
+    // #752: the bulk decode fast path for vectors of fixed-width primitives
+    // must support newtype elements, including nested ones.
+    #[derive(PartialEq, Debug, Deserialize, CandidType)]
+    struct Wrapped(X);
+    let v = vec![Wrapped(X(1)), Wrapped(X(2))];
+    test_decode(&encode(&v), &v);
+
+    // bool/nat8/int8 read their bytes differently from the other widths.
+    #[derive(PartialEq, Debug, Deserialize, CandidType)]
+    struct B(bool);
+    let v = vec![B(true), B(false)];
+    test_decode(&encode(&v), &v);
+    #[derive(PartialEq, Debug, Deserialize, CandidType)]
+    struct N8(u8);
+    let v = vec![N8(0), N8(255)];
+    test_decode(&encode(&v), &v);
+    #[derive(PartialEq, Debug, Deserialize, CandidType)]
+    struct I8(i8);
+    let v = vec![I8(-128), I8(127)];
+    test_decode(&encode(&v), &v);
 }
 
 #[test]

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "candid_derive"
 # sync with the version in `candid/Cargo.toml`
-version = "0.10.33"
+version = "0.10.34"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]

--- a/tools/ui/Cargo.lock
+++ b/tools/ui/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "candid"
-version = "0.10.33"
+version = "0.10.34"
 dependencies = [
  "anyhow",
  "binrw",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.33"
+version = "0.10.34"
 dependencies = [
  "lazy_static",
  "proc-macro2",


### PR DESCRIPTION
> [!NOTE]
> Maintainer edit (@lwshang): pushed two follow-up commits — a second fix found while reviewing, and the 0.10.34 release bookkeeping. Everything from `## Summary` down to the end of `## Notes for reviewers` is @hpeebles' original description, unchanged except for the stale version-heading note. See [Maintainer follow-ups](#maintainer-follow-ups) at the bottom.

## Summary

Fixes #752. Since 0.10.27, decoding a `vec` of fixed-width primitives fails whenever the Rust element type is a newtype struct (e.g. `struct EventIndex(u32)`) — a value fails to decode against **its own encoding**, with a misleading `Subtyping error` even though the wire and expected types are identical.

```rust
#[derive(CandidType, Deserialize, Debug)]
struct EventIndex(u32);

let bytes = encode_one(&vec![EventIndex(1), EventIndex(2)]).unwrap();
decode_one::<Vec<EventIndex>>(&bytes).unwrap();  // panics before this PR
```

## Cause

#721 added a bulk fast path for primitive vectors. Its `PrimitiveVecAccess::next_element_seed` feeds each element through serde's value deserializers (`u32.into_deserializer()` etc.). Those forward *everything* to `visit_u32`-style calls and never implement `deserialize_newtype_struct`, so a derived newtype `Deserialize` — which calls exactly that — fails with serde's expecting-text, which candid wraps as a subtyping error.

The pre-#721 path was fine because elements still flowed through the real candid `Deserializer`, whose `deserialize_newtype_struct` forwards transparently via `visitor.visit_newtype_struct(self)`. That code is unchanged and correct; the bulk path simply bypassed it.

## Fix

Wrap each element's value deserializer in `NewtypeCompat`, which forwards `deserialize_newtype_struct` the same way the main `Deserializer` does and delegates everything else unchanged. Because it hands `self` back to `visit_newtype_struct`, nested newtypes unwrap recursively. The bulk-read performance win from #721 is untouched — this only changes the per-element value handoff, so each arm is a one-token change (`v.into_deserializer()` → `newtype_compat(v)`).

## Testing

Added to `test_newtype`: the issue's repro, a nested newtype (`Wrapped(X(i32))`), and the `bool` / `nat8` / `int8` arms, which read their bytes differently from the other widths. I verified each of those three fails without the fix in isolation rather than relying on the combined assertion, which would short-circuit at the first case.

Note the bug also affected `Vec<Newtype(bool)>`, not just the integer index types named in the issue.

Ran the full CI matrix locally — `build`, `test --no-default-features`, `test`, `test --features all`, `fmt --check`, `clippy --features all --tests -D warnings`, and `doc` all clean. I did not run `cargo +nightly fuzz build`.

## Notes for reviewers

- **Cost accounting.** On little-endian, plain, newtype, and nested-newtype vecs now consume identical decoding quota (measured: 66 for a 4-element `vec nat32` in all three cases). The big-endian path charges `add_cost(1)` per newtype level per element via the main deserializer, so the two diverge slightly. It's an undercharge bounded by newtype nesting depth — a compile-time constant of the receiving type, not attacker-controllable — and wasm32 is little-endian, so I left it rather than threading a cost counter into the bulk path. Happy to change it if you'd rather they match.
- **Version heading.** ~~The CHANGELOG entry is filed under `Candid 0.10.33`, but I have not bumped any `Cargo.toml`~~ — handled in the follow-up commits below; 0.10.33 shipped separately in #753, so this is now 0.10.34.
- The regression test lives in `tests/serde.rs`, which has `required-features = ["bignum"]`, so it doesn't run in the `--no-default-features` CI leg. The bug is unrelated to bignum; this just follows where the file already sits.

---

## Maintainer follow-ups

Two commits added on top of @hpeebles' work.

### 1. `is_human_readable()` also diverges in the fast path (`25297d1`)

Found while reviewing. `NewtypeCompat` reconciled the value deserializers' missing `deserialize_newtype_struct`, but they differ from the main `Deserializer` in a second way: they inherit serde's default `is_human_readable() == true`, whereas candid's `Deserializer` reports `false` because candid is a binary format.

So a `Deserialize` impl that branches on it — the common "string when human-readable, native when binary" pattern, e.g. `serde_with`-style wrappers — took its human-readable branch inside a `vec` and its binary branch everywhere else, **silently decoding to a different value with no error raised**:

```rust
#[derive(CandidType, Debug, PartialEq)]
struct Flag(u32);

impl<'de> Deserialize<'de> for Flag {
    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
        let human_readable = d.is_human_readable();
        let v = u32::deserialize(d)?;
        Ok(Flag(if human_readable { u32::MAX } else { v }))
    }
}

// scalar   -> Flag(7)          correct, via the main Deserializer
// Vec<Flag> -> Flag(4294967295) wrong, via the bulk fast path
```

Same root cause and same era as the newtype bug — present since 0.10.27 — but **independent of it**: this one also affected plain, non-newtype elements, which reach the same value deserializers directly. Fixed by overriding `is_human_readable` on `NewtypeCompat`, whose doc comment now describes both divergences it reconciles.

Test written first and confirmed to fail before the fix; removing just the three-line override makes it fail again, so it genuinely guards the invariant rather than passing incidentally. `test_primitive_vec_reports_binary_format` asserts that the same type decodes identically as a scalar and inside a `vec`, and sits next to `test_nested_map_non_text_key`, following that test's documented-regression style.

### 2. Release candid 0.10.34 (`56b861d`)

0.10.33 was published while this PR was open (#753, the `binrw` migration), so the CHANGELOG entry needed to move out of an already-shipped section. Split into a new `### Candid 0.10.34` and bumped `candid` + `candid_derive`, plus the four lockfiles the release convention touches (`Cargo.lock`, `rust/bench/`, `rust/candid/fuzz/`, `tools/ui/`).

Note `tools/ui` reaches candid through `[patch.crates-io.candid]`, so `cargo update --workspace` silently skips it — it needs `-p candid`. Incidental `cc`/`find-msvc-tools`/`shlex` bumps were pinned back with `--precise` to keep the lock diffs to the version change alone.

### Verification

Full CI matrix re-run on the merged result, all clean: `build`, `test`, `test --no-default-features`, `test --features all`, `fmt --check`, `clippy --features all --tests -D warnings`, `doc`. All with `--locked`, so the regenerated lockfiles are confirmed consistent. `cargo +nightly fuzz build` not run.

Also verified from the review, independently of the author's own checks: all eight remaining width arms (`u16`/`i16`/`u32`/`i32`/`u64`/`i64`/`f32`/`f64`) decode correctly into newtypes; `exact_primitive_type` still rejects `vec nat32` → `Vec<Newtype(u64)>`, so the transparent `ty()` can't smuggle a width change; and the `forward_to_deserialize_any!` list is behaviour-preserving — serde_core's `primitive_deserializer!` already routes `option`/`seq`/`enum`/… to `deserialize_any`, so `newtype_struct` and `is_human_readable` are the only deltas.

### Unrelated CI note

The `run benchmark` check fails on this PR at its final `Post comment` step with `Resource not accessible by integration`. Both `canbench` runs succeed; the comment POST is rejected because `pull_request` from a fork gets a read-only `GITHUB_TOKEN`. Not caused by these changes — it will fail on every external-contributor PR, and `bench.yml` needs the artifact + `workflow_run` split to fix properly. Side effect worth knowing: the perf comparison is lost for this PR, since both the report and the diff table are redirected to files only that failed step reads.
