### PR TITLE
fix(candid): bound length-prefixed allocations in header parser + release candid 0.10.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Candid 0.10.35
 
 * Bug fixes:
-  + Bound the allocation when reading a length-prefixed byte field in the type-table header. A byte vector (a future type's payload, or a service method's name) previously reserved its full declared length up front, so a length larger than the remaining input requested a correspondingly large allocation instead of failing on the short read. These fields now grow their buffer incrementally, so an out-of-range or truncated length surfaces as an ordinary parse error. The wire format and decoder error behaviour are otherwise unchanged.
+  + Bound the allocation when reading a length-prefixed byte field in the type-table header. A byte vector (a future type's payload, or a service method's name) previously reserved its full declared length up front, so a length larger than the remaining input requested a correspondingly large allocation instead of failing on the short read. These fields now grow their buffer incrementally, so an out-of-range or truncated length surfaces as an ordinary parse error. The wire format is unchanged and valid messages decode identically.
 
 ## 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-08-11
+
+### Candid 0.10.35
+
+* Bug fixes:
+  + Bound the allocation when reading a length-prefixed byte field in the type-table header. A byte vector (a future type's payload, or a service method's name) previously reserved its full declared length up front, so a length larger than the remaining input requested a correspondingly large allocation instead of failing on the short read. These fields now grow their buffer incrementally, so an out-of-range or truncated length surfaces as an ordinary parse error. The wire format and decoder error behaviour are otherwise unchanged.
+
 ## 2026-07-27
 
 ### Candid 0.10.34

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,13 +244,13 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.34"
+version = "0.10.35"
 dependencies = [
  "anyhow",
  "bincode",
  "binrw",
  "byteorder",
- "candid_derive 0.10.34",
+ "candid_derive 0.10.35",
  "candid_parser 0.4.0",
  "hex",
  "ic_principal 0.1.5",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.34"
+version = "0.10.35"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.86",
@@ -315,7 +315,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "candid 0.10.34",
+ "candid 0.10.35",
  "codespan-reporting",
  "console",
  "convert_case",

--- a/rust/bench/Cargo.lock
+++ b/rust/bench/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.34"
+version = "0.10.35"
 dependencies = [
  "anyhow",
  "binrw",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.34"
+version = "0.10.35"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/rust/candid/Cargo.toml
+++ b/rust/candid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "candid"
 # sync with the version in `candid_derive/Cargo.toml`
-version = "0.10.34"
+version = "0.10.35"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]
@@ -16,7 +16,7 @@ keywords = ["internet-computer", "idl", "candid", "dfinity"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-candid_derive = { path = "../candid_derive", version = "=0.10.34" }
+candid_derive = { path = "../candid_derive", version = "=0.10.35" }
 ic_principal = { path = "../ic_principal", version = "0.1.0" }
 # `verbose-backtrace` (a default feature) pulls in `owo-colors` and generates
 # backtrace frames that `get_binread_labels` discards, so keep it off.

--- a/rust/candid/src/binary_parser.rs
+++ b/rust/candid/src/binary_parser.rs
@@ -6,6 +6,55 @@ use std::convert::TryInto;
 
 const MAX_TYPE_TABLE_LEN: u64 = 10_000; // Max type entries
 
+// Upper bound on a single allocation step while reading a length-prefixed byte
+// blob. The buffer grows in steps of at most this size.
+const READ_CHUNK: u64 = 8 * 1024;
+
+/// Read `len` bytes into a fresh `Vec`, growing the buffer in bounded steps.
+///
+/// A plain `#[br(count = len)]` on a `Vec<u8>` passes the wire-declared length
+/// straight to `reserve_exact`, allocating `len` bytes up front before any are
+/// read. A length prefix need not match the amount of data actually present, so
+/// a value far larger than the input would reserve a correspondingly large
+/// buffer instead of failing cleanly on the short read. Growing the buffer in
+/// bounded chunks keeps the reservation proportional to the bytes available, so
+/// an out-of-range or truncated length surfaces as an ordinary parse error.
+fn read_len_prefixed<R: std::io::Read>(reader: &mut R, pos: u64, len: u64) -> BinResult<Vec<u8>> {
+    use std::io::Read;
+    let mut buf = Vec::new();
+    let mut remaining = len;
+    while remaining > 0 {
+        let want = remaining.min(READ_CHUNK);
+        // `read_to_end` on a bounded `Take` reserves at most `want`, so the
+        // buffer never grows faster than the input is consumed.
+        let read = reader.by_ref().take(want).read_to_end(&mut buf)? as u64;
+        if read < want {
+            // Fewer bytes were available than declared: short input.
+            return Err(BError::Custom {
+                pos,
+                err: Box::new("not enough bytes"),
+            });
+        }
+        remaining -= read;
+    }
+    Ok(buf)
+}
+
+#[binrw::parser(reader)]
+fn read_bytes(len: u64) -> BinResult<Vec<u8>> {
+    let pos = reader.stream_position()?;
+    read_len_prefixed(reader, pos, len)
+}
+#[binrw::parser(reader)]
+fn read_text(len: u64) -> BinResult<String> {
+    let pos = reader.stream_position()?;
+    let bytes = read_len_prefixed(reader, pos, len)?;
+    String::from_utf8(bytes).map_err(|_| BError::Custom {
+        pos,
+        err: Box::new("invalid utf8"),
+    })
+}
+
 #[binrw::parser(reader)]
 fn read_leb(name: &'static str) -> BinResult<u64> {
     let pos = reader.stream_position()?;
@@ -130,14 +179,14 @@ struct FutureType {
     opcode: i64,
     #[br(parse_with = read_leb, args("len"))]
     len: u64,
-    #[br(count = len)]
+    #[br(parse_with = read_bytes, args(len))]
     blob: Vec<u8>,
 }
 #[derive(BinRead, Debug)]
 struct Meths {
     #[br(parse_with = read_leb, args("len"))]
     len: u64,
-    #[br(count = len, try_map = |x:Vec<u8>| String::from_utf8(x).map_err(|_| "invalid utf8"))]
+    #[br(parse_with = read_text, args(len))]
     name: String,
     ty: IndexType,
 }

--- a/rust/candid/tests/type_table_alloc.rs
+++ b/rust/candid/tests/type_table_alloc.rs
@@ -1,0 +1,32 @@
+//! Parsing the type-table header must not turn a wire-declared length into an
+//! oversized up-front allocation. A length prefix need not match the bytes
+//! actually present, so an out-of-range value must fail as an ordinary parse
+//! error rather than reserving a correspondingly large buffer.
+
+use candid::de::IDLDeserialize;
+
+/// Decode only exercises the header parse; the payloads below carry no argument
+/// section, so a healthy parser rejects them with an error and returns normally.
+fn decode(hex: &str) -> candid::Result<()> {
+    let bytes = hex::decode(hex).unwrap();
+    IDLDeserialize::new(&bytes).map(|_| ())
+}
+
+#[test]
+fn future_blob_out_of_range_length_is_rejected() {
+    // "DIDL" 01 67 <sleb opcode> <uleb len = 2^62> with no blob bytes present.
+    assert!(decode("4449444c0167808080808080808040").is_err());
+}
+
+#[test]
+fn future_blob_short_input_is_rejected() {
+    // Same shape, a modest declared length (1024) but a truncated blob.
+    assert!(decode("4449444c01678008").is_err());
+}
+
+#[test]
+fn service_method_name_out_of_range_length_is_rejected() {
+    // A `service` table entry (0x69) with one method whose name declares a
+    // 2^62-byte length: "DIDL" 01 69 01 <uleb name-len = 2^62>, no name bytes.
+    assert!(decode("4449444c016901808080808080808040").is_err());
+}

--- a/rust/candid_derive/Cargo.toml
+++ b/rust/candid_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "candid_derive"
 # sync with the version in `candid/Cargo.toml`
-version = "0.10.34"
+version = "0.10.35"
 edition = "2021"
 rust-version.workspace = true
 authors = ["DFINITY Team"]


### PR DESCRIPTION
Patch release. Bounds allocation for length-prefixed fields in the type-table header parser. See CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)